### PR TITLE
Corregir emoji ButterSuizo en aviso diario

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -84,6 +84,9 @@ canales_permitidos = ['457740100097540106']
 # Lista de comandos a los que el bot reaccionará
 comandos = ['eco', 'otroComando']
 
+# Emoji usado en los avisos del Butter Suizo
+BUTTER_SUIZO_EMOJI = "<:ButterSuizo:1496804851340808284>"
+
 # IDs para la actualización programada de peticiones de razas
 PETICIONES_RAZAS_CANAL_ID = 1280102673059680316
 PETICIONES_RAZAS_HEADER_MESSAGE_ID = 1450467375794094083
@@ -6738,7 +6741,7 @@ async def func_proximos_partidos_suizo_emparejamiento(bot, usuario, torneo_id, c
         )
 
     mensaje = (
-        "**¿Quienes serán los paladines de la mantequilla? Hoy los siguientes grandes se lo juegan en el Butter Suizo** :ButterSuizo: !\n\n"
+        f"**¿Quienes serán los paladines de la mantequilla? Hoy los siguientes grandes se lo juegan en el Butter Suizo** {BUTTER_SUIZO_EMOJI} !\n\n"
         + "\n".join(partidos)
     )
 
@@ -6882,7 +6885,7 @@ async def func_proximos_partidos_suizo_emparejamiento(bot, usuario, torneo_id, c
         )
 
     mensaje = (
-        "¿Quienes serán los paladines de la mantequilla? Hoy los siguientes grandes se lo juegan en el Butter Suizo :ButterSuizo:!\n\n"
+        f"¿Quienes serán los paladines de la mantequilla? Hoy los siguientes grandes se lo juegan en el Butter Suizo {BUTTER_SUIZO_EMOJI}!\n\n"
         + "\n".join(partidos)
     )
 


### PR DESCRIPTION
### Motivation
- El aviso diario del Butter Suizo mostraba el texto `:ButterSuizo:` en vez del icono porque no se estaba usando la sintaxis completa del emoji con su ID. 
- Se quería que el bot envíe el emoji custom para que Discord renderice el icono en lugar del texto plano.

### Description
- Añadida la constante `BUTTER_SUIZO_EMOJI = "<:ButterSuizo:1496804851340808284>"` para centralizar el emoji. 
- Reemplazadas las dos plantillas de mensaje en `func_proximos_partidos_suizo_emparejamiento` para usar f-strings e insertar `BUTTER_SUIZO_EMOJI` en lugar de `:ButterSuizo:`. 
- Ajustado un comentario descriptivo cerca de la nueva constante para mayor claridad.

### Testing
- Ejecutado `python -m py_compile LombardBot.py` y la compilación fue exitosa. 
- Ejecutado `git diff --check` y no se detectaron problemas de formato o whitespace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda29db3b8832ab138894e1afb1279)