### PR TITLE
Usar raza de participante en avisos suizos

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -6687,19 +6687,35 @@ async def func_proximos_partidos_suizo_emparejamiento(bot, usuario, torneo_id, c
 
     UsuarioCoach1 = aliased(GestorSQL.Usuario)
     UsuarioCoach2 = aliased(GestorSQL.Usuario)
+    ParticipanteCoach1 = aliased(GestorSQL.SuizoParticipante)
+    ParticipanteCoach2 = aliased(GestorSQL.SuizoParticipante)
 
     eventos = (
         session.query(
             GestorSQL.SuizoEmparejamiento,
             GestorSQL.SuizoRonda.numero.label("ronda_numero"),
             UsuarioCoach1.nombre_discord.label("nombre_discord1"),
-            UsuarioCoach1.raza.label("raza1"),
+            ParticipanteCoach1.raza_competicion.label("raza1"),
             UsuarioCoach2.nombre_discord.label("nombre_discord2"),
-            UsuarioCoach2.raza.label("raza2"),
+            ParticipanteCoach2.raza_competicion.label("raza2"),
         )
         .join(GestorSQL.SuizoRonda, GestorSQL.SuizoEmparejamiento.ronda_id == GestorSQL.SuizoRonda.id)
         .join(UsuarioCoach1, GestorSQL.SuizoEmparejamiento.coach1_usuario_id == UsuarioCoach1.idUsuarios)
         .join(UsuarioCoach2, GestorSQL.SuizoEmparejamiento.coach2_usuario_id == UsuarioCoach2.idUsuarios)
+        .join(
+            ParticipanteCoach1,
+            and_(
+                ParticipanteCoach1.torneo_id == GestorSQL.SuizoEmparejamiento.torneo_id,
+                ParticipanteCoach1.usuario_id == GestorSQL.SuizoEmparejamiento.coach1_usuario_id,
+            ),
+        )
+        .join(
+            ParticipanteCoach2,
+            and_(
+                ParticipanteCoach2.torneo_id == GestorSQL.SuizoEmparejamiento.torneo_id,
+                ParticipanteCoach2.usuario_id == GestorSQL.SuizoEmparejamiento.coach2_usuario_id,
+            ),
+        )
         .filter(
             GestorSQL.SuizoEmparejamiento.torneo_id == torneo_id,
             GestorSQL.SuizoEmparejamiento.es_bye == False,
@@ -6815,19 +6831,35 @@ async def func_proximos_partidos_suizo_emparejamiento(bot, usuario, torneo_id, c
 
     UsuarioCoach1 = aliased(GestorSQL.Usuario)
     UsuarioCoach2 = aliased(GestorSQL.Usuario)
+    ParticipanteCoach1 = aliased(GestorSQL.SuizoParticipante)
+    ParticipanteCoach2 = aliased(GestorSQL.SuizoParticipante)
 
     eventos = (
         session.query(
             GestorSQL.SuizoEmparejamiento,
             GestorSQL.SuizoRonda.numero.label("ronda_numero"),
             UsuarioCoach1.nombre_discord.label("nombre_discord1"),
-            UsuarioCoach1.raza.label("raza1"),
+            ParticipanteCoach1.raza_competicion.label("raza1"),
             UsuarioCoach2.nombre_discord.label("nombre_discord2"),
-            UsuarioCoach2.raza.label("raza2"),
+            ParticipanteCoach2.raza_competicion.label("raza2"),
         )
         .join(GestorSQL.SuizoRonda, GestorSQL.SuizoEmparejamiento.ronda_id == GestorSQL.SuizoRonda.id)
         .join(UsuarioCoach1, GestorSQL.SuizoEmparejamiento.coach1_usuario_id == UsuarioCoach1.idUsuarios)
         .join(UsuarioCoach2, GestorSQL.SuizoEmparejamiento.coach2_usuario_id == UsuarioCoach2.idUsuarios)
+        .join(
+            ParticipanteCoach1,
+            and_(
+                ParticipanteCoach1.torneo_id == GestorSQL.SuizoEmparejamiento.torneo_id,
+                ParticipanteCoach1.usuario_id == GestorSQL.SuizoEmparejamiento.coach1_usuario_id,
+            ),
+        )
+        .join(
+            ParticipanteCoach2,
+            and_(
+                ParticipanteCoach2.torneo_id == GestorSQL.SuizoEmparejamiento.torneo_id,
+                ParticipanteCoach2.usuario_id == GestorSQL.SuizoEmparejamiento.coach2_usuario_id,
+            ),
+        )
         .filter(
             GestorSQL.SuizoEmparejamiento.torneo_id == torneo_id,
             GestorSQL.SuizoEmparejamiento.es_bye == False,


### PR DESCRIPTION
### Motivation

- El aviso recurrente de partidos suizos estaba leyendo la raza desde la tabla de `usuarios` en lugar de usar la raza de competición específica del torneo almacenada en `suizo_participante.raza_competicion`.

### Description

- En `LombardBot.py` se añadieron los aliases `ParticipanteCoach1` y `ParticipanteCoach2` para `SuizoParticipante` y se cambió la consulta para seleccionar `raza_competicion` en lugar de `usuarios.raza`.
- Se añadieron joins a `SuizoParticipante` condicionados por `torneo_id` y `usuario_id` para resolver la raza de competición de cada coach del emparejamiento.
- El mismo cambio se aplicó en ambas definiciones de `func_proximos_partidos_suizo_emparejamiento` presentes en el archivo para mantener coherencia entre la versión programada y la definición final.
- Archivo modificado: `LombardBot.py` (consulta de eventos y construcción del mensaje de aviso).

### Testing

- `python -m py_compile LombardBot.py` se ejecutó correctamente y no reportó errores.
- `git diff --check` se ejecutó correctamente y no reportó problemas sintácticos en el diff.
- `pytest -q` no pudo completarse por limitación del entorno ya que falta la dependencia `sqlalchemy`, por lo que los tests unitarios no pudieron ejecutarse aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3fb52d70832a8e8167d242e4c269)