### PR TITLE
Asignar bye al peor elegible sin bye previo y determinizar selección

### DIFF
--- a/SuizoCore.py
+++ b/SuizoCore.py
@@ -420,6 +420,7 @@ def generar_pairings_backtracking(session, torneo_id, ronda_numero):
         activos_por_puntos.setdefault(puntos, []).append(int(fila["usuario_id"]))
 
     usuarios_ordenados = [int(f["usuario_id"]) for f in activos]
+    puntos_por_usuario = {int(f["usuario_id"]): _decimal(f["puntos"]) for f in activos}
     grupo_por_usuario = {}
     for idx, (_, usuarios) in enumerate(
         sorted(activos_por_puntos.items(), key=lambda item: Decimal(item[0]), reverse=True)
@@ -459,17 +460,17 @@ def generar_pairings_backtracking(session, torneo_id, ronda_numero):
         return bool(raza1 and raza2 and raza1 == raza2)
 
     def elegir_bye(disponibles):
-        elegibles = [u for u in disponibles if byes_previos.get(u, 0) == 0]
-        pool = elegibles if elegibles else list(disponibles)
-        return sorted(
+        elegibles_sin_bye = [u for u in disponibles if byes_previos.get(u, 0) == 0]
+        pool = elegibles_sin_bye if elegibles_sin_bye else list(disponibles)
+        orden_peor_a_mejor = sorted(
             pool,
             key=lambda u: (
-                grupo_por_usuario.get(u, 10**6),
-                _decimal(next(f["puntos"] for f in activos if int(f["usuario_id"]) == u)),
-                u,
+                -grupo_por_usuario.get(u, -1),
+                puntos_por_usuario.get(u, Decimal("0")),
+                -u,
             ),
-            reverse=True,
-        )[-1]
+        )
+        return orden_peor_a_mejor[0]
 
     def resolver(allow_repeat, allow_mirror):
         conflictos = {"repetido": 0, "mirror": 0, "sin_rival": 0}

--- a/tests/test_suizo_core.py
+++ b/tests/test_suizo_core.py
@@ -249,6 +249,36 @@ def test_fallback_a_repetidos_cuando_no_hay_solucion():
     assert ultima_traza.resultado == "FALLBACK_REPETIDO"
 
 
+def test_bye_se_asigna_al_peor_elegible_sin_bye_previo():
+    session = _build_session()
+    _crear_torneo_base(session, torneo_id=31)
+    for uid, raza in ((1, "A"), (2, "B"), (3, "C"), (4, "D"), (5, "E")):
+        _crear_usuario_y_participante(session, 31, uid, raza=raza)
+
+    # Ronda 1: líder claro (1), dos jugadores con bye previo (4 y 5).
+    r1 = _crear_ronda(session, 31, 1)
+    _crear_emparejamiento(session, 31, r1.id, 1, 1, 2, score1=1, score2=0, puntos1=Decimal("3"), puntos2=Decimal("0"))
+    _crear_emparejamiento(session, 31, r1.id, 2, 3, 4, score1=1, score2=0, puntos1=Decimal("3"), puntos2=Decimal("0"))
+    _crear_emparejamiento(session, 31, r1.id, 3, 5, None, es_bye=True)
+
+    # Ronda 2: nuevo bye a jugador 4 para que 4 y 5 queden con bye previo.
+    r2 = _crear_ronda(session, 31, 2)
+    _crear_emparejamiento(session, 31, r2.id, 1, 1, 3, score1=1, score2=0, puntos1=Decimal("3"), puntos2=Decimal("0"))
+    _crear_emparejamiento(session, 31, r2.id, 2, 2, 5, score1=1, score2=0, puntos1=Decimal("3"), puntos2=Decimal("0"))
+    _crear_emparejamiento(session, 31, r2.id, 3, 4, None, es_bye=True)
+
+    _crear_ronda(session, 31, 3, estado="ABIERTA")
+    session.commit()
+
+    pairings = generar_pairings_backtracking(session, 31, 3)
+    bye_r3 = next(p for p in pairings if p["es_bye"])
+
+    # Elegibles sin bye previo en R3: 1,2,3. Entre 2 y 3 empatan en puntos y grupo;
+    # el desempate determinista por id deja peor a 3 (id mayor), nunca al líder 1.
+    assert bye_r3["coach1"] == 3
+    assert bye_r3["coach1"] != 1
+
+
 def test_drop_genera_forfeit_1_0_con_3_puntos():
     session = _build_session()
     _crear_torneo_base(session, torneo_id=40, rondas_totales=1)


### PR DESCRIPTION
### Motivation
- Evitar asignar bye a jugadores que ya tuvieron bye cuando existen elegibles sin bye y garantizar una selección determinista del "peor" jugador.

### Description
- Se precomputan los puntos por usuario en `puntos_por_usuario` para evitar recalcularlos durante la comparación.
- Se reescribe `elegir_bye` para priorizar participantes con `byes_previos == 0` y, si no hay, usar todo el conjunto disponible.
- La comparación ahora ordena por grupo (peor grupo primero), luego por puntos (menos puntos primero) y finalmente por id (id mayor gana el desempate), y devuelve el primer elemento de la ordenación.

### Testing
- Se añadió el test unitario `test_bye_se_asigna_al_peor_elegible_sin_bye_previo` que verifica la lógica de asignación de bye entre elegibles sin bye previo.
- Ejecuté `pytest tests/test_suizo_core.py::test_bye_se_asigna_al_peor_elegible_sin_bye_previo` y el test existente `tests/test_suizo_core.py::test_fallback_a_repetidos_cuando_no_hay_solucion`, y ambos pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecfcf0e5dc832a9d7173f5f16c87ed)