### PR TITLE
Switch daily calendar automation to playoff tables

### DIFF
--- a/APIBbowl.py
+++ b/APIBbowl.py
@@ -27,7 +27,7 @@ def obtener_partido_PlayOfTicket(api_token):
     return obtener_partidos(api_token, competition_id)
 
 def obtener_partido_PlayOff(api_token):
-    competition_id = 'f7d2a10b-65ac-11f0-a124-bc2411305479' #id del PLayoff
+    competition_id = 'ec5ad94d-cae3-11f0-a124-bc2411305479' #id del PLayoff
     return obtener_partidos(api_token, competition_id)
 
 

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -3661,7 +3661,7 @@ tareas_programadas = {
     "Monday": {
         "09": [
             (
-                func_proximos_eventos,
+                func_proximos_partidos_playoff,
                 {
                     "bot": bot,
                     "usuario": maestros[0],
@@ -3674,7 +3674,7 @@ tareas_programadas = {
     "Tuesday": {
         "09": [
             (
-                func_proximos_eventos,
+                func_proximos_partidos_playoff,
                 {
                     "bot": bot,
                     "usuario": maestros[0],
@@ -3687,7 +3687,7 @@ tareas_programadas = {
     "Wednesday": {
         "09": [
             (
-                func_proximos_eventos,
+                func_proximos_partidos_playoff,
                 {
                     "bot": bot,
                     "usuario": maestros[0],
@@ -3709,7 +3709,7 @@ tareas_programadas = {
     "Thursday": {
         "09": [
             (
-                func_proximos_eventos,
+                func_proximos_partidos_playoff,
                 {
                     "bot": bot,
                     "usuario": maestros[0],
@@ -3722,7 +3722,7 @@ tareas_programadas = {
     "Friday": {
         "09": [
             (
-                func_proximos_eventos,
+                func_proximos_partidos_playoff,
                 {
                     "bot": bot,
                     "usuario": maestros[0],
@@ -3735,7 +3735,7 @@ tareas_programadas = {
     "Saturday": {
         "09": [
             (
-                func_proximos_eventos,
+                func_proximos_partidos_playoff,
                 {
                     "bot": bot,
                     "usuario": maestros[0],
@@ -3748,7 +3748,7 @@ tareas_programadas = {
     "Sunday": {
         "09": [
             (
-                func_proximos_eventos,
+                func_proximos_partidos_playoff,
                 {
                     "bot": bot,
                     "usuario": maestros[0],


### PR DESCRIPTION
## Summary
- replace the daily 9:00 calendar notification with playoff tables updates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928beb75a08832a848f6abcf97c7ec3)