### PR TITLE
Aleatoriza desempates en pairings suizos

### DIFF
--- a/SuizoCore.py
+++ b/SuizoCore.py
@@ -1,6 +1,7 @@
 """Lógica base de standings para torneos suizos."""
 
 import json
+import random
 from datetime import datetime
 from decimal import Decimal
 from functools import cmp_to_key
@@ -377,13 +378,16 @@ def procesar_cierre_ronda_si_corresponde(session, torneo_id, ronda_numero):
     }
 
 
-def generar_pairings_backtracking(session, torneo_id, ronda_numero):
+def generar_pairings_backtracking(session, torneo_id, ronda_numero, rng=None):
     """Genera pairings de ronda usando backtracking con reglas suizas.
 
     Prioridades:
     1) Evitar rivales repetidos.
     2) Evitar mirror de raza.
-    3) Permitir repetidos/mirror como fallback si no hay solución.
+    3) Mantener cercanía de grupo de puntos.
+    4) Resolver empates de orden y múltiples rivales válidos de forma aleatoria,
+       no por id de usuario.
+    5) Permitir repetidos/mirror como fallback si no hay solución.
     """
     ronda = (
         session.query(SuizoRonda)
@@ -395,6 +399,8 @@ def generar_pairings_backtracking(session, torneo_id, ronda_numero):
     )
     if ronda is None:
         return []
+
+    rng = rng or random.SystemRandom()
 
     standings = calcular_standings(session, torneo_id, hasta_ronda=ronda_numero - 1 if ronda_numero > 1 else None)
     participantes = (
@@ -413,6 +419,23 @@ def generar_pairings_backtracking(session, torneo_id, ronda_numero):
     activos = [fila for fila in standings if int(fila["usuario_id"]) in participantes_por_usuario]
     if not activos:
         return []
+
+    def _valor_h2h_para_pairing(fila):
+        valor = fila.get("h2h_valor")
+        # En clasificación solo desempata si ambos tienen H2H; para ordenar el
+        # barrido de pairings, None queda neutro y el empate final lo rompe el azar.
+        return _decimal(valor) if valor is not None else Decimal("0")
+
+    activos = sorted(
+        activos,
+        key=lambda fila: (
+            -_decimal(fila.get("puntos")),
+            -_valor_h2h_para_pairing(fila),
+            -_decimal(fila.get("buchholz_cut")),
+            -int(fila.get("diff_score") or 0),
+            rng.random(),
+        ),
+    )
 
     activos_por_puntos: Dict[str, List[int]] = {}
     for fila in activos:
@@ -467,7 +490,7 @@ def generar_pairings_backtracking(session, torneo_id, ronda_numero):
             key=lambda u: (
                 -grupo_por_usuario.get(u, -1),
                 puntos_por_usuario.get(u, Decimal("0")),
-                -u,
+                rng.random(),
             ),
         )
         return orden_peor_a_mejor[0]
@@ -499,10 +522,10 @@ def generar_pairings_backtracking(session, torneo_id, ronda_numero):
             candidatos = []
             for u2 in pendientes[1:]:
                 delta_grupo = abs(grupo_por_usuario.get(u1, 0) - grupo_por_usuario.get(u2, 0))
-                candidatos.append((delta_grupo, es_mirror(u1, u2), u2))
+                candidatos.append((delta_grupo, es_mirror(u1, u2), rng.random(), u2))
             candidatos.sort(key=lambda x: (x[0], x[1], x[2]))
 
-            for _, mirror_actual, u2 in candidatos:
+            for _, mirror_actual, _, u2 in candidatos:
                 repetido = u2 in rivales_previos.get(u1, set())
                 if repetido and not allow_repeat:
                     conflictos["repetido"] += 1
@@ -530,10 +553,7 @@ def generar_pairings_backtracking(session, torneo_id, ronda_numero):
         ok = backtrack(restantes)
         if not ok:
             return None, conflictos
-        mesas_ordenadas = sorted(
-            mesas,
-            key=lambda m: (0 if not m["es_bye"] else 1, m["coach1"], m["coach2"] if m["coach2"] is not None else 10**9),
-        )
+        mesas_ordenadas = [m for m in mesas if not m["es_bye"]] + [m for m in mesas if m["es_bye"]]
         return mesas_ordenadas, conflictos
 
     seed_snapshot = (
@@ -568,6 +588,7 @@ def generar_pairings_backtracking(session, torneo_id, ronda_numero):
                 "agrupado_por_puntos": True,
                 "allow_repeat": allow_repeat,
                 "allow_mirror": allow_mirror,
+                "desempate_aleatorio": True,
             },
             conflictos=conflictos,
             created_at=datetime.utcnow(),

--- a/tests/test_suizo_core.py
+++ b/tests/test_suizo_core.py
@@ -1,3 +1,4 @@
+import random
 import sys
 from pathlib import Path
 
@@ -220,6 +221,24 @@ def test_h2h_rompe_empate_por_encima_de_buchholz():
     assert fila_1["rank"] < fila_2["rank"]
 
 
+def test_primera_ronda_desempata_emparejamientos_por_azar_no_por_id():
+    session = _build_session()
+    _crear_torneo_base(session, torneo_id=29)
+    for uid, raza in ((1, "A"), (2, "B"), (3, "C"), (4, "D")):
+        _crear_usuario_y_participante(session, 29, uid, raza=raza)
+
+    _crear_ronda(session, 29, 1, estado="ABIERTA")
+    session.commit()
+
+    pairings = generar_pairings_backtracking(session, 29, 1, rng=random.Random(2))
+    parejas = {frozenset((p["coach1"], p["coach2"])) for p in pairings if not p["es_bye"]}
+
+    assert parejas == {frozenset((1, 3)), frozenset((2, 4))}
+    assert parejas != {frozenset((1, 2)), frozenset((3, 4))}
+
+    ultima_traza = session.query(SuizoPairingTrace).order_by(SuizoPairingTrace.id.desc()).first()
+    assert ultima_traza.reglas_aplicadas["desempate_aleatorio"] is True
+
 def test_fallback_a_repetidos_cuando_no_hay_solucion():
     session = _build_session()
     _crear_torneo_base(session, torneo_id=30)
@@ -270,12 +289,12 @@ def test_bye_se_asigna_al_peor_elegible_sin_bye_previo():
     _crear_ronda(session, 31, 3, estado="ABIERTA")
     session.commit()
 
-    pairings = generar_pairings_backtracking(session, 31, 3)
+    pairings = generar_pairings_backtracking(session, 31, 3, rng=random.Random(0))
     bye_r3 = next(p for p in pairings if p["es_bye"])
 
     # Elegibles sin bye previo en R3: 1,2,3. Entre 2 y 3 empatan en puntos y grupo;
-    # el desempate determinista por id deja peor a 3 (id mayor), nunca al líder 1.
-    assert bye_r3["coach1"] == 3
+    # el desempate se resuelve por azar controlado en el test, nunca por id ni sobre el líder 1.
+    assert bye_r3["coach1"] == 2
     assert bye_r3["coach1"] != 1
 
 


### PR DESCRIPTION
### Motivation
- Corregir el sesgo observado en la generación de emparejamientos suizos donde, ante múltiples rivales válidos (especialmente en la primera ronda), se resolvían empates por `usuario_id` en lugar de aleatoriamente.
- Evitar que ordenes deterministas por id influyan en BYE y emparejamientos cuando los criterios deportivos son equivalentes.

### Description
- Modifica `generar_pairings_backtracking` en `SuizoCore.py` añadiendo un parámetro `rng` y usando `random.SystemRandom()` por defecto para que el desempate pueda ser aleatorio o inyectable en tests. 
- Ordena el barrido inicial de participantes por criterios deportivos (puntos, H2H, Buchholz, diff) y añade `rng.random()` como último criterio para romper empates de forma aleatoria. 
- Cambia la elección de `BYE` y la selección de candidatos del backtracking para usar `rng.random()` en lugar de `usuario_id` cuando haya empates equivalentes, y evita reordenado final por id manteniendo el orden descubierto por el algoritmo (BYE al final).
- Registra en `SuizoPairingTrace` la regla aplicada `desempate_aleatorio` para trazabilidad y actualiza `tests/test_suizo_core.py` añadiendo un test que verifica que la primera ronda ya no empareja por id y ajustando el test de BYE para comprobar desempate controlado.

### Testing
- Ejecuté los tests unitarios con `python -m pytest tests/test_suizo_core.py` sobre el módulo modificado, y todos los tests pasaron: `11 passed, 0 failed`.
- Las pruebas incluyeron el nuevo `test_primera_ronda_desempata_emparejamientos_por_azar_no_por_id` y la variante ajustada de la prueba de BYE con `rng` inyectado para reproducibilidad.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffa52a2e3c832a92cc1a8909cc3098)