### PR TITLE
Use stored usuario_id when adding suizo participant to avoid undefined variable

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -4267,6 +4267,7 @@ async def suizo_add_jugador(ctx, torneo_id: int, usuario: discord.Member, raza_c
 
     Session = sessionmaker(bind=GestorSQL.conexionEngine())
     session = Session()
+    usuario_id_db = None
     try:
         torneo = session.query(GestorSQL.SuizoTorneo).filter_by(id=torneo_id).first()
         if torneo is None:
@@ -4293,9 +4294,10 @@ async def suizo_add_jugador(ctx, torneo_id: int, usuario: discord.Member, raza_c
             return
 
         raza_final = raza_competicion if raza_competicion is not None else usuario_bd.raza
+        usuario_id_db = usuario_bd.idUsuarios
         nuevo_participante = GestorSQL.SuizoParticipante(
             torneo_id=torneo_id,
-            usuario_id=usuario_bd.idUsuarios,
+            usuario_id=usuario_id_db,
             estado="ACTIVO",
             tiene_bye=0,
             cantidad_byes=0,
@@ -4317,7 +4319,7 @@ async def suizo_add_jugador(ctx, torneo_id: int, usuario: discord.Member, raza_c
     await ctx.send(
         "✅ Jugador añadido correctamente al torneo suizo.\n"
         f"Torneo ID: **{torneo_id}**\n"
-        f"Usuario: {usuario.mention} (idUsuarios: **{usuario_bd.idUsuarios}**)\n"
+        f"Usuario: {usuario.mention} (idUsuarios: **{usuario_id_db}**)\n"
         f"Raza competición: **{raza_texto}**"
     )
 


### PR DESCRIPTION
### Motivation
- Prevent referencing `usuario_bd.idUsuarios` outside the try block or after the session is closed by capturing the database user id in a local variable before creating the participant and sending the confirmation message.

### Description
- Add `usuario_id_db` and assign `usuario_bd.idUsuarios` to it, then use `usuario_id_db` for the `SuizoParticipante.usuario_id` field and in the final confirmation message instead of referencing `usuario_bd.idUsuarios` directly.

### Testing
- No new automated tests were added; the change is a small refactor and existing test suites or bot command smoke checks were run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca4219f60832a973ff592e7e1908a)