### PR TITLE
Añade aviso diario para emparejamamientos suizos (Butter Suizo, torneo 2)

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -6680,6 +6680,17 @@ aviso_playoffs = (
     }
 )
 
+aviso_suizo = (
+    func_proximos_partidos_suizo_emparejamiento,
+    {
+        "bot": bot,
+        "usuario": maestros[0],
+        "torneo_id": 2,
+        "canal_destino_id": 1224689043032506429,
+        "respuesta_privada": False
+    }
+)
+
 actualizacion_peticiones = (
     actualizar_peticiones_razas,
     {
@@ -6690,7 +6701,7 @@ actualizacion_peticiones = (
 tareas_programadas = {
     dia: {
         "09": [aviso_playoffs],
-        "10": [actualizacion_peticiones],
+        "10": [aviso_suizo, actualizacion_peticiones],
         "22": [actualizacion_peticiones],
     }
     for dia in dias_semana
@@ -6704,7 +6715,83 @@ tareas_programadas = {
 #         }
 #     )
 # ]
+async def func_proximos_partidos_suizo_emparejamiento(bot, usuario, torneo_id, canal_destino_id=None, respuesta_privada=True):
+    Session = sessionmaker(bind=GestorSQL.conexionEngine())
+    session = Session()
+
+    ahora = datetime.now()
+    fin = (ahora + timedelta(days=1)).replace(hour=12, minute=0, second=0, microsecond=0)
+
+    canal_destino = bot.get_channel(int(canal_destino_id)) if canal_destino_id else None
+
+    if respuesta_privada:
+        try:
+            canal_destino = await usuario.create_dm()
+        except Exception as e:
+            print(f"No se pudo crear un DM con el usuario: {e}")
+            session.close()
+            return
+    else:
+        if not canal_destino:
+            if hasattr(usuario, 'channel'):
+                canal_destino = usuario.channel
+            else:
+                print("No se encontró un canal válido para enviar el mensaje.")
+                session.close()
+                return
+
+    UsuarioCoach1 = aliased(GestorSQL.Usuario)
+    UsuarioCoach2 = aliased(GestorSQL.Usuario)
+
+    eventos = (
+        session.query(
+            GestorSQL.SuizoEmparejamiento,
+            GestorSQL.SuizoRonda.numero.label("ronda_numero"),
+            UsuarioCoach1.nombre_discord.label("nombre_discord1"),
+            UsuarioCoach1.raza.label("raza1"),
+            UsuarioCoach2.nombre_discord.label("nombre_discord2"),
+            UsuarioCoach2.raza.label("raza2"),
+        )
+        .join(GestorSQL.SuizoRonda, GestorSQL.SuizoEmparejamiento.ronda_id == GestorSQL.SuizoRonda.id)
+        .join(UsuarioCoach1, GestorSQL.SuizoEmparejamiento.coach1_usuario_id == UsuarioCoach1.idUsuarios)
+        .join(UsuarioCoach2, GestorSQL.SuizoEmparejamiento.coach2_usuario_id == UsuarioCoach2.idUsuarios)
+        .filter(
+            GestorSQL.SuizoEmparejamiento.torneo_id == torneo_id,
+            GestorSQL.SuizoEmparejamiento.es_bye == False,
+            GestorSQL.SuizoEmparejamiento.fecha.isnot(None),
+            GestorSQL.SuizoEmparejamiento.fecha >= ahora,
+            GestorSQL.SuizoEmparejamiento.fecha <= fin,
+        )
+        .order_by(GestorSQL.SuizoEmparejamiento.fecha)
+        .all()
+    )
+
+    if not eventos:
+        session.close()
+        return
+
+    partidos = []
+    for calendario, ronda_numero, nd1, raza1, nd2, raza2 in eventos:
+        partidos.append(
+            f"Mesa {calendario.mesa_numero} (R{ronda_numero}): **{nd1}** ({raza1}) VS **{nd2}** ({raza2}), <t:{int(calendario.fecha.timestamp())}:f>"
+        )
+
+    mensaje = (
+        "¿Quienes serán los paladines de la mantequilla? Hoy los siguientes grandes se lo juegan en el Butter Suizo :ButterSuizo:!\n\n"
+        + "\n".join(partidos)
+    )
+
+    try:
+        await canal_destino.send(mensaje)
+    except Exception as e:
+        print(f"No se pudo enviar el mensaje de suizo: {e}")
+    finally:
+        session.close()
+
+
+
 
         
 # Ejecutar el bot con el token correspondiente
 bot.run(discord_bot_token)
+


### PR DESCRIPTION
### Motivation
- Añadir una notificación diaria similar a `aviso_playoffs` para avisar de los partidos del calendario de `suizo_emparejamiento` del Butter Suizo. 
- Ejecutarla todos los días a las 10:00 y aceptar `torneo_id` como argumento (para este caso `2`).

### Description
- Se añade la función `func_proximos_partidos_suizo_emparejamiento(...)` que consulta `GestorSQL.SuizoEmparejamiento` unida a `SuizoRonda` y `Usuario` y recopila emparejamientos con `fecha` en la ventana `[ahora, mañana 12:00]` y `es_bye == False` para el `torneo_id` recibido. 
- La función construye y envía el mensaje con el formato solicitado: `¿Quienes serán los paladines de la mantequilla? ... :ButterSuizo:!` seguido del listado de partidos con mesa, ronda y fecha. 
- Se introduce la tupla `aviso_suizo` (con `torneo_id: 2`) y se incorpora al planificador `tareas_programadas` para ejecutarse diariamente a las `10` junto a `actualizacion_peticiones`. 
- Si no hay emparejamientos en el intervalo, la tarea queda silenciosa y no envía mensaje (comportamiento apto para cron jobs). 

### Testing
- Se compiló el archivo modificado con `python -m py_compile LombardBot.py` y no se reportaron errores. 
- No se modificaron tests unitarios existentes; la integración se limitó a verificar la sintaxis del fichero principal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f99e30d5f4832a9545900f7fc63fda)