### PR TITLE
Calcular `fecha_fin` de rondas suizas a partir de la ronda anterior y añadir validación

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -4914,9 +4914,19 @@ async def suizo_generar_ronda(ctx, torneo_id: int, numero_ronda: int):
                     f"está en estado `{ronda_anterior.estado}`."
                 )
                 return
+            if ronda_anterior.fecha_fin is None:
+                await ctx.send(
+                    f"No se puede generar la ronda `{numero_ronda}`: la ronda `{numero_ronda - 1}` "
+                    "no tiene `fecha_fin` definida. Corrige la ronda anterior para evitar fechas inconsistentes."
+                )
+                return
 
         fecha_inicio = datetime.utcnow()
-        fecha_fin = torneo.fecha_fin_ronda1 if numero_ronda == 1 else (fecha_inicio + timedelta(days=7))
+        fecha_fin = (
+            torneo.fecha_fin_ronda1
+            if numero_ronda == 1
+            else (ronda_anterior.fecha_fin + timedelta(days=7))
+        )
         nueva_ronda = GestorSQL.SuizoRonda(
             torneo_id=torneo_id,
             numero=numero_ronda,


### PR DESCRIPTION
### Motivation
- Evitar que el cierre de rondas posteriores se desplace por la hora real de apertura y asegurar que el calendario de deadlines respete la planificación previa.
- Prevenir generación de rondas con fechas inconsistentes cuando la ronda anterior no tenga `fecha_fin` definido.

### Description
- Para `numero_ronda > 1`, se calcula `fecha_fin` como `ronda_anterior.fecha_fin + timedelta(days=7)` en lugar de `fecha_inicio + timedelta(days=7)` dentro de `suizo_generar_ronda` en `LombardBot.py`.
- Se añadió una validación que aborta y envía un mensaje claro si `ronda_anterior.fecha_fin is None` para evitar calendarios inconsistentes.
- `fecha_inicio` sigue siendo `datetime.utcnow()` para reflejar el momento real de apertura de la ronda.

### Testing
- Se compiló el módulo con `python -m py_compile LombardBot.py` y la comprobación de sintaxis finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba12af2dc832a8657bf2bc06005b9)