### PR TITLE
Añade mensajes inicial/subsiguiente en canales del suizo

### DIFF
--- a/GestorSQL.py
+++ b/GestorSQL.py
@@ -285,6 +285,8 @@ class SuizoTorneo(Base):
     fecha_fin_ronda1 = Column(DateTime, nullable=False)
     dias_por_ronda = Column(Integer, nullable=False, default=7)
     canal_hub_id = Column(BigInteger, nullable=True)
+    mensajeInicial = Column(Text, nullable=True)
+    mensajesSubsiguientes = Column(Text, nullable=True)
     creado_por_discord_id = Column(BigInteger, nullable=True)
     created_at = Column(DateTime, nullable=False)
     updated_at = Column(DateTime, nullable=False)

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -5235,6 +5235,9 @@ async def suizo_generar_ronda(ctx, torneo_id: int, numero_ronda: int):
                         category=categoria_destino,
                         overwrites=overwrites,
                     )
+                    mensaje_canal = _mensaje_suizo_canal(torneo, True, jugador1, jugador2, nueva_ronda)
+                    if mensaje_canal:
+                        await canal_creado.send(mensaje_canal)
                     emp.canal_id = canal_creado.id
                     canales_ok += 1
                 except Exception:
@@ -5490,6 +5493,9 @@ async def suizo_regenerar_ronda(ctx, torneo_id: int, numero_ronda: int):
                         category=categoria_destino,
                         overwrites=overwrites,
                     )
+                    mensaje_canal = _mensaje_suizo_canal(torneo, False, jugador1, jugador2, ronda)
+                    if mensaje_canal:
+                        await canal_creado.send(mensaje_canal)
                     emp.canal_id = canal_creado.id
                     canales_creados += 1
                 except Exception:
@@ -5807,6 +5813,36 @@ async def publicar_resultado_suizo_en_foro(
     with open(ruta_imagen, "rb") as img:
         await hilo.send(file=File(img))
     threading.Timer(10, lambda: Imagenes.eliminar_imagen(ruta_imagen)).start()
+
+
+def _mensaje_suizo_canal(torneo, es_mensaje_inicial, jugador1, jugador2, ronda):
+    plantilla = torneo.mensajeInicial if es_mensaje_inicial else torneo.mensajesSubsiguientes
+    if not plantilla:
+        return ""
+    mention1 = f"<@{jugador1.id_discord}>" if jugador1 and jugador1.id_discord else ""
+    mention2 = f"<@{jugador2.id_discord}>" if jugador2 and jugador2.id_discord else ""
+    raza1 = (getattr(jugador1, "raza", "") or "").strip()
+    raza2 = (getattr(jugador2, "raza", "") or "").strip()
+    mensajePreferencias1 = ""
+    mensajePreferencias2 = ""
+    pref1 = getattr(getattr(jugador1, "preferencias_fecha", None), "preferencia", "") if jugador1 else ""
+    pref2 = getattr(getattr(jugador2, "preferencias_fecha", None), "preferencia", "") if jugador2 else ""
+    if jugador1 and jugador1.id_discord and pref1:
+        mensajePreferencias1 = f"\n<@{jugador1.id_discord}> suele poder jugar {pref1}"
+    if jugador2 and jugador2.id_discord and pref2:
+        mensajePreferencias2 = f"\n<@{jugador2.id_discord}> suele poder jugar {pref2}"
+    fecha = ""
+    if ronda and getattr(ronda, "fecha_fin", None):
+        fecha = f"\n\nLa Fecha límite para jugar el partido es el <t:{int(ronda.fecha_fin.timestamp())}:f>"
+    return plantilla.format(
+        mention1=mention1,
+        mention2=mention2,
+        raza1=raza1,
+        raza2=raza2,
+        mensajePreferencias1=mensajePreferencias1,
+        mensajePreferencias2=mensajePreferencias2,
+        fecha=fecha,
+    )
 
 
 @bot.command(name="actualiza_suizo")


### PR DESCRIPTION
### Motivation
- Permitir que los canales creados para emparejamientos suizos incluyan un mensaje configurable almacenado en la tabla `suizo_torneo` para evitar que los canales aparezcan vacíos.
- Reutilizar plantillas con placeholders para mencionar jugadores, razas, preferencias y fecha límite de la ronda.

### Description
- Añadí los campos ORM `mensajeInicial` y `mensajesSubsiguientes` en `SuizoTorneo` para exponer las nuevas columnas de la BD a la aplicación (`GestorSQL.py`).
- Implementé la función `_mensaje_suizo_canal(torneo, es_mensaje_inicial, jugador1, jugador2, ronda)` que compone el texto a enviar sustituyendo los placeholders `{mention1}`, `{mention2}`, `{raza1}`, `{raza2}`, `{mensajePreferencias1}`, `{mensajePreferencias2}` y `{fecha}`.
- Envío automático del mensaje al crear canales en los flujos de `!suizo_generar_ronda` (usa `mensajeInicial`) y `!suizo_regenerar_ronda`/reapertura (usa `mensajesSubsiguientes`) justo después de crear el canal.
- Si la plantilla está vacía o `NULL`, no se envía mensaje y se mantiene el comportamiento previo; las preferencias solo se anaden si existen.

### Testing
- Compilación estática de los módulos con `python -m py_compile LombardBot.py GestorSQL.py` realizada y exitosa.
- No se ejecutaron tests de integración en Discord en este cambio; se diseñó para no romper el flujo si las plantillas no están definidas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f777a2cc68832ab4b6a5ea950bcb8f)