### PR TITLE
Add reform tracking with reformado command

### DIFF
--- a/GestorSQL.py
+++ b/GestorSQL.py
@@ -1,7 +1,7 @@
 import mysql.connector
 from dotenv import load_dotenv
 import os
-from sqlalchemy import create_engine, Column, Integer, String, ForeignKey, DateTime, BigInteger, Text, Numeric
+from sqlalchemy import create_engine, Column, Integer, String, ForeignKey, DateTime, BigInteger, Text, Numeric, Boolean
 from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
@@ -122,7 +122,7 @@ class Spin(Base):
 
 
 def insertar_spin( usuario, fecha, tipo):
-    # Esta es la función que inserta un nuevo Spin en la base de datos
+    # Esta es la funciÃ³n que inserta un nuevo Spin en la base de datos
     new_spin = Spin(user=usuario, fecha=fecha, tipo=tipo)
     Session = sessionmaker(bind=conexionEngine())
     session = Session()
@@ -238,6 +238,7 @@ class RegistroPartidos(Base):
     ganados = Column(Integer, nullable=False, default=0)
     empatados = Column(Integer, nullable=False, default=0)
     perdidos = Column(Integer, nullable=False, default=0)
+    usado = Column(Boolean, nullable=False, default=False)
 
     equipo_reformado = relationship("equiposReformados", back_populates="registro_partidos")
 
@@ -249,11 +250,11 @@ class Recompensas(Base):
     sesion               = Column(Integer, nullable=False)
     recompensa           = Column(Numeric(10,2), nullable=False)
 
-    # Relación con equiposReformados
+    # RelaciÃ³n con equiposReformados
     equipo_reformado     = relationship("equiposReformados", back_populates="recompensas")
 
 def conexionEngine():
-    # Conectarse a la base de datos y crear una sesión
+    # Conectarse a la base de datos y crear una sesiÃ³n
     load_dotenv()
     user = os.getenv('UsuBD')
     password = os.getenv('PassBD')

--- a/Reformas.py
+++ b/Reformas.py
@@ -35,7 +35,8 @@ def calcular_dinero_reforma(session, equipo_id):
 
     # Traer todos los registros de partidos de este equipo
     partidos = session.query(GestorSQL.RegistroPartidos).filter(
-        GestorSQL.RegistroPartidos.idEquiposReformados == equipo_id
+        GestorSQL.RegistroPartidos.idEquiposReformados == equipo_id,
+        GestorSQL.RegistroPartidos.usado == False
     ).all()
 
     for partido in partidos:
@@ -82,6 +83,7 @@ async def lanzar_reformas(bot):
             GestorSQL.equiposReformados.id_usuario
         )
         .join(GestorSQL.equiposReformados, GestorSQL.RegistroPartidos.idEquiposReformados == GestorSQL.equiposReformados.id)
+        .filter(GestorSQL.RegistroPartidos.usado == False)
         .group_by(
             GestorSQL.RegistroPartidos.idEquiposReformados,
             GestorSQL.equiposReformados.nombre_equipo,
@@ -150,7 +152,8 @@ async def iniciar_reforma(interaction: discord.Interaction, api_token: str):
     equipo_reformar = None
     for eq in equipos:
         cnt = session.query(func.count(GestorSQL.RegistroPartidos.id)).filter(
-            GestorSQL.RegistroPartidos.idEquiposReformados == eq.id
+            GestorSQL.RegistroPartidos.idEquiposReformados == eq.id,
+            GestorSQL.RegistroPartidos.usado == False
         ).scalar()
         if cnt == 2:
             equipo_reformar = eq


### PR DESCRIPTION
## Summary
- add `usado` field to `RegistroPartidos`
- mark stats as unused when creating `RegistroPartidos`
- modify reform logic to consider only unused records
- add `!reformado` command to mark records as used

## Testing
- `python3 -m py_compile GestorSQL.py LombardBot.py Reformas.py`

------
https://chatgpt.com/codex/tasks/task_e_688203ed170c832abe176cdd5ae64bac