### PR TITLE
Add `!suizo_add_jugador` command to register participants in Swiss tournaments

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -4187,6 +4187,69 @@ async def suizo_set_puntos(ctx, torneo_id: int, win: str, draw: str, loss: str, 
         f"loss: **{torneo.puntos_loss}** | bye: **{torneo.puntos_bye}**"
     )
 
+
+@bot.command(name="suizo_add_jugador")
+async def suizo_add_jugador(ctx, torneo_id: int, usuario: discord.Member, raza_competicion: Optional[str] = None):
+    if not es_comisario(ctx):
+        await ctx.send("No tienes permiso. Este comando es exclusivo para Comisario.")
+        return
+
+    Session = sessionmaker(bind=GestorSQL.conexionEngine())
+    session = Session()
+    try:
+        torneo = session.query(GestorSQL.SuizoTorneo).filter_by(id=torneo_id).first()
+        if torneo is None:
+            await ctx.send(f"No existe un torneo suizo con ID `{torneo_id}`.")
+            return
+
+        usuario_bd = session.query(GestorSQL.Usuario).filter_by(id_discord=usuario.id).first()
+        if usuario_bd is None:
+            await ctx.send(
+                f"El usuario {usuario.mention} no está registrado en `usuarios` "
+                "(campo `id_discord`)."
+            )
+            return
+
+        participante_existente = (
+            session.query(GestorSQL.SuizoParticipante)
+            .filter_by(torneo_id=torneo_id, usuario_id=usuario_bd.idUsuarios)
+            .first()
+        )
+        if participante_existente is not None:
+            await ctx.send(
+                f"El usuario {usuario.mention} ya está inscrito en el torneo `{torneo_id}`."
+            )
+            return
+
+        raza_final = raza_competicion if raza_competicion is not None else usuario_bd.raza
+        nuevo_participante = GestorSQL.SuizoParticipante(
+            torneo_id=torneo_id,
+            usuario_id=usuario_bd.idUsuarios,
+            estado="ACTIVO",
+            tiene_bye=0,
+            cantidad_byes=0,
+            late_join_ronda=None,
+            puntos_ajuste_inicial=0,
+            raza_competicion=raza_final,
+            created_at=datetime.now(),
+        )
+        session.add(nuevo_participante)
+        session.commit()
+    except Exception as e:
+        session.rollback()
+        await ctx.send(f"No se pudo añadir el jugador al torneo suizo: {e}")
+        return
+    finally:
+        session.close()
+
+    raza_texto = raza_final if raza_final else "sin raza definida"
+    await ctx.send(
+        "✅ Jugador añadido correctamente al torneo suizo.\n"
+        f"Torneo ID: **{torneo_id}**\n"
+        f"Usuario: {usuario.mention} (idUsuarios: **{usuario_bd.idUsuarios}**)\n"
+        f"Raza competición: **{raza_texto}**"
+    )
+
 # Estructura: { "Día": {"Hora": [lista_de_funciones]} }
 # tareas_programadas = {
 #     "Monday": {


### PR DESCRIPTION
### Motivation
- Provide a Comisario-only admin command to add a participant to an existing Swiss tournament without creating duplicates.
- Ensure the participant is linked to an existing `usuarios` record and that required participant fields are populated with correct defaults.

### Description
- Adds `@bot.command(name="suizo_add_jugador")` with signature `suizo_add_jugador(ctx, torneo_id: int, usuario: discord.Member, raza_competicion: Optional[str] = None)` to `LombardBot.py`.
- Validates Comisario permission via `es_comisario`, checks existence of the tournament in `suizo_torneo`, and resolves the mentioned Discord user to `usuarios.idUsuarios` using `usuarios.id_discord`.
- Prevents duplicate registrations by checking `suizo_participante` for the (`torneo_id`, `usuario_id`) pair and returns a clear message if already registered.
- Inserts a new `SuizoParticipante` with `estado='ACTIVO'`, `tiene_bye=0`, `cantidad_byes=0`, `late_join_ronda=NULL`, `puntos_ajuste_inicial=0`, `raza_competicion` (falls back to `usuarios.raza`), and sets `created_at=datetime.now()` with rollback on error and user-facing success/failure messages.

### Testing
- Ran `python -m py_compile LombardBot.py` to validate syntax and the compile check succeeded.
- Verified repository status with `git status --short` and committed the change with `git commit`, and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea10caf350832a8972195925b098be)