### PR TITLE
Añadir comprobación de desertores en verificación de inscripciones

### DIFF
--- a/GestorSQL.py
+++ b/GestorSQL.py
@@ -26,6 +26,15 @@ class Usuario(Base):
     resultados_encuesta = relationship("ResultadoEncuesta", back_populates="usuario")
     equipos_reformados= relationship("equiposReformados", back_populates="usuario")
 
+class Desertor(Base):
+    __tablename__ = 'desertores'
+    idUsuarios = Column(Integer, primary_key=True)
+    nombre_discord = Column(String)
+    id_discord = Column(BigInteger)
+    nombre_bloodbowl = Column(String)
+    id_bloodbowl = Column(String)
+    motivo = Column(Text)
+
 
 class PreferenciasFecha(Base):
     __tablename__ = 'preferenciasFecha'

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -3304,6 +3304,10 @@ async def verificar_inscripciones(ctx):
     role_name = "Butter Cup"         # Nombre del rol a revisar
     canal_inscripciones_id = 1280102673059680316  # ID del canal donde está el mensaje
     canal_inscripciones = bot.get_channel(canal_inscripciones_id)
+    inscritos_ids = {
+        inscripcion_id[0]
+        for inscripcion_id in session.query(GestorSQL.Inscripcion.id_usuario_discord).all()
+    }
 
     # 1. OBTENER EL MENSAJE Y SUS REACCIONES
     try:
@@ -3385,6 +3389,22 @@ async def verificar_inscripciones(ctx):
             respuesta.append(f"- <@{user_id}>")
     else:
         respuesta.append("Todos los usuarios en la tabla 'Usuarios' están inscritos.")
+
+    respuesta.append("\n")
+
+    if inscritos_ids:
+        desertores_inscritos = session.query(GestorSQL.Desertor).filter(
+            GestorSQL.Desertor.id_discord.in_(inscritos_ids)
+        ).all()
+    else:
+        desertores_inscritos = []
+
+    if desertores_inscritos:
+        respuesta.append("**Usuarios desertores que están inscritos:**")
+        for desertor in desertores_inscritos:
+            respuesta.append(f"- <@{desertor.id_discord}>")
+    else:
+        respuesta.append("No hay desertores inscritos.")
 
     # Enviar la respuesta en partes para evitar el límite de 2000 caracteres
     mensaje_actual = ""


### PR DESCRIPTION
## Summary
- agregar la clase `Desertor` en GestorSQL para mapear la tabla `desertores`
- actualizar `verificar_inscripciones` para obtener inscripciones y reportar desertores con el mismo id de Discord que un inscrito, indicando cuando no hay coincidencias

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bf5ae1c08832a9ea53894083da07f)