### PR TITLE
Añadir comando !comunicaciones_inscritos para avisos a inscritos

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -3690,6 +3690,71 @@ Si no quieres recibir más notificaciones mías, escribe a **SrLombard** para qu
         except discord.HTTPException:
             await ctx.send(f"Hubo un error al intentar enviar un mensaje a {member.name}.")
 
+@bot.command(name="comunicaciones_inscritos")
+@commands.has_permissions(administrator=True)
+async def comunicaciones_inscritos(ctx, solo_objetivo: Optional[int] = None):
+    Session = sessionmaker(bind=GestorSQL.conexionEngine())
+    session = Session()
+
+    role_name = "Butter Cup"
+    guild = ctx.guild
+
+    if guild is None:
+        await ctx.send("Este comando solo se puede ejecutar en un servidor (guild), no en mensajes privados.")
+        session.close()
+        return
+
+    butter_role = discord.utils.get(guild.roles, name=role_name)
+    if butter_role is None:
+        await ctx.send(f"No se encontró el rol `{role_name}` en este servidor.")
+        session.close()
+        return
+
+    TARGET_REMINDER_IDS = {
+        681577610010296372,
+        208239645014753280,
+    }
+
+    solo_ids_objetivo = str(solo_objetivo) == "1"
+
+    miembros_con_rol = butter_role.members
+    if solo_ids_objetivo:
+        miembros_con_rol = [member for member in miembros_con_rol if member.id in TARGET_REMINDER_IDS]
+
+    inscritos_con_rol = []
+    for member in miembros_con_rol:
+        registro = session.query(GestorSQL.Inscripcion).filter_by(id_usuario_discord=member.id).first()
+        if registro:
+            inscritos_con_rol.append(member)
+
+    if not inscritos_con_rol:
+        await ctx.send(f"No hay miembros inscritos con el rol '{role_name}'.")
+        session.close()
+        return
+
+    for member in inscritos_con_rol:
+        try:
+            await member.send(
+"""
+📣 **Normas para inscritos - Butter Cup**
+
+Gracias por inscribirte. Te compartimos un recordatorio rápido de normas:
+
+1) Revisa siempre el canal de anuncios y respeta las fechas de cada jornada.
+2) Contacta con tu rival con antelación y proponed horario.
+3) Juega con deportividad y comunica cualquier incidencia a la organización.
+4) Si vas a abandonar o no puedes jugar, avisa cuanto antes.
+
+Este texto es provisional y se puede ajustar cuando quieras.
+"""
+            )
+            await ctx.send(f"Comunicación enviada a {member.name}")
+        except discord.Forbidden:
+            await ctx.send(f"No se pudo enviar un mensaje privado a {member.name}. Puede que tenga los mensajes privados desactivados.")
+        except discord.HTTPException:
+            await ctx.send(f"Hubo un error al intentar enviar un mensaje a {member.name}.")
+    session.close()
+
 @bot.command(name='comprueba_quedadas')
 async def comprueba_quedadas(ctx, enviar_mensaje: int = 0):
     await func_comprueba_quedadas(enviar_mensaje)


### PR DESCRIPTION
### Motivation
- Añadir un comando de administración que envíe por DM comunicaciones a los usuarios ya inscritos (complementario a `!recordar_inscripciones` que avisa a los no inscritos). 
- Reutilizar la lógica de selección por rol (`Butter Cup`) y el filtro opcional `solo_objetivo=1` para mantener comportamiento consistente con el comando existente.

### Description
- Se añadió el comando `!comunicaciones_inscritos` en `LombardBot.py` que selecciona miembros con el rol `Butter Cup` y envía un mensaje por DM solo a los que tienen registro en la tabla `Inscripcion` (`GestorSQL.Inscripcion`).
- El comando acepta el mismo filtro opcional `solo_objetivo=1` y reutiliza la lista `TARGET_REMINDER_IDS` para pruebas/filtrado puntual.
- El mensaje enviado es un texto provisional con las “Normas para inscritos” que puede ajustarse posteriormente, y el envío maneja `discord.Forbidden` y `discord.HTTPException`.
- Se añadieron `session.close()` en las salidas tempranas y al final del flujo para evitar sesiones abiertas en caso de retornos anticipados.

### Testing
- Se ejecutó `python -m py_compile LombardBot.py` para verificar la sintaxis y compilación del módulo y la comprobación final fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb98bced70832ab6c7179f5a96dd17)