### PR TITLE
Añade comando !suizo_crear para crear torneos suizos

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -4042,6 +4042,92 @@ async def crear_peticiones_razas(ctx):
     finally:
         session.close()
 
+
+@bot.command(name="suizo_crear")
+async def suizo_crear(
+    ctx,
+    nombre: str,
+    rondas: int,
+    ida_vuelta: str,
+    formato_serie: str,
+    fecha_fin: str,
+    hora_fin: str,
+    canal_hub_id: Optional[int] = None,
+):
+    if not es_comisario(ctx):
+        await ctx.send("No tienes permiso. Este comando es exclusivo para Comisario.")
+        return
+
+    if rondas < 1:
+        await ctx.send("El número de rondas debe ser mayor o igual a 1.")
+        return
+
+    ida_vuelta_normalizado = ida_vuelta.strip().lower()
+    if ida_vuelta_normalizado == "ida":
+        ida_vuelta_valor = 0
+    elif ida_vuelta_normalizado == "idavuelta":
+        ida_vuelta_valor = 1
+    else:
+        await ctx.send("Valor inválido para ida/vuelta. Usa `ida` o `idavuelta`.")
+        return
+
+    formato_normalizado = formato_serie.strip().upper()
+    if formato_normalizado not in {"BO1", "BO3", "BO5"}:
+        await ctx.send("Formato de serie inválido. Usa `bo1`, `bo3` o `bo5`.")
+        return
+
+    try:
+        fecha_fin_ronda1 = datetime.strptime(f"{fecha_fin} {hora_fin}", "%Y-%m-%d %H:%M")
+    except ValueError:
+        await ctx.send("Fecha inválida. Usa el formato `YYYY-MM-DD HH:MM`.")
+        return
+
+    Session = sessionmaker(bind=GestorSQL.conexionEngine())
+    session = Session()
+    try:
+        ahora = datetime.now()
+        nuevo_torneo = GestorSQL.SuizoTorneo(
+            nombre=nombre,
+            activo=1,
+            estado="CREADO",
+            rondas_totales=rondas,
+            ida_vuelta=ida_vuelta_valor,
+            formato_serie=formato_normalizado,
+            puntos_win=3,
+            puntos_draw=1,
+            puntos_loss=0,
+            puntos_bye=1.5,
+            fecha_fin_ronda1=fecha_fin_ronda1,
+            dias_por_ronda=7,
+            canal_hub_id=canal_hub_id,
+            creado_por_discord_id=ctx.author.id,
+            created_at=ahora,
+            updated_at=ahora,
+        )
+        session.add(nuevo_torneo)
+        session.commit()
+        session.refresh(nuevo_torneo)
+    except Exception as e:
+        session.rollback()
+        await ctx.send(f"No se pudo crear el torneo suizo: {e}")
+        return
+    finally:
+        session.close()
+
+    ida_vuelta_texto = "idavuelta (1)" if ida_vuelta_valor == 1 else "ida (0)"
+    canal_hub_texto = canal_hub_id if canal_hub_id is not None else "sin canal"
+
+    await ctx.send(
+        "✅ Torneo suizo creado correctamente.\n"
+        f"ID torneo: **{nuevo_torneo.id}**\n"
+        f"Nombre: **{nombre}**\n"
+        f"Rondas: **{rondas}**\n"
+        f"Modo: **{ida_vuelta_texto}**\n"
+        f"Formato: **{formato_normalizado}**\n"
+        f"Fin ronda 1: **{fecha_fin_ronda1.strftime('%Y-%m-%d %H:%M')}**\n"
+        f"Canal hub: **{canal_hub_texto}**"
+    )
+
 # Estructura: { "Día": {"Hora": [lista_de_funciones]} }
 # tareas_programadas = {
 #     "Monday": {


### PR DESCRIPTION
### Motivation
- Añadir un comando de texto para crear torneos suizos desde Discord validando permisos, normalizando entradas y persistiendo un registro válido en la tabla `suizo_torneo`.
- Facilitar a los comisarios la creación rápida de torneos con parámetros comunes (rondas, ida/idavuelta, formato, fecha de fin de la ronda 1 y canal hub).

### Description
- Se añadió el comando `@bot.command(name="suizo_crear")` con la firma `suizo_crear(ctx, nombre: str, rondas: int, ida_vuelta: str, formato_serie: str, fecha_fin: str, hora_fin: str, canal_hub_id: Optional[int]=None)` y una nota de uso donde la fecha/hora se pasan como dos argumentos y se parsean juntos con `datetime.strptime("%Y-%m-%d %H:%M")`.
- Se valida que el autor tenga el rol `Comisario` usando la función `es_comisario`, que `rondas >= 1`, que `ida`/`idavuelta` se conviertan a `0`/`1`, y que el formato de serie se normalice a `BO1|BO3|BO5`.
- Se crea e inserta un registro `GestorSQL.SuizoTorneo` con `estado="CREADO"`, `activo=1`, puntos por defecto (`puntos_win=3`, `puntos_draw=1`, `puntos_loss=0`, `puntos_bye=1.5`), `dias_por_ronda=7`, `canal_hub_id`, `creado_por_discord_id`, y marcas de tiempo `created_at`/`updated_at`; la operación usa `session.rollback()` en caso de error.
- El bot responde en Discord con el `ID` del torneo creado y un resumen de los parámetros aceptados (nombre, rondas, modo ida/idavuelta, formato, fin de ronda 1 y canal hub).

### Testing
- Se ejecutó `python -m py_compile LombardBot.py` y el archivo compiló sin errores de sintaxis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0c7c4610832aa5a34a24496b9a66)