### PR TITLE
Handle BYE pairings as administered with assigned points when generating/regenerating Swiss rounds

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -4996,21 +4996,27 @@ async def suizo_generar_ronda(ctx, torneo_id: int, numero_ronda: int):
             coach1_id = int(mesa["coach1"])
             coach2_raw = mesa.get("coach2")
             coach2_id = int(coach2_raw) if coach2_raw is not None else None
+            es_bye = bool(mesa.get("es_bye", False))
+            estado_inicial = "ADMINISTRADO" if es_bye else "PENDIENTE"
+            partidos_reportados = partidos_requeridos if es_bye else 0
+            puntos_c1 = Decimal(str(torneo.puntos_bye)) if es_bye else Decimal("0")
+            resultado_origen = "BYE" if es_bye else None
             emp = GestorSQL.SuizoEmparejamiento(
                 torneo_id=torneo_id,
                 ronda_id=nueva_ronda.id,
                 mesa_numero=idx,
                 coach1_usuario_id=coach1_id,
                 coach2_usuario_id=coach2_id,
-                estado="PENDIENTE",
-                es_bye=bool(mesa.get("es_bye", False)),
+                estado=estado_inicial,
+                es_bye=es_bye,
                 forfeit_tipo=mesa.get("forfeit_tipo", "NONE"),
                 partidos_requeridos=partidos_requeridos,
-                partidos_reportados=0,
+                partidos_reportados=partidos_reportados,
                 score_final_c1=0,
                 score_final_c2=0,
-                puntos_c1=0,
+                puntos_c1=puntos_c1,
                 puntos_c2=0,
+                resultado_origen=resultado_origen,
             )
             session.add(emp)
             emparejamientos_db.append(emp)
@@ -5247,21 +5253,27 @@ async def suizo_regenerar_ronda(ctx, torneo_id: int, numero_ronda: int):
             coach1_id = int(mesa["coach1"])
             coach2_raw = mesa.get("coach2")
             coach2_id = int(coach2_raw) if coach2_raw is not None else None
+            es_bye = bool(mesa.get("es_bye", False))
+            estado_inicial = "ADMINISTRADO" if es_bye else "PENDIENTE"
+            partidos_reportados = partidos_requeridos if es_bye else 0
+            puntos_c1 = Decimal(str(torneo.puntos_bye)) if es_bye else Decimal("0")
+            resultado_origen = "BYE" if es_bye else None
             emp = GestorSQL.SuizoEmparejamiento(
                 torneo_id=torneo_id,
                 ronda_id=ronda.id,
                 mesa_numero=idx,
                 coach1_usuario_id=coach1_id,
                 coach2_usuario_id=coach2_id,
-                estado="PENDIENTE",
-                es_bye=bool(mesa.get("es_bye", False)),
+                estado=estado_inicial,
+                es_bye=es_bye,
                 forfeit_tipo=mesa.get("forfeit_tipo", "NONE"),
                 partidos_requeridos=partidos_requeridos,
-                partidos_reportados=0,
+                partidos_reportados=partidos_reportados,
                 score_final_c1=0,
                 score_final_c2=0,
-                puntos_c1=0,
+                puntos_c1=puntos_c1,
                 puntos_c2=0,
+                resultado_origen=resultado_origen,
             )
             session.add(emp)
             emparejamientos_db.append(emp)


### PR DESCRIPTION
### Motivation

- Ensure BYE pairings created during Swiss round generation or regeneration are treated as already completed and receive the configured BYE points and reported matches automatically.

### Description

- In `suizo_generar_ronda` and `suizo_regenerar_ronda` determine `es_bye` from the pairing and set `estado` to `"ADMINISTRADO"` when true. 
- Set `partidos_reportados` to the full `partidos_requeridos` for BYE pairings and `0` otherwise. 
- Assign `puntos_c1` for BYE pairings from `Decimal(str(torneo.puntos_bye))` and leave non-BYE points as `Decimal("0")`. 
- Record `resultado_origen` as `"BYE"` and persist `es_bye` on the `SuizoEmparejamiento` rows.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecae121b60832a9ac203502fa2caf5)