### PR TITLE
Persistir cierre de ronda suizo en UTC

### DIFF
--- a/SuizoCore.py
+++ b/SuizoCore.py
@@ -355,7 +355,7 @@ def procesar_cierre_ronda_si_corresponde(session, torneo_id, ronda_numero):
         }
 
     ronda.estado = RONDA_CERRADA
-    ronda.cerrada_en = datetime.now()
+    ronda.cerrada_en = datetime.utcnow()
 
     standings = calcular_standings(session, torneo_id, hasta_ronda=ronda_numero)
     snapshot_filas = guardar_snapshot_ronda(session, torneo_id, ronda_numero, standings)


### PR DESCRIPTION
### Motivation
- Unificar el criterio de timestamps persistidos en la base de datos del flujo suizo usando UTC en lugar de la hora local.

### Description
- Reemplacé en `SuizoCore.py` la asignación `ronda.cerrada_en = datetime.now()` por `ronda.cerrada_en = datetime.utcnow()` en la función `procesar_cierre_ronda_si_corresponde`.
- Revisé el flujo suizo en `SuizoCore.py` y confirmé que los demás timestamps de persistencia relevantes en el core de suizo (por ejemplo `SuizoPairingTrace.created_at`) ya usan `datetime.utcnow()`.

### Testing
- Ejecuté `pytest -q tests/test_suizo_core.py`, que no pudo completar la recolección por falta de la dependencia `sqlalchemy` en el entorno (error: `ModuleNotFoundError: No module named 'sqlalchemy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba0ad4dc8832a8562f13d1e89c5e0)