### PR TITLE
Usa raza de participante suizo en resultados

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -39,7 +39,7 @@ import math
 from sqlalchemy import BIGINT, create_engine, Column, Integer, String, ForeignKey, false, true,text
 from sqlalchemy import and_, or_ 
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, relationship
+from sqlalchemy.orm import object_session, sessionmaker, relationship
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import case,func
 import inspect
@@ -50,6 +50,7 @@ from SuizoCore import (
     calcular_standings,
     generar_pairings_backtracking,
     procesar_cierre_ronda_si_corresponde,
+    obtener_raza_suizo_o_usuario,
 )
 
 
@@ -5875,6 +5876,20 @@ async def publicar_resultado_suizo_en_foro(
     else:
         ganador = {"ruta": "./plantillas/Empate.png", "x": 729, "y": 241}
 
+    db_session = object_session(emparejamiento)
+    raza1 = obtener_raza_suizo_o_usuario(
+        db_session,
+        getattr(torneo, "id", None),
+        emparejamiento.coach1_usuario_id,
+        emparejamiento.coach1_usuario,
+    )
+    raza2 = obtener_raza_suizo_o_usuario(
+        db_session,
+        getattr(torneo, "id", None),
+        emparejamiento.coach2_usuario_id,
+        emparejamiento.coach2_usuario,
+    )
+
     ruta_imagen = Imagenes.crear_imagen(
         "resultado",
         "",
@@ -5882,8 +5897,8 @@ async def publicar_resultado_suizo_en_foro(
         resultados={"0": score_c1, "1": score_c2},
         escudos={"0": f"Logos/{logo_local}", "1": f"Logos/{logo_visitante}"},
         razas={
-            "0": getattr(emparejamiento.coach1_usuario, "raza", "") or "",
-            "1": getattr(emparejamiento.coach2_usuario, "raza", "") or "",
+            "0": raza1,
+            "1": raza2,
         },
         nombre_equipos={
             "0": str(team_local.get("teamname") or "-"),

--- a/SuizoCore.py
+++ b/SuizoCore.py
@@ -42,6 +42,26 @@ def _get_valor_registro(registro: Any, campo: str, default: Any = None) -> Any:
     return getattr(registro, campo, default)
 
 
+def obtener_raza_suizo_o_usuario(session: Any, torneo_id: Any, usuario_id: Any, usuario: Any = None) -> str:
+    """Obtiene la raza usada en competición suiza, con fallback a la ficha habitual.
+
+    Para torneos suizos la raza oficial del participante vive en
+    ``suizo_participante.raza_competicion``. Si no hay sesión, participante o valor
+    informado, se mantiene el comportamiento habitual usando ``usuarios.raza``.
+    """
+    raza_usuario = (getattr(usuario, "raza", "") or "").strip() if usuario is not None else ""
+    if session is None or torneo_id is None or usuario_id is None:
+        return raza_usuario
+
+    participante = (
+        session.query(SuizoParticipante)
+        .filter_by(torneo_id=torneo_id, usuario_id=usuario_id)
+        .first()
+    )
+    raza_competicion = (getattr(participante, "raza_competicion", "") or "").strip()
+    return raza_competicion or raza_usuario
+
+
 def calcular_h2h(standings: List[EstadoFila], emparejamientos_cerrados: List[Any]) -> Dict[int, Optional[Decimal]]:
     """Calcula H2H solo para empates con enfrentamiento directo real.
 

--- a/tests/test_suizo_core.py
+++ b/tests/test_suizo_core.py
@@ -23,6 +23,7 @@ from SuizoCore import (
     calcular_h2h,
     calcular_standings,
     generar_pairings_backtracking,
+    obtener_raza_suizo_o_usuario,
     procesar_cierre_ronda_si_corresponde,
 )
 
@@ -113,6 +114,24 @@ def _crear_emparejamiento(session, torneo_id, ronda_id, mesa, c1, c2, estado="AD
             puntos_c2=puntos2,
         )
     )
+
+
+def test_obtener_raza_suizo_prioriza_raza_competicion_y_fallback_habitual():
+    session = _build_session()
+    _crear_torneo_base(session, torneo_id=42)
+    _crear_usuario_y_participante(session, 42, 1, raza="Skaven")
+    usuario = session.query(Usuario).filter_by(idUsuarios=1).first()
+    usuario.raza = "Humano"
+    session.commit()
+
+    assert obtener_raza_suizo_o_usuario(session, 42, 1, usuario) == "Skaven"
+
+    participante = session.query(SuizoParticipante).filter_by(torneo_id=42, usuario_id=1).first()
+    participante.raza_competicion = None
+    session.commit()
+
+    assert obtener_raza_suizo_o_usuario(session, 42, 1, usuario) == "Humano"
+    assert obtener_raza_suizo_o_usuario(None, None, 1, usuario) == "Humano"
 
 
 def test_h2h_aplicable_y_no_aplicable():


### PR DESCRIPTION
### Motivation

- Al publicar imágenes desde `!actualiza_suizo` se estaba usando la `raza` del usuario en lugar de la `raza_competicion` almacenada en `suizo_participante`, por lo que las imágenes no reflejaban la raza usada en la competición suiza.

### Description

- Añadida la función `obtener_raza_suizo_o_usuario` en `SuizoCore.py` que prioriza `suizo_participante.raza_competicion` y hace fallback a `usuarios.raza` cuando no aplica.
- Modificada la función que publica resultados en foro (`publicar_resultado_suizo_en_foro` en `LombardBot.py`) para obtener la sesión del emparejamiento con `object_session`, resolver `raza1` y `raza2` mediante el helper y pasar esas razas a `Imagenes.crear_imagen`.
- Añadida una prueba unitaria en `tests/test_suizo_core.py` que verifica la prioridad de `raza_competicion` y el fallback al valor habitual.

### Testing

- Se compiló `SuizoCore.py` y `LombardBot.py` con `python -m py_compile` exitosamente.
- Se ejecutaron los tests con `pytest -q tests/test_suizo_core.py` y todos los tests pasaron (`12 passed`, advertencias presentadas pero no fallos).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060e2a3cf4832ab0f9ab56c8f02e04)