### PR TITLE
Cambiar tarea de las 09:00 para avisos de playoffs

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -4267,8 +4267,8 @@ dias_semana = [
     "Sunday"
 ]
 
-aviso_calendario = (
-    func_proximos_eventos,
+aviso_playoffs = (
+    func_proximos_partidos_playoff,
     {
         "bot": bot,
         "usuario": maestros[0],
@@ -4286,7 +4286,7 @@ actualizacion_peticiones = (
 
 tareas_programadas = {
     dia: {
-        "09": [aviso_calendario],
+        "09": [aviso_playoffs],
         "10": [actualizacion_peticiones],
         "22": [actualizacion_peticiones],
     }


### PR DESCRIPTION
### Motivation
- Sustituir el aviso matutino general por uno específico de partidos de playoff para que la tarea recurrente de las 09:00 informe sobre encuentros de playoff en lugar del calendario general.

### Description
- Renombrada la tupla de configuración `aviso_calendario` a `aviso_playoffs` y ahora apunta a `func_proximos_partidos_playoff` manteniendo los mismos parámetros de envío.
- Actualizado `tareas_programadas` para que la franja `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae765f2ea0832aadbbeeea74ccaf13)