### PR TITLE
Actualizar torneo a EN_CURSO al generar la ronda 1

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -4925,6 +4925,10 @@ async def suizo_generar_ronda(ctx, torneo_id: int, numero_ronda: int):
             generada_por_discord_id=ctx.author.id,
         )
         session.add(nueva_ronda)
+
+        if numero_ronda == 1 and torneo.estado == "CREADO":
+            torneo.estado = "EN_CURSO"
+
         session.flush()
 
         pairings = generar_pairings_backtracking(session, torneo_id, numero_ronda)


### PR DESCRIPTION
### Motivation
- Al generar la primera ronda de un torneo suizo, el torneo debe pasar de `CREADO` a `EN_CURSO` y esa transición debe persistirse junto con la creación de la ronda.

### Description
- En `suizo_generar_ronda` se añadió, tras crear la instancia de `SuizoRonda` y antes de `session.flush()`, la condición `if numero_ronda == 1 and torneo.estado == "CREADO": torneo.estado = "EN_CURSO"` para actualizar el estado del torneo en la misma transacción.

### Testing
- Se ejecutó `python -m py_compile /workspace/LombardBot/LombardBot.py` y la comprobación de sintaxis fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9d13ada0832a981a85f4c7fae8a1)