### PR TITLE
Agregar persistencia de snapshot de standings por ronda

### DIFF
--- a/SuizoCore.py
+++ b/SuizoCore.py
@@ -1,10 +1,17 @@
 """Lógica base de standings para torneos suizos."""
 
+import json
 from decimal import Decimal
 from functools import cmp_to_key
 from typing import Any, Dict, List, Optional
 
-from GestorSQL import SuizoEmparejamiento, SuizoParticipante, SuizoRonda, SuizoTorneo
+from GestorSQL import (
+    SuizoEmparejamiento,
+    SuizoParticipante,
+    SuizoRonda,
+    SuizoStandingSnapshot,
+    SuizoTorneo,
+)
 from SuizoConstantes import EMP_ADMINISTRADO, EMP_CERRADO
 
 
@@ -219,3 +226,71 @@ def calcular_standings(session, torneo_id, hasta_ronda: Optional[int] = None) ->
             fila["buchholz_cut"] = suma_rivales - min(puntos_rivales)
 
     return ordenar_standings(list(filas.values()))
+
+
+def _normalizar_json_detalle_tiebreak(fila: EstadoFila) -> Dict[str, Any]:
+    detalle = fila.get("json_detalle_tiebreak")
+    if isinstance(detalle, dict):
+        return dict(detalle)
+
+    if isinstance(detalle, str) and detalle.strip():
+        try:
+            parsed = json.loads(detalle)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+
+    return {
+        "criterios": {
+            "h2h": str(fila.get("h2h_valor")) if fila.get("h2h_valor") is not None else None,
+            "buchholz_cut": str(_decimal(fila.get("buchholz_cut"))),
+            "diff_score": int(fila.get("diff_score") or 0),
+        },
+        "explicacion": (
+            "Orden aplicado: puntos DESC, h2h DESC (si existe), "
+            "buchholz_cut DESC, diff_score DESC y usuario_id ASC."
+        ),
+    }
+
+
+def guardar_snapshot_ronda(session, torneo_id, ronda_numero, standings_ordenados):
+    """Guarda snapshot completo de standings para una ronda.
+
+    Inserta una fila por jugador con estadísticas completas y desempates.
+    Si ya existía snapshot para la ronda, lo reemplaza por completo.
+    """
+    session.query(SuizoStandingSnapshot).filter(
+        SuizoStandingSnapshot.torneo_id == torneo_id,
+        SuizoStandingSnapshot.ronda_numero == ronda_numero,
+    ).delete(synchronize_session=False)
+
+    snapshots = []
+    for idx, fila in enumerate(standings_ordenados, start=1):
+        rank_ronda = int(fila.get("rank") or idx)
+        snapshots.append(
+            SuizoStandingSnapshot(
+                torneo_id=torneo_id,
+                ronda_numero=ronda_numero,
+                usuario_id=int(fila["usuario_id"]),
+                estado_participante=fila.get("estado_participante") or "ACTIVO",
+                pj=int(fila.get("pj") or 0),
+                pg=int(fila.get("pg") or 0),
+                pe=int(fila.get("pe") or 0),
+                pp=int(fila.get("pp") or 0),
+                puntos=_decimal(fila.get("puntos")),
+                score_favor=int(fila.get("score_favor") or 0),
+                score_contra=int(fila.get("score_contra") or 0),
+                diff_score=int(fila.get("diff_score") or 0),
+                buchholz_cut=_decimal(fila.get("buchholz_cut")),
+                h2h_valor=_decimal(fila.get("h2h_valor")) if fila.get("h2h_valor") is not None else None,
+                rank_ronda=rank_ronda,
+                json_detalle_tiebreak=_normalizar_json_detalle_tiebreak(fila),
+            )
+        )
+
+    if snapshots:
+        session.bulk_save_objects(snapshots)
+
+    session.flush()
+    return len(snapshots)


### PR DESCRIPTION
### Motivation
- Necesidad de guardar un snapshot consultable del standing tras cerrar una ronda para poder auditar y usar como semilla en emparejamientos posteriores.
- Incluir en la persistencia las estadísticas completas por jugador y los valores de desempate (`h2h`, `buchholz_cut`, `diff_score`) para consultas deterministas posteriores.
- Normalizar y almacenar un detalle explicativo (`json_detalle_tiebreak`) para facilitar inspección humana y machine-readable de por qué se aplicó un desempate.

### Description
- Importa `SuizoStandingSnapshot` y `json` en `SuizoCore.py` y añade la función `guardar_snapshot_ronda(session, torneo_id, ronda_numero, standings_ordenados)` que persiste un registro por jugador en la tabla `suizo_standing_snapshot`.
- Antes de insertar, elimina cualquier snapshot existente para `(torneo_id, ronda_numero)` para que la operación sea idempotente por ronda.
- Mapea y normaliza campos estadísticos (`pj`, `pg`, `pe`, `pp`, `puntos`, `score_favor`, `score_contra`, `diff_score`, `buchholz_cut`, `h2h_valor`) y asigna `rank_ronda` usando el `rank` del standing o un fallback por orden.
- Añade `_normalizar_json_detalle_tiebreak(fila)` que acepta objetos dict, intenta parsear strings JSON y, si falla, genera un JSON explicativo con los criterios aplicados y una explicación de la ordenación.

### Testing
- Ejecuté `python -m compileall SuizoCore.py` y la compilación del módulo completó exitosamente.
- No se ejecutaron tests unitarios adicionales automáticamente en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1965982c832aa770daff3e8f0ef1)