### PR TITLE
Fix imagenResultado for Ticket results

### DIFF
--- a/Imagenes.py
+++ b/Imagenes.py
@@ -268,6 +268,9 @@ async def imagenResultado(idPartido):
             or session.query(GestorSQL.PlayOffsBronce)
             .filter(GestorSQL.PlayOffsBronce.partidos_idPartidos == idPartido)
             .first()
+            or session.query(GestorSQL.Ticket)
+            .filter(GestorSQL.Ticket.partidos_idPartidos == idPartido)
+            .first()
         )
 
         if not registro:


### PR DESCRIPTION
## Summary
- ensure `Imagenes.imagenResultado` checks the Ticket table when generating match images

This prevents a `TypeError` when `actualiza_Ticket` publishes Ticket results.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886ac2f1714832a9e9a1d3d5fa07dd9