### PR TITLE
Cierre automático de ronda suiza con snapshot y avance de ronda

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -46,7 +46,10 @@ import inspect
 import mysql.connector
 import Inscripcion
 import Reformas
-from SuizoCore import generar_pairings_backtracking
+from SuizoCore import (
+    generar_pairings_backtracking,
+    procesar_cierre_ronda_si_corresponde,
+)
 
 
 # Cargar las variables de entorno desde .env
@@ -4759,10 +4762,49 @@ async def actualiza_suizo(ctx, torneo_id: int, todos: int = 0):
                 f"Emparejamientos pendientes: **{pendientes}**."
             )
         else:
-            await ctx.send(
-                f"🏁 Ronda {ronda_abierta.numero} completa en torneo {torneo_id}. "
-                "Se dispara cierre automático (tarea 17)."
-            )
+            cierre = procesar_cierre_ronda_si_corresponde(session, torneo_id, ronda_abierta.numero)
+            if not cierre.get("cerrada"):
+                await ctx.send(
+                    f"⏳ Ronda {ronda_abierta.numero} aún no se puede cerrar en torneo {torneo_id}. "
+                    f"Motivo: **{cierre.get('motivo', 'DESCONOCIDO')}**."
+                )
+            else:
+                session.commit()
+                await ctx.send(
+                    f"🏁 Ronda {ronda_abierta.numero} cerrada en torneo {torneo_id}. "
+                    f"Snapshot de standings guardado: **{cierre.get('snapshot_filas', 0)}** filas."
+                )
+
+                if cierre.get("es_ultima_ronda"):
+                    clasificacion = cierre.get("standings") or []
+                    top = []
+                    for fila in clasificacion[:16]:
+                        usuario_id = int(fila.get("usuario_id"))
+                        usuario = session.query(GestorSQL.Usuario).filter_by(idUsuarios=usuario_id).first()
+                        nombre = (
+                            getattr(usuario, "nombreAMostrar", None)
+                            or getattr(usuario, "nombre_discord", None)
+                            or f"u{usuario_id}"
+                        )
+                        top.append(
+                            f"**#{fila.get('rank')}** {nombre} — "
+                            f"{fila.get('puntos')} pts | "
+                            f"PJ {fila.get('pj')} | "
+                            f"Dif {fila.get('diff_score')}"
+                        )
+
+                    await ctx.send(
+                        f"🏆 Torneo **{torneo_id}** finalizado.\n"
+                        "Clasificación final:\n"
+                        + ("\n".join(top) if top else "_Sin datos de clasificación._")
+                    )
+                else:
+                    siguiente_ronda = int(cierre.get("siguiente_ronda_numero"))
+                    await ctx.send(
+                        f"➡️ Se generará automáticamente la ronda **{siguiente_ronda}** "
+                        f"del torneo **{torneo_id}**."
+                    )
+                    await suizo_generar_ronda(ctx, torneo_id, siguiente_ronda)
 
         await ctx.send(
             "📊 Actualización suiza terminada.\n"

--- a/SuizoCore.py
+++ b/SuizoCore.py
@@ -14,7 +14,13 @@ from GestorSQL import (
     SuizoStandingSnapshot,
     SuizoTorneo,
 )
-from SuizoConstantes import EMP_ADMINISTRADO, EMP_CERRADO
+from SuizoConstantes import (
+    EMP_ADMINISTRADO,
+    EMP_CERRADO,
+    EMP_PENDIENTE,
+    RONDA_CERRADA,
+    TORNEO_FINALIZADO,
+)
 
 
 EstadoFila = Dict[str, Any]
@@ -296,6 +302,64 @@ def guardar_snapshot_ronda(session, torneo_id, ronda_numero, standings_ordenados
 
     session.flush()
     return len(snapshots)
+
+
+def procesar_cierre_ronda_si_corresponde(session, torneo_id, ronda_numero):
+    """Cierra una ronda si ya no hay emparejamientos pendientes.
+
+    Flujo:
+    - Si quedan emparejamientos en estado PENDIENTE, no cierra.
+    - Cierra ronda (estado + cerrada_en), recalcula standings y guarda snapshot.
+    - Si era última ronda, finaliza torneo.
+    - Si no era la última, devuelve instrucción para generar la siguiente.
+    """
+    torneo = session.query(SuizoTorneo).filter(SuizoTorneo.id == torneo_id).one_or_none()
+    if torneo is None:
+        return {"cerrada": False, "motivo": "TORNEO_NO_EXISTE", "pendientes": None}
+
+    ronda = (
+        session.query(SuizoRonda)
+        .filter(
+            SuizoRonda.torneo_id == torneo_id,
+            SuizoRonda.numero == ronda_numero,
+        )
+        .one_or_none()
+    )
+    if ronda is None:
+        return {"cerrada": False, "motivo": "RONDA_NO_EXISTE", "pendientes": None}
+
+    pendientes = (
+        session.query(SuizoEmparejamiento)
+        .filter(
+            SuizoEmparejamiento.torneo_id == torneo_id,
+            SuizoEmparejamiento.ronda_id == ronda.id,
+            SuizoEmparejamiento.estado == EMP_PENDIENTE,
+        )
+        .count()
+    )
+    if pendientes > 0:
+        return {"cerrada": False, "motivo": "HAY_PENDIENTES", "pendientes": int(pendientes)}
+
+    ronda.estado = RONDA_CERRADA
+    ronda.cerrada_en = datetime.now()
+
+    standings = calcular_standings(session, torneo_id, hasta_ronda=ronda_numero)
+    snapshot_filas = guardar_snapshot_ronda(session, torneo_id, ronda_numero, standings)
+
+    es_ultima_ronda = int(ronda_numero) >= int(torneo.rondas_totales)
+    if es_ultima_ronda:
+        torneo.estado = TORNEO_FINALIZADO
+
+    session.flush()
+    return {
+        "cerrada": True,
+        "motivo": "CERRADA",
+        "pendientes": 0,
+        "es_ultima_ronda": es_ultima_ronda,
+        "siguiente_ronda_numero": None if es_ultima_ronda else int(ronda_numero) + 1,
+        "snapshot_filas": int(snapshot_filas),
+        "standings": standings,
+    }
 
 
 def generar_pairings_backtracking(session, torneo_id, ronda_numero):


### PR DESCRIPTION
### Motivation
- Implementar el cierre seguro de una ronda suiza siguiendo las reglas operativas del torneo (no cerrar si quedan emparejamientos `PENDIENTE`).
- Al cerrar una ronda debe persistirse el `estado=CERRADA`, registrar `cerrada_en=now`, recalcular `standings` y guardar un `snapshot` de la ronda.
- Si hay más rondas se debe preparar/generar la siguiente automáticamente; si era la última, finalizar el torneo y publicar la clasificación final.

### Description
- Se añade `procesar_cierre_ronda_si_corresponde(session, torneo_id, ronda_numero)` en `SuizoCore.py` que verifica emparejamientos `PENDIENTE`, cierra la ronda (`estado = RONDA_CERRADA`, `cerrada_en = datetime.now()`), recalcula standings con `calcular_standings` y guarda snapshot con `guardar_snapshot_ronda`, y devuelve un resumen con `cerrada`, `es_ultima_ronda`, `siguiente_ronda_numero` y `snapshot_filas`.
- Se importó la nueva función en `LombardBot.py` y se integró en el flujo existente de `actualiza_suizo` para activar el cierre automático cuando ya no quedan emparejamientos pendientes.
- Tras un cierre exitoso, el bot hace `session.commit()`, notifica el cierre y si no es la última ronda llama internamente a `suizo_generar_ronda(ctx, torneo_id, siguiente_ronda)` para generar la siguiente; si es la última marca el torneo como `FINALIZADO` y publica la clasificación final.
- La función respeta el criterio de aceptación: no cierra la ronda si existe al menos un emparejamiento en estado `PENDIENTE` y devuelve el motivo en el resultado.

### Testing
- Se compiló el código modificado con `python -m py_compile SuizoCore.py LombardBot.py` y la compilación finalizó correctamente.
- No se ejecutaron tests unitarios adicionales automáticos en este cambio (solo verificación de compilación estática).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea985a084c832a9ab102bf4d235561)