### PR TITLE
Ajusta conteo de pendientes en `!actualiza_suizo` a `PENDIENTE`

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -5584,7 +5584,7 @@ async def actualiza_suizo(ctx, torneo_id: int, todos: int = 0):
                 torneo_id=torneo_id,
                 ronda_id=ronda_abierta.id,
             )
-            .filter(GestorSQL.SuizoEmparejamiento.estado != "CERRADO")
+            .filter(GestorSQL.SuizoEmparejamiento.estado == "PENDIENTE")
             .count()
         )
 


### PR DESCRIPTION
### Motivation
- Alinear el criterio de "pendientes" en `!actualiza_suizo` con `procesar_cierre_ronda_si_corresponde` para que mesas en `ADMINISTRADO` no bloqueen el cierre de ronda.

### Description
- En `LombardBot.py` reemplacé `.filter(GestorSQL.SuizoEmparejamiento.estado != "CERRADO")` por `.filter(GestorSQL.SuizoEmparejamiento.estado == "PENDIENTE")` para contar solo emparejamientos pendientes.

### Testing
- Intenté ejecutar `pytest -q tests/test_suizo_core.py -k cierre_de_ronda_solo_cuando_todo_esta_resuelto` pero la ejecución falló por falta de la dependencia del entorno (`ModuleNotFoundError: No module named 'sqlalchemy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9b9b259c832a8718240dcb8f6838)