### PR TITLE
Agregar `SuizoConstantes.py` con constantes y normalizador de formato de serie

### DIFF
--- a/SuizoConstantes.py
+++ b/SuizoConstantes.py
@@ -1,0 +1,32 @@
+"""Constantes y utilidades mínimas para torneo suizo."""
+
+# Estados de torneo
+TORNEO_CREADO = "CREADO"
+TORNEO_EN_CURSO = "EN_CURSO"
+TORNEO_FINALIZADO = "FINALIZADO"
+
+# Estados de ronda
+RONDA_ABIERTA = "ABIERTA"
+RONDA_BLOQUEADA = "BLOQUEADA"
+RONDA_CERRADA = "CERRADA"
+
+# Estados de emparejamiento
+EMP_PENDIENTE = "PENDIENTE"
+EMP_REPORTADO = "REPORTADO"
+EMP_ADMINISTRADO = "ADMINISTRADO"
+EMP_CERRADO = "CERRADO"
+
+# Estados de participante
+PART_ACTIVO = "ACTIVO"
+PART_RETIRADO = "RETIRADO"
+
+# Formatos de serie
+FORMATOS_SERIE = {"BO1", "BO3", "BO5"}
+
+
+def normalizar_formato_serie(texto):
+    """Normaliza bo1/bo3/bo5 a BO1/BO3/BO5 o lanza ValueError."""
+    valor = str(texto).strip().upper()
+    if valor not in FORMATOS_SERIE:
+        raise ValueError(f"Formato de serie inválido: {texto!r}")
+    return valor


### PR DESCRIPTION
### Motivation
- Proveer un conjunto mínimo de constantes y una utilidad para manejar estados y formatos en torneos suizos, evitando duplicación y facilitando validaciones centrales.

### Description
- Añade `SuizoConstantes.py` que define constantes de estado para torneo, ronda, emparejamiento y participante, establece `FORMATOS_SERIE = {"BO1","BO3","BO5"}` y agrega la función `normalizar_formato_serie(texto)` que normaliza entradas como `bo3` a `BO3` y lanza `ValueError` para valores inválidos.

### Testing
- Ejecuté un chequeo rápido en Python importando `FORMATOS_SERIE` y llamando a `normalizar_formato_serie('bo3')`, la importación fue exitosa y la función devolvió `BO3`, por lo que las condiciones de aceptación se cumplen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea050a0668832a86a288bbdfc0a279)