### PR TITLE
Integrar H2H en `calcular_standings` y añadir test que prioriza H2H sobre Buchholz

### DIFF
--- a/SuizoCore.py
+++ b/SuizoCore.py
@@ -185,7 +185,9 @@ def calcular_standings(session, torneo_id, hasta_ronda: Optional[int] = None) ->
     if hasta_ronda is not None:
         emparejamientos_q = emparejamientos_q.filter(SuizoRonda.numero <= hasta_ronda)
 
-    for emp in emparejamientos_q.all():
+    emparejamientos_cerrados = emparejamientos_q.all()
+
+    for emp in emparejamientos_cerrados:
         c1 = emp.coach1_usuario_id
         c2 = emp.coach2_usuario_id
 
@@ -235,7 +237,12 @@ def calcular_standings(session, torneo_id, hasta_ronda: Optional[int] = None) ->
             suma_rivales = sum(puntos_rivales, Decimal("0"))
             fila["buchholz_cut"] = suma_rivales - min(puntos_rivales)
 
-    return ordenar_standings(list(filas.values()))
+    standings_intermedios = list(filas.values())
+    h2h_por_usuario = calcular_h2h(standings_intermedios, emparejamientos_cerrados)
+    for fila in standings_intermedios:
+        fila["h2h_valor"] = h2h_por_usuario.get(int(fila["usuario_id"]))
+
+    return ordenar_standings(standings_intermedios)
 
 
 def _normalizar_json_detalle_tiebreak(fila: EstadoFila) -> Dict[str, Any]:

--- a/tests/test_suizo_core.py
+++ b/tests/test_suizo_core.py
@@ -181,6 +181,45 @@ def test_bye_suma_puntos_y_no_pj():
     assert standings[1]["pj"] == 0
 
 
+def test_h2h_rompe_empate_por_encima_de_buchholz():
+    session = _build_session()
+    _crear_torneo_base(session, torneo_id=25)
+    for uid in (1, 2, 3, 4):
+        _crear_usuario_y_participante(session, 25, uid)
+
+    participante_3 = session.query(SuizoParticipante).filter_by(torneo_id=25, usuario_id=3).one()
+    participante_4 = session.query(SuizoParticipante).filter_by(torneo_id=25, usuario_id=4).one()
+    participante_3.puntos_ajuste_inicial = Decimal("3")
+    participante_4.puntos_ajuste_inicial = Decimal("-3")
+
+    r1 = _crear_ronda(session, 25, 1)
+    _crear_emparejamiento(
+        session, 25, r1.id, 1, 1, 2, score1=1, score2=0, puntos1=Decimal("3"), puntos2=Decimal("0")
+    )
+    _crear_emparejamiento(
+        session, 25, r1.id, 2, 3, 4, score1=1, score2=0, puntos1=Decimal("3"), puntos2=Decimal("0")
+    )
+
+    r2 = _crear_ronda(session, 25, 2)
+    _crear_emparejamiento(
+        session, 25, r2.id, 1, 4, 1, score1=1, score2=0, puntos1=Decimal("3"), puntos2=Decimal("0")
+    )
+    _crear_emparejamiento(
+        session, 25, r2.id, 2, 2, 3, score1=1, score2=0, puntos1=Decimal("3"), puntos2=Decimal("0")
+    )
+    session.commit()
+
+    standings = calcular_standings(session, 25)
+    fila_1 = next(f for f in standings if f["usuario_id"] == 1)
+    fila_2 = next(f for f in standings if f["usuario_id"] == 2)
+
+    assert fila_1["puntos"] == fila_2["puntos"] == Decimal("3")
+    assert fila_2["buchholz_cut"] > fila_1["buchholz_cut"]
+    assert fila_1["h2h_valor"] == Decimal("3")
+    assert fila_2["h2h_valor"] == Decimal("0")
+    assert fila_1["rank"] < fila_2["rank"]
+
+
 def test_fallback_a_repetidos_cuando_no_hay_solucion():
     session = _build_session()
     _crear_torneo_base(session, torneo_id=30)


### PR DESCRIPTION
### Motivation
- Aplicar el criterio de enfrentamiento directo (H2H) a empates de puntos cuando exista partido directo entre los jugadores y dejar `None` cuando no aplique.
- Asegurar que el valor H2H se use como criterio de desempate antes de `buchholz_cut` al ordenar el standing.

### Description
- En `calcular_standings` se materializa la lista de emparejamientos cerrados/administrados en `emparejamientos_cerrados` y se reutiliza para el cálculo de H2H. 
- Se construyen `standings_intermedios`, se llama a `calcular_h2h(standings_intermedios, emparejamientos_cerrados)` y se vuelca el resultado en `fila['h2h_valor']` por usuario antes de llamar a `ordenar_standings`.
- Se añadió el test `test_h2h_rompe_empate_por_encima_de_buchholz` en `tests/test_suizo_core.py` que verifica que, en un empate de puntos, un H2H directo puede invertir el orden que daría Buchholz y afectar el `rank`.

### Testing
- Ejecuté `pytest -q tests/test_suizo_core.py`, pero la ejecución falló en este entorno por una dependencia ausente: `ModuleNotFoundError: No module named 'sqlalchemy'`.
- El nuevo test está presente y listo para ejecución en un entorno con las dependencias instaladas; el intento local no pudo validar éxito/fracaso de los tests por la dependencia faltante.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9ac7aeac832ab3e4d66418018ec5)