### PR TITLE
Use `ronda_id` to delete SuizoPairingTrace in `suizo_regenerar_ronda`

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -5166,7 +5166,9 @@ async def suizo_regenerar_ronda(ctx, torneo_id: int, numero_ronda: int):
         )
         (
             session.query(GestorSQL.SuizoPairingTrace)
-            .filter_by(torneo_id=torneo_id, ronda_numero=numero_ronda)
+            # Usamos `ronda.id` (PK de `suizo_ronda`) en lugar de `numero_ronda`
+            # porque el trace se relaciona por FK con la ronda concreta.
+            .filter_by(torneo_id=torneo_id, ronda_id=ronda.id)
             .delete(synchronize_session=False)
         )
         session.flush()


### PR DESCRIPTION
### Motivation
- Corregir el borrado de trazas de pairing para que elimine las filas vinculadas a la ronda concreta por PK/FK y no por el número de ronda, evitando inconsistencias cuando la relación usa `ronda.id`.

### Description
- Cambié la consulta de borrado en `suizo_regenerar_ronda` para que `SuizoPairingTrace` se filtre por `ronda_id=ronda.id` y siga incluyendo `torneo_id` como filtro adicional.
- Añadí un comentario inline que explica por qué se usa `ronda.id` (la FK real) en lugar de `numero_ronda`.

### Testing
- Ejecuté `python -m py_compile LombardBot.py` y la verificación de sintaxis pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9a3af4cc832a9ffc56746919840f)