### PR TITLE
Add suizo channel message templates and send formatted messages on channel creation

### DIFF
--- a/GestorSQL.py
+++ b/GestorSQL.py
@@ -285,6 +285,8 @@ class SuizoTorneo(Base):
     fecha_fin_ronda1 = Column(DateTime, nullable=False)
     dias_por_ronda = Column(Integer, nullable=False, default=7)
     canal_hub_id = Column(BigInteger, nullable=True)
+    mensajeInicial = Column(Text, nullable=True)
+    mensajesSubsiguientes = Column(Text, nullable=True)
     creado_por_discord_id = Column(BigInteger, nullable=True)
     created_at = Column(DateTime, nullable=False)
     updated_at = Column(DateTime, nullable=False)

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -5148,6 +5148,18 @@ async def suizo_generar_ronda(ctx, torneo_id: int, numero_ronda: int):
             .all()
         )
         usuarios_por_id = {int(u.idUsuarios): u for u in usuarios}
+        participantes_torneo = (
+            session.query(GestorSQL.SuizoParticipante)
+            .filter(
+                GestorSQL.SuizoParticipante.torneo_id == torneo_id,
+                GestorSQL.SuizoParticipante.usuario_id.in_(ids_usuarios),
+            )
+            .all()
+        )
+        raza_por_usuario = {
+            int(p.usuario_id): (p.raza_competicion or "").strip()
+            for p in participantes_torneo
+        }
         partidos_requeridos = _partidos_requeridos_desde_formato(torneo.formato_serie)
 
         emparejamientos_db = []
@@ -5235,6 +5247,17 @@ async def suizo_generar_ronda(ctx, torneo_id: int, numero_ronda: int):
                         category=categoria_destino,
                         overwrites=overwrites,
                     )
+                    mensaje_canal = _mensaje_suizo_canal(
+                        torneo,
+                        True,
+                        jugador1,
+                        jugador2,
+                        nueva_ronda,
+                        raza_por_usuario.get(int(emp.coach1_usuario_id), ""),
+                        raza_por_usuario.get(int(emp.coach2_usuario_id), "") if emp.coach2_usuario_id else "",
+                    )
+                    if mensaje_canal:
+                        await canal_creado.send(mensaje_canal)
                     emp.canal_id = canal_creado.id
                     canales_ok += 1
                 except Exception:
@@ -5405,6 +5428,18 @@ async def suizo_regenerar_ronda(ctx, torneo_id: int, numero_ronda: int):
             .all()
         )
         usuarios_por_id = {int(u.idUsuarios): u for u in usuarios}
+        participantes_torneo = (
+            session.query(GestorSQL.SuizoParticipante)
+            .filter(
+                GestorSQL.SuizoParticipante.torneo_id == torneo_id,
+                GestorSQL.SuizoParticipante.usuario_id.in_(ids_usuarios),
+            )
+            .all()
+        )
+        raza_por_usuario = {
+            int(p.usuario_id): (p.raza_competicion or "").strip()
+            for p in participantes_torneo
+        }
         partidos_requeridos = _partidos_requeridos_desde_formato(torneo.formato_serie)
 
         emparejamientos_db = []
@@ -5490,6 +5525,17 @@ async def suizo_regenerar_ronda(ctx, torneo_id: int, numero_ronda: int):
                         category=categoria_destino,
                         overwrites=overwrites,
                     )
+                    mensaje_canal = _mensaje_suizo_canal(
+                        torneo,
+                        False,
+                        jugador1,
+                        jugador2,
+                        ronda,
+                        raza_por_usuario.get(int(emp.coach1_usuario_id), ""),
+                        raza_por_usuario.get(int(emp.coach2_usuario_id), "") if emp.coach2_usuario_id else "",
+                    )
+                    if mensaje_canal:
+                        await canal_creado.send(mensaje_canal)
                     emp.canal_id = canal_creado.id
                     canales_creados += 1
                 except Exception:
@@ -5807,6 +5853,36 @@ async def publicar_resultado_suizo_en_foro(
     with open(ruta_imagen, "rb") as img:
         await hilo.send(file=File(img))
     threading.Timer(10, lambda: Imagenes.eliminar_imagen(ruta_imagen)).start()
+
+
+def _mensaje_suizo_canal(torneo, es_mensaje_inicial, jugador1, jugador2, ronda, raza1="", raza2=""):
+    plantilla = torneo.mensajeInicial if es_mensaje_inicial else torneo.mensajesSubsiguientes
+    if not plantilla:
+        return ""
+    mention1 = f"<@{jugador1.id_discord}>" if jugador1 and jugador1.id_discord else ""
+    mention2 = f"<@{jugador2.id_discord}>" if jugador2 and jugador2.id_discord else ""
+    raza1 = (raza1 or getattr(jugador1, "raza", "") or "").strip()
+    raza2 = (raza2 or getattr(jugador2, "raza", "") or "").strip()
+    mensajePreferencias1 = ""
+    mensajePreferencias2 = ""
+    pref1 = getattr(getattr(jugador1, "preferencias_fecha", None), "preferencia", "") if jugador1 else ""
+    pref2 = getattr(getattr(jugador2, "preferencias_fecha", None), "preferencia", "") if jugador2 else ""
+    if jugador1 and jugador1.id_discord and pref1:
+        mensajePreferencias1 = f"\n<@{jugador1.id_discord}> suele poder jugar {pref1}"
+    if jugador2 and jugador2.id_discord and pref2:
+        mensajePreferencias2 = f"\n<@{jugador2.id_discord}> suele poder jugar {pref2}"
+    fecha = ""
+    if ronda and getattr(ronda, "fecha_fin", None):
+        fecha = f"\n\nLa Fecha límite para jugar el partido es el <t:{int(ronda.fecha_fin.timestamp())}:f>"
+    return plantilla.format(
+        mention1=mention1,
+        mention2=mention2,
+        raza1=raza1,
+        raza2=raza2,
+        mensajePreferencias1=mensajePreferencias1,
+        mensajePreferencias2=mensajePreferencias2,
+        fecha=fecha,
+    )
 
 
 @bot.command(name="actualiza_suizo")


### PR DESCRIPTION
### Motivation
- Allow tournaments to store initial and follow-up message templates in the DB for suizo tournaments by adding template fields to the model. 
- Automatically send a formatted message to match channels when they are created so players receive matchup details and scheduling info. 
- Include participants' chosen race and scheduling preferences in those messages to reduce manual notification work.

### Description
- Added two new columns to `SuizoTorneo`: `mensajeInicial` and `mensajesSubsiguientes` (both `Text`) to persist message templates. 
- When generating or regenerating a suizo round, query `SuizoParticipante` for participants and build a `raza_por_usuario` map from `raza_competicion`. 
- After creating each match text channel, call a new helper `_mensaje_suizo_canal(...)` which formats the appropriate template (initial vs subsequent) and includes mentions, races, player scheduling preferences, and the match deadline, then sends it to the channel if non-empty. 
- Implemented `_mensaje_suizo_canal` to safely build and return the formatted message or an empty string when no template is configured.

### Testing
- Ran the project's automated test suite with `pytest -q`, and the tests completed successfully. 
- Ran static checks with `flake8` and no new lint errors were reported. 
- No failing tests were observed after these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f777a2cc68832ab4b6a5ea950bcb8f)