### PR TITLE
Agregar cálculo `buchholz_cut` al standing suizo

### DIFF
--- a/SuizoCore.py
+++ b/SuizoCore.py
@@ -98,6 +98,7 @@ def calcular_standings(session, torneo_id, hasta_ronda: Optional[int] = None) ->
     )
 
     filas: Dict[int, EstadoFila] = {}
+    rivales_por_usuario: Dict[int, List[int]] = {}
     for p in participantes:
         filas[p.usuario_id] = {
             "usuario_id": p.usuario_id,
@@ -110,7 +111,9 @@ def calcular_standings(session, torneo_id, hasta_ronda: Optional[int] = None) ->
             "score_favor": 0,
             "score_contra": 0,
             "diff_score": 0,
+            "buchholz_cut": Decimal("0"),
         }
+        rivales_por_usuario[p.usuario_id] = []
 
     emparejamientos_q = (
         session.query(SuizoEmparejamiento)
@@ -151,6 +154,8 @@ def calcular_standings(session, torneo_id, hasta_ronda: Optional[int] = None) ->
 
         filas[c1]["puntos"] += _decimal(emp.puntos_c1)
         filas[c2]["puntos"] += _decimal(emp.puntos_c2)
+        rivales_por_usuario[c1].append(c2)
+        rivales_por_usuario[c2].append(c1)
 
         if s1 > s2:
             filas[c1]["pg"] += 1
@@ -164,6 +169,13 @@ def calcular_standings(session, torneo_id, hasta_ronda: Optional[int] = None) ->
 
     for fila in filas.values():
         fila["diff_score"] = fila["score_favor"] - fila["score_contra"]
+        rivales = rivales_por_usuario.get(fila["usuario_id"], [])
+        puntos_rivales = [_decimal(filas[r]["puntos"]) for r in rivales if r in filas]
+        if len(puntos_rivales) < 2:
+            fila["buchholz_cut"] = Decimal("0")
+        else:
+            suma_rivales = sum(puntos_rivales, Decimal("0"))
+            fila["buchholz_cut"] = suma_rivales - min(puntos_rivales)
 
     return sorted(
         filas.values(),


### PR DESCRIPTION
### Motivation

- Añadir un criterio de desempate Buchholz Cut estable y reproducible al cálculo de standings suizos para reflejar la suma de puntos de rivales excepto el peor. 
- Manejar casos de BYE y listas cortas (0 o 1 rival) de forma consistente devolviendo `0` cuando corresponda.

### Description

- Se añadió el tracking de rivales por jugador con `rivales_por_usuario` durante el recorrido de emparejamientos, y se excluyen los BYE al no registrar rivales en esos casos. 
- Se inicializó un nuevo campo lógico `buchholz_cut` en cada fila de standings con `Decimal("0")`. 
- Al final del cálculo se construye la lista `puntos_rivales` usando `_decimal(filas[r]["puntos"])` y se calcula `buchholz_cut` como la suma de esos puntos menos su mínimo, y se pone `0` cuando la lista tiene menos de 2 elementos. 

### Testing

- Se compiló el módulo con `python -m py_compile SuizoCore.py` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1787c9e4832aba0acd62d147b5a1)