### PR TITLE
Apply new Swiss tie-break order (Buchholz > Diff > H2H), update code, docs and tests

### DIFF
--- a/DOCUMENTACION_TORNEO_SUIZO.md
+++ b/DOCUMENTACION_TORNEO_SUIZO.md
@@ -180,3 +180,17 @@ En phpadmin Procedimientos-> GeneralTorneoSuizo Para panorámica general
 ---
 
 
+
+## 8) Orden de clasificación y desempates
+
+La clasificación suiza se ordena aplicando estos criterios, en este orden:
+
+1. Puntos totales, de mayor a menor.
+2. Buchholz Cut, de mayor a menor.
+3. Diferencia de score, de mayor a menor.
+4. H2H, de mayor a menor, solo cuando ambos jugadores comparados tienen un valor H2H aplicable.
+5. ID de usuario, de menor a mayor, como último criterio determinista.
+
+El H2H mantiene su cálculo actual: dentro de cada grupo empatado a puntos suma los puntos obtenidos por cada jugador en sus enfrentamientos contra otros integrantes de ese mismo grupo. Si un jugador no se enfrentó a nadie del grupo, su H2H no es aplicable (`None`) y se pasa directamente al ID después de haber comparado Buchholz Cut y diferencia de score.
+
+El mismo orden de criterios se utiliza como base al preparar los emparejamientos de la siguiente ronda. El último desempate de los emparejamientos continúa siendo aleatorio para no favorecer sistemáticamente a los ID más bajos.

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -5025,18 +5025,18 @@ async def suizo_consulta_desempates(interaction: discord.Interaction, torneo_id:
                 _nombre_usuario_suizo(por_id.get(uid)),
                 fila.get("estado_participante"),
                 fila.get("puntos"),
-                fila.get("h2h_valor") if fila.get("h2h_valor") is not None else "-",
                 fila.get("buchholz_cut"),
                 fila.get("diff_score"),
+                fila.get("h2h_valor") if fila.get("h2h_valor") is not None else "-",
             ])
 
-        tabla = _tabla_compacta(["#", "Jugador", "Estado", "PTS", "H2H", "BH", "DIF"], filas)
+        tabla = _tabla_compacta(["#", "Jugador", "Estado", "PTS", "BH", "DIF", "H2H"], filas)
         ronda_txt = ronda if ronda is not None else "actual"
         await _responder_interaction_bloque_codigo_largo(
             interaction,
             (
                 f"**Desempates** torneo `{torneo_id}` (ronda: {ronda_txt})\n"
-                "Orden: puntos > H2H (si aplica) > Buchholz Cut > diferencia de score."
+                "Orden: puntos > Buchholz Cut > diferencia de score > H2H (si aplica) > ID."
             ),
             tabla,
         )

--- a/SuizoCore.py
+++ b/SuizoCore.py
@@ -126,14 +126,6 @@ def ordenar_standings(standings: List[EstadoFila]) -> List[EstadoFila]:
         if puntos_a != puntos_b:
             return -1 if puntos_a > puntos_b else 1
 
-        h2h_a = fila_a.get("h2h_valor")
-        h2h_b = fila_b.get("h2h_valor")
-        if h2h_a is not None and h2h_b is not None:
-            h2h_a_dec = _decimal(h2h_a)
-            h2h_b_dec = _decimal(h2h_b)
-            if h2h_a_dec != h2h_b_dec:
-                return -1 if h2h_a_dec > h2h_b_dec else 1
-
         buchholz_a = _decimal(fila_a.get("buchholz_cut"))
         buchholz_b = _decimal(fila_b.get("buchholz_cut"))
         if buchholz_a != buchholz_b:
@@ -143,6 +135,14 @@ def ordenar_standings(standings: List[EstadoFila]) -> List[EstadoFila]:
         diff_b = int(fila_b.get("diff_score") or 0)
         if diff_a != diff_b:
             return -1 if diff_a > diff_b else 1
+
+        h2h_a = fila_a.get("h2h_valor")
+        h2h_b = fila_b.get("h2h_valor")
+        if h2h_a is not None and h2h_b is not None:
+            h2h_a_dec = _decimal(h2h_a)
+            h2h_b_dec = _decimal(h2h_b)
+            if h2h_a_dec != h2h_b_dec:
+                return -1 if h2h_a_dec > h2h_b_dec else 1
 
         usuario_a = int(fila_a.get("usuario_id"))
         usuario_b = int(fila_b.get("usuario_id"))
@@ -286,8 +286,8 @@ def _normalizar_json_detalle_tiebreak(fila: EstadoFila) -> Dict[str, Any]:
             "diff_score": int(fila.get("diff_score") or 0),
         },
         "explicacion": (
-            "Orden aplicado: puntos DESC, h2h DESC (si existe), "
-            "buchholz_cut DESC, diff_score DESC y usuario_id ASC."
+            "Orden aplicado: puntos DESC, buchholz_cut DESC, diff_score DESC, "
+            "h2h DESC (si existe para ambos jugadores) y usuario_id ASC."
         ),
     }
 
@@ -450,9 +450,9 @@ def generar_pairings_backtracking(session, torneo_id, ronda_numero, rng=None):
         activos,
         key=lambda fila: (
             -_decimal(fila.get("puntos")),
-            -_valor_h2h_para_pairing(fila),
             -_decimal(fila.get("buchholz_cut")),
             -int(fila.get("diff_score") or 0),
+            -_valor_h2h_para_pairing(fila),
             rng.random(),
         ),
     )

--- a/tests/test_suizo_core.py
+++ b/tests/test_suizo_core.py
@@ -24,6 +24,7 @@ from SuizoCore import (
     calcular_standings,
     generar_pairings_backtracking,
     obtener_raza_suizo_o_usuario,
+    ordenar_standings,
     procesar_cierre_ronda_si_corresponde,
 )
 
@@ -201,7 +202,7 @@ def test_bye_suma_puntos_y_no_pj():
     assert standings[1]["pj"] == 0
 
 
-def test_h2h_rompe_empate_por_encima_de_buchholz():
+def test_buchholz_rompe_empate_por_encima_de_h2h():
     session = _build_session()
     _crear_torneo_base(session, torneo_id=25)
     for uid in (1, 2, 3, 4):
@@ -237,7 +238,76 @@ def test_h2h_rompe_empate_por_encima_de_buchholz():
     assert fila_2["buchholz_cut"] > fila_1["buchholz_cut"]
     assert fila_1["h2h_valor"] == Decimal("3")
     assert fila_2["h2h_valor"] == Decimal("0")
-    assert fila_1["rank"] < fila_2["rank"]
+    assert fila_2["rank"] < fila_1["rank"]
+
+
+def test_diff_score_rompe_empate_por_encima_de_h2h():
+    standings = [
+        {
+            "usuario_id": 1,
+            "puntos": Decimal("6"),
+            "buchholz_cut": Decimal("9"),
+            "diff_score": 1,
+            "h2h_valor": Decimal("3"),
+        },
+        {
+            "usuario_id": 2,
+            "puntos": Decimal("6"),
+            "buchholz_cut": Decimal("9"),
+            "diff_score": 2,
+            "h2h_valor": Decimal("0"),
+        },
+    ]
+
+    ordenados = ordenar_standings(standings)
+
+    assert [fila["usuario_id"] for fila in ordenados] == [2, 1]
+
+
+def test_h2h_rompe_empate_despues_de_buchholz_y_diff_score():
+    standings = [
+        {
+            "usuario_id": 2,
+            "puntos": Decimal("6"),
+            "buchholz_cut": Decimal("9"),
+            "diff_score": 2,
+            "h2h_valor": Decimal("0"),
+        },
+        {
+            "usuario_id": 1,
+            "puntos": Decimal("6"),
+            "buchholz_cut": Decimal("9"),
+            "diff_score": 2,
+            "h2h_valor": Decimal("3"),
+        },
+    ]
+
+    ordenados = ordenar_standings(standings)
+
+    assert [fila["usuario_id"] for fila in ordenados] == [1, 2]
+
+
+def test_id_rompe_empate_cuando_h2h_no_es_aplicable():
+    standings = [
+        {
+            "usuario_id": 2,
+            "puntos": Decimal("6"),
+            "buchholz_cut": Decimal("9"),
+            "diff_score": 2,
+            "h2h_valor": None,
+        },
+        {
+            "usuario_id": 1,
+            "puntos": Decimal("6"),
+            "buchholz_cut": Decimal("9"),
+            "diff_score": 2,
+            "h2h_valor": Decimal("3"),
+        },
+    ]
+
+    ordenados = ordenar_standings(standings)
+
+    assert [fila["usuario_id"] for fila in ordenados] == [1, 2]
 
 
 def test_primera_ronda_desempata_emparejamientos_por_azar_no_por_id():


### PR DESCRIPTION
### Motivation

- Change the Swiss ranking and pairing logic so Buchholz Cut and score difference break ties before H2H, and use H2H only when applicable for both players, with user ID as final deterministic tie-breaker.
- Make presentation and pairing preparation consistent with the documented rules and avoid biasing by user ID when randomness is used for pairing tie-breaks.

### Description

- Reordered comparison in `ordenar_standings` to apply `puntos` then `buchholz_cut` then `diff_score` then `h2h_valor` (if applicable) and finally `usuario_id` for determinism. 
- Updated `_normalizar_json_detalle_tiebreak` to reflect the new explanation string and adjusted H2H handling semantics.
- Changed pairing preparation in `generar_pairings_backtracking` to sort by `puntos`, `buchholz_cut`, `diff_score`, then H2H-neutral value and randomness, so pairings follow the same tie-break priority.
- Updated the bot command `suizo_consulta_desempates` column order and explanatory text to match the new tie-break order, and added the new documentation section in `DOCUMENTACION_TORNEO_SUIZO.md` describing the ordering rules.
- Added and adjusted unit tests and imports in `tests/test_suizo_core.py` to cover Buchholz > Diff > H2H ordering, H2H applicability, and ID fallback.

### Testing

- Ran the Swiss core unit tests in `tests/test_suizo_core.py` including `test_buchholz_rompe_empate_por_encima_de_h2h`, `test_diff_score_rompe_empate_por_encima_de_h2h`, `test_h2h_rompe_empate_despues_de_buchholz_y_diff_score`, and `test_id_rompe_empate_cuando_h2h_no_es_aplicable`.
- Executed the updated test module with `pytest -q tests/test_suizo_core.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24001760ec832a8382126153b10ea0)