### PR TITLE
Añadir nombre de Blood Bowl en mensaje de invitación

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -1607,9 +1607,9 @@ async def enviarInvitacion(ctx):
                 u for u in usuarios 
                 if u.grupo == usuario.grupo and u.idUsuarios != usuario.idUsuarios
             ]
-            # Construir lista de "nombre_discord (raza)"
+            # Construir lista de "nombre_discord (nombre_bbowl, raza)"
             lista_compañeros = [
-                f"{c.nombre_discord} ({c.raza or 'raza no asignada'})"
+                f"{c.nombre_discord} ({c.nombre_bloodbowl or 'BBowl no asignado'}, {c.raza or 'raza no asignada'})"
                 for c in compañeros
             ]
             # Formatear con comas y 'y'


### PR DESCRIPTION
## Resumen
- Incluye el nombre del entrenador de Blood Bowl junto al usuario de Discord y la raza en las invitaciones.

## Testing
- `python -m py_compile LombardBot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6bd59aa94832ab30967c6070f184c