### PR TITLE
Usar mensajes correctos según número de ronda en suizos

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -5305,7 +5305,7 @@ async def suizo_generar_ronda(ctx, torneo_id: int, numero_ronda: int):
                     )
                     mensaje_canal = _mensaje_suizo_canal(
                         torneo,
-                        True,
+                        _es_mensaje_inicial_suizo(numero_ronda),
                         jugador1,
                         jugador2,
                         nueva_ronda,
@@ -5583,7 +5583,7 @@ async def suizo_regenerar_ronda(ctx, torneo_id: int, numero_ronda: int):
                     )
                     mensaje_canal = _mensaje_suizo_canal(
                         torneo,
-                        False,
+                        _es_mensaje_inicial_suizo(numero_ronda),
                         jugador1,
                         jugador2,
                         ronda,
@@ -5929,6 +5929,10 @@ async def publicar_resultado_suizo_en_foro(
     with open(ruta_imagen, "rb") as img:
         await hilo.send(file=File(img))
     threading.Timer(10, lambda: Imagenes.eliminar_imagen(ruta_imagen)).start()
+
+
+def _es_mensaje_inicial_suizo(numero_ronda) -> bool:
+    return int(numero_ronda) == 1
 
 
 def _mensaje_suizo_canal(torneo, es_mensaje_inicial, jugador1, jugador2, ronda, raza1="", raza2=""):


### PR DESCRIPTION
### Motivation
- Evitar que las rondas posteriores a la primera usen siempre `mensajeInicial`; la primera ronda debe usar `mensajeInicial` y las siguientes `mensajesSubsiguientes`.

### Description
- Añade el helper `_es_mensaje_inicial_suizo(numero_ronda)` para centralizar la decisión de si una ronda es la inicial (ronda 1).
- Reemplaza los usos directos de `True`/`False` al invocar `_mensaje_suizo_canal` en la generación (`!suizo_generar_ronda`) y regeneración (`!suizo_regenerar_ronda`) de rondas para pasar la respuesta de `_es_mensaje_inicial_suizo(numero_ronda)`.
- Archivo modificado: `LombardBot.py`.

### Testing
- Ejecutado `python -m pytest -q` y la suite de tests automatizados relacionados con suizo pasó correctamente (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061bb448f0832ab1f5b9c3446dfd77)