### PR TITLE
Añade helper `es_comisario` para validar rol Comisario

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -69,6 +69,9 @@ bot = DiscordClientSingleton.initialize(discord_bot_token, intents)
 #Lista de usuarios con permisos
 maestros = ["208239645014753280","681577610010296372","1297346191130103859"]
 
+def es_comisario(ctx):
+    return any(getattr(rol, "name", "") == "Comisario" for rol in getattr(ctx.author, "roles", []))
+
 # Lista de IDs de canales permitidos
 canales_permitidos = ['457740100097540106']
 


### PR DESCRIPTION
### Motivation
- Centralizar una comprobación reutilizable que permita restringir comandos administrativos a usuarios con el rol de Discord llamado exactamente `Comisario` (preparación para aplicar el guard en comandos administrativos suizo). 

### Description
- Se añadió la función `def es_comisario(ctx):` en `LombardBot.py` que devuelve `True` si `ctx.author` tiene un rol con nombre exacto `Comisario` y `False` en cualquier otro caso, colocada junto a la sección de permisos globales (`maestros`), y no se modificaron comandos porque no se encontraron definiciones `suizo_*` ni `actualiza_suizo` en el archivo. 

### Testing
- Se ejecutó `python -m py_compile LombardBot.py` y búsquedas con `rg` para verificar la ausencia de comandos `suizo_*`/`actualiza_suizo`, y la comprobación de sintaxis y las búsquedas automatizadas finalizaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0aec92fc832a8ab6d0489c6b1cdc)