### PR TITLE
Aclarar la hora de España en la respuesta de /fecha

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -16,6 +16,7 @@ from discord import File
 from discord.ext import commands
 from discord import app_commands
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 import tzlocal
 import os
 from wcwidth import wcswidth
@@ -2040,7 +2041,13 @@ async def fecha(interaction: discord.Interaction, dia: int, mes: int, hora: int,
             session.commit()
 
             timestamp = int(fecha_nueva.timestamp())
-            response_message = f"Se ha concertado la cita para <t:{timestamp}:F>"
+            fecha_espana = fecha_nueva.astimezone(ZoneInfo("Europe/Madrid"))
+            hora_espana = fecha_espana.strftime("%H:%M")
+            dia_espana = fecha_espana.strftime("%d/%m/%Y")
+            response_message = (
+                f"Se ha concertado la cita para <t:{timestamp}:F>, "
+                f"que corresponde a las {hora_espana} del día {dia_espana} en España."
+            )
             await interaction.response.send_message(response_message)
             
             #de momento no cambio nombre a canales porque se pone triste discord


### PR DESCRIPTION
### Motivation
- Evitar confusiones sobre la hora mostrada por el comando `/fecha` indicando explícitamente la hora y fecha correspondientes en la zona horaria de España.

### Description
- En `LombardBot.py` se añadió `from zoneinfo import ZoneInfo` y se actualizó el comando `/fecha` para convertir `fecha_nueva` a `ZoneInfo("Europe/Madrid")` y devolver en la confirmación la hora (`%H:%M`) y día (`%d/%m/%Y`) en España además del timestamp de Discord.

### Testing
- No se ejecutaron tests automáticos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698489fa32e4832aa9288ada1d0e58d4)