### PR TITLE
Unify DB timestamps to UTC and localize Discord displays

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -2135,7 +2135,7 @@ async def obtener_spins_recientes(interaction: discord.Interaction, minutos: int
     session = Session()
     
     # Calcular el momento de tiempo desde el cual queremos obtener los registros
-    tiempo_desde = datetime.now() - timedelta(minutes=minutos)
+    tiempo_desde = datetime.utcnow() - timedelta(minutes=minutos)
     
     try:
         # Realizar la consulta filtrando por fecha
@@ -2144,9 +2144,10 @@ async def obtener_spins_recientes(interaction: discord.Interaction, minutos: int
             all()
         
         # Formatear los resultados en Markdown
-        tabla_markdown = "```| Fecha                | Usuario | Acción |\n|---------------------|---------|--------|"
+        tabla_markdown = "```| Fecha (Europe/Madrid) | Usuario | Acción |\n|----------------------|---------|--------|"
         for fecha, usuario, tipo in resultados:
-            tabla_markdown += f"\n| {fecha.strftime('%Y-%m-%d %H:%M:%S')} | {usuario} | {tipo} |"
+            fecha_madrid = fecha.replace(tzinfo=ZoneInfo('UTC')).astimezone(ZoneInfo('Europe/Madrid')) if fecha.tzinfo is None else fecha.astimezone(ZoneInfo('Europe/Madrid'))
+            tabla_markdown += f"\n| {fecha_madrid.strftime('%Y-%m-%d %H:%M:%S')} | {usuario} | {tipo} |"
         
         tabla_markdown += "```"
         
@@ -4156,7 +4157,7 @@ async def suizo_crear(
     Session = sessionmaker(bind=GestorSQL.conexionEngine())
     session = Session()
     try:
-        ahora = datetime.now()
+        ahora = datetime.utcnow()
         nuevo_torneo = GestorSQL.SuizoTorneo(
             nombre=nombre,
             activo=1,
@@ -4239,7 +4240,7 @@ async def suizo_set_puntos(ctx, torneo_id: int, win: str, draw: str, loss: str, 
         torneo.puntos_draw = puntos_draw
         torneo.puntos_loss = puntos_loss
         torneo.puntos_bye = puntos_bye
-        torneo.updated_at = datetime.now()
+        torneo.updated_at = datetime.utcnow()
 
         session.commit()
         session.refresh(torneo)
@@ -4301,7 +4302,7 @@ async def suizo_add_jugador(ctx, torneo_id: int, usuario: discord.Member, raza_c
             late_join_ronda=None,
             puntos_ajuste_inicial=0,
             raza_competicion=raza_final,
-            created_at=datetime.now(),
+            created_at=datetime.utcnow(),
         )
         session.add(nuevo_participante)
         session.commit()
@@ -4390,7 +4391,7 @@ async def suizo_add_lote(ctx, torneo_id: int, *tokens_usuarios: str):
                 late_join_ronda=None,
                 puntos_ajuste_inicial=0,
                 raza_competicion=raza_final,
-                created_at=datetime.now(),
+                created_at=datetime.utcnow(),
             )
             session.add(nuevo_participante)
             altas_ok += 1
@@ -4489,7 +4490,7 @@ async def suizo_add_tardio(ctx, torneo_id: int, usuario: discord.Member, raza_co
             late_join_ronda=late_join_ronda,
             puntos_ajuste_inicial=puntos_ajuste_inicial,
             raza_competicion=raza_final,
-            created_at=datetime.now(),
+            created_at=datetime.utcnow(),
         )
         session.add(nuevo_participante)
         session.commit()
@@ -4914,7 +4915,7 @@ async def suizo_generar_ronda(ctx, torneo_id: int, numero_ronda: int):
                 )
                 return
 
-        fecha_inicio = datetime.now()
+        fecha_inicio = datetime.utcnow()
         fecha_fin = torneo.fecha_fin_ronda1 if numero_ronda == 1 else (fecha_inicio + timedelta(days=7))
         nueva_ronda = GestorSQL.SuizoRonda(
             torneo_id=torneo_id,
@@ -5573,7 +5574,7 @@ async def actualiza_suizo(ctx, torneo_id: int, todos: int = 0):
                 score_c2=score_c2,
                 origen="API",
                 confirmado=True,
-                fecha_registro=datetime.now(),
+                fecha_registro=datetime.utcnow(),
             )
             session.add(nuevo_game)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# LombardBot
+
+## Operación y manejo de fechas
+
+- **Convención única de almacenamiento:** todas las fechas/horas que se persisten en base de datos se guardan en **UTC**.
+- En la capa de persistencia se utiliza `datetime.utcnow()` para registrar timestamps.
+- En mensajes de Discord donde aplica visualización para usuarios, las fechas se formatean en la zona deseada (por ejemplo, `Europe/Madrid`).
+
+### Recomendación operativa
+
+- Mantener la BD en UTC para evitar ambigüedades por horario de verano.
+- Convertir a la zona de negocio únicamente en la capa de presentación (mensajes, embeds, reportes).

--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -272,7 +272,7 @@ class SpinButtonsView(discord.ui.View):
             primer_mensaje = await self.obtener_primer_mensaje(mensaje_spin.channel)
             await primer_mensaje.edit(content='El spin está **LIBRE**')
             
-            thread = Thread(target=GestorSQL.insertar_spin, args=('LOMBARDBOT', datetime.now(), 'Encontrado'))
+            thread = Thread(target=GestorSQL.insertar_spin, args=('LOMBARDBOT', datetime.utcnow(), 'Encontrado'))
             thread.start()
 
 
@@ -365,7 +365,7 @@ class SpinButtonsView(discord.ui.View):
             await interaction.followup.send("No tienes ningún partido. No puedes spinear.", ephemeral=True)
             return
 
-        now_time = datetime.now()
+        now_time = datetime.utcnow()
 
         def proximidad(p):
             if getattr(p, 'fecha', None):
@@ -393,7 +393,7 @@ class SpinButtonsView(discord.ui.View):
 
         await interaction.followup.send("Ahora puedes buscar partido.", ephemeral=True)
 
-        thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.now(), 'Spin'))
+        thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Spin'))
         thread.start()
             
     @discord.ui.button(label="Encontrado", style=discord.ButtonStyle.blurple, custom_id='your_bot:encontrado')
@@ -424,7 +424,7 @@ class SpinButtonsView(discord.ui.View):
 
             primer_mensaje = await self.obtener_primer_mensaje(channel)
             await primer_mensaje.edit(content='El spin está **LIBRE**')
-            thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.now(), 'Encontrado'))
+            thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Encontrado'))
             thread.start()
 
             


### PR DESCRIPTION
### Motivation

- Evitar usos mixtos de zona horaria en persistencia y asegurar una única convención (UTC) para todos los timestamps almacenados en la BD.
- Mantener la conversión de zona (por ejemplo `Europe/Madrid`) solo en la capa de presentación para mensajes de Discord.

### Description

- Replaced persistence timestamps from `datetime.now()` to `datetime.utcnow()` in `LombardBot.py` and `UtilesDiscord.py` for `created_at`, `updated_at`, `fecha_inicio`, `fecha_registro` and other DB writes.
- Updated spin-related code to record events with `datetime.utcnow()` when calling `GestorSQL.insertar_spin` and to use UTC for proximity calculations.
- Modified the `ultimosspins` command to compute `tiempo_desde` in UTC and to convert stored UTC datetimes to `Europe/Madrid` via `ZoneInfo` when formatting the message for Discord.
- Added `README.md` documenting the operational convention: store all DB datetimes in UTC and convert to business timezone only at presentation.

### Testing

- `python -m py_compile LombardBot.py UtilesDiscord.py GestorSQL.py` ran successfully.
- `python -m pytest -q` failed during collection due to a missing environment dependency (`ModuleNotFoundError: No module named 'sqlalchemy'`).
- Basic runtime string/replace and static checks were performed to ensure no syntax regressions after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9ef9de40832aae76732e6589dbbd)