### PR TITLE
Centralizar constantes y validaciones del torneo de comunidades

### DIFF
--- a/ComunidadesConstantes.py
+++ b/ComunidadesConstantes.py
@@ -1,0 +1,201 @@
+"""Valores canónicos y validaciones puras del torneo de comunidades.
+
+Este módulo no depende de Discord, de la base de datos ni de ``LombardBot``.
+Los textos se comparan de forma exacta: no se corrigen mayúsculas, acentos,
+espacios ni errores ortográficos.
+"""
+
+from decimal import Decimal, InvalidOperation
+
+# Estados de torneo
+TORNEO_CREADO = "CREADO"
+TORNEO_EN_CURSO = "EN_CURSO"
+TORNEO_FINALIZADO = "FINALIZADO"
+ESTADOS_TORNEO = frozenset({
+    TORNEO_CREADO,
+    TORNEO_EN_CURSO,
+    TORNEO_FINALIZADO,
+})
+
+# Estados de ronda
+RONDA_ABIERTA = "ABIERTA"
+RONDA_BLOQUEADA = "BLOQUEADA"
+RONDA_CERRADA = "CERRADA"
+ESTADOS_RONDA = frozenset({
+    RONDA_ABIERTA,
+    RONDA_BLOQUEADA,
+    RONDA_CERRADA,
+})
+
+# Estados de enfrentamiento
+ENFRENTAMIENTO_PENDIENTE_ELECCIONES = "PENDIENTE_ELECCIONES"
+ENFRENTAMIENTO_PARTIDOS_CREADOS = "PARTIDOS_CREADOS"
+ENFRENTAMIENTO_EN_CURSO = "EN_CURSO"
+ENFRENTAMIENTO_CERRADO = "CERRADO"
+ENFRENTAMIENTO_ADMINISTRADO = "ADMINISTRADO"
+ESTADOS_ENFRENTAMIENTO = frozenset({
+    ENFRENTAMIENTO_PENDIENTE_ELECCIONES,
+    ENFRENTAMIENTO_PARTIDOS_CREADOS,
+    ENFRENTAMIENTO_EN_CURSO,
+    ENFRENTAMIENTO_CERRADO,
+    ENFRENTAMIENTO_ADMINISTRADO,
+})
+
+# Estados de partido individual
+PARTIDO_PENDIENTE = "PENDIENTE"
+PARTIDO_EN_CURSO = "EN_CURSO"
+PARTIDO_FINALIZADO = "FINALIZADO"
+PARTIDO_ADMINISTRADO = "ADMINISTRADO"
+ESTADOS_PARTIDO = frozenset({
+    PARTIDO_PENDIENTE,
+    PARTIDO_EN_CURSO,
+    PARTIDO_FINALIZADO,
+    PARTIDO_ADMINISTRADO,
+})
+
+# Estado temporal del equipo. La condición zombie es independiente y permanente.
+ESTADO_TEMPORAL_NEUTRO = "NEUTRO"
+ESTADO_TEMPORAL_CAZADOR = "CAZADOR"
+ESTADO_TEMPORAL_CAZADOR_Z = "CAZADOR_Z"
+ESTADO_TEMPORAL_HERIDO = "HERIDO"
+ESTADOS_TEMPORALES = frozenset({
+    ESTADO_TEMPORAL_NEUTRO,
+    ESTADO_TEMPORAL_CAZADOR,
+    ESTADO_TEMPORAL_CAZADOR_Z,
+    ESTADO_TEMPORAL_HERIDO,
+})
+
+# Orígenes de resultados
+RESULTADO_ORIGEN_API = "API"
+RESULTADO_ORIGEN_ADMIN = "ADMIN"
+ORIGENES_RESULTADO = frozenset({
+    RESULTADO_ORIGEN_API,
+    RESULTADO_ORIGEN_ADMIN,
+})
+
+# Tipos aceptados por el comando de administración de partidos.
+TIPO_ADMIN_FORFEIT_LOCAL = "forfeit_local"
+TIPO_ADMIN_FORFEIT_VISITANTE = "forfeit_visitante"
+TIPO_ADMIN_EMPATE = "empate_admin"
+TIPO_ADMIN_DOBLE_FORFEIT = "doble_forfeit"
+TIPO_ADMIN_MANUAL = "manual"
+TIPOS_ADMINISTRATIVOS = frozenset({
+    TIPO_ADMIN_FORFEIT_LOCAL,
+    TIPO_ADMIN_FORFEIT_VISITANTE,
+    TIPO_ADMIN_EMPATE,
+    TIPO_ADMIN_DOBLE_FORFEIT,
+    TIPO_ADMIN_MANUAL,
+})
+
+# Razas canónicas. El orden coincide con la especificación funcional.
+RAZAS = (
+    "Alianza V. Mundo",
+    "Amazonas",
+    "Caos Elegido",
+    "Elfos Oscuros",
+    "Elfos Silvanos",
+    "Enanos del Caos",
+    "Enanos",
+    "Hombres Lagarto",
+    "Horror Nigromantico",
+    "Humanos",
+    "Inframundo",
+    "Khorne",
+    "No muertos",
+    "Nobleza Imperial",
+    "Nordicos",
+    "Nurgle",
+    "Orcos negros",
+    "Orcos",
+    "Renegados",
+    "Skaven",
+    "Stunty",
+    "Union Elfica",
+    "Vampiros",
+)
+RAZAS_VALIDAS = frozenset(RAZAS)
+
+# El mapeo es deliberadamente explícito: la ruta física no se deduce ni admite aliases.
+ICONOS_POR_RAZA = {
+    "Alianza V. Mundo": "Iconos/Alianza V. Mundo.png",
+    "Amazonas": "Iconos/Amazonas.png",
+    "Caos Elegido": "Iconos/Caos Elegido.png",
+    "Elfos Oscuros": "Iconos/Elfos Oscuros.png",
+    "Elfos Silvanos": "Iconos/Elfos Silvanos.png",
+    "Enanos del Caos": "Iconos/Enanos del Caos.png",
+    "Enanos": "Iconos/Enanos.png",
+    "Hombres Lagarto": "Iconos/Hombres Lagarto.png",
+    "Horror Nigromantico": "Iconos/Horror Nigromantico.png",
+    "Humanos": "Iconos/Humanos.png",
+    "Inframundo": "Iconos/Inframundo.png",
+    "Khorne": "Iconos/Khorne.png",
+    "No muertos": "Iconos/No muertos.png",
+    "Nobleza Imperial": "Iconos/Nobleza Imperial.png",
+    "Nordicos": "Iconos/Nordicos.png",
+    "Nurgle": "Iconos/Nurgle.png",
+    "Orcos negros": "Iconos/Orcos negros.png",
+    "Orcos": "Iconos/Orcos.png",
+    "Renegados": "Iconos/Renegados.png",
+    "Skaven": "Iconos/Skaven.png",
+    "Stunty": "Iconos/Stunty.png",
+    "Union Elfica": "Iconos/Union Elfica.png",
+    "Vampiros": "Iconos/Vampiros.png",
+}
+
+# Textos de estado para presentaciones que no quieran depender de Discord.
+EMOJI_CAZADOR = "🏹"
+EMOJI_HERIDO = "🩸"
+EMOJI_ZOMBIE = "🧟"
+EMOJI_CAZADOR_Z = f"{EMOJI_CAZADOR}{EMOJI_ZOMBIE}"
+EMOJIS_ESTADO_TEMPORAL = {
+    ESTADO_TEMPORAL_NEUTRO: "",
+    ESTADO_TEMPORAL_CAZADOR: EMOJI_CAZADOR,
+    ESTADO_TEMPORAL_CAZADOR_Z: EMOJI_CAZADOR_Z,
+    ESTADO_TEMPORAL_HERIDO: EMOJI_HERIDO,
+}
+
+LIMITE_CANALES_POR_CATEGORIA = 40
+
+
+def validar_raza(raza):
+    """Indica si ``raza`` coincide exactamente con un nombre canónico."""
+    return isinstance(raza, str) and raza in RAZAS_VALIDAS
+
+
+def validar_puntuacion(valor):
+    """Valida una puntuación no negativa, finita y con hasta dos decimales.
+
+    Se aceptan números y textos decimales sin espacios exteriores. Los booleanos,
+    la notación no finita y los valores que no caben en ``DECIMAL(6, 2)`` se
+    rechazan para mantener la misma restricción que la configuración persistida.
+    """
+    if isinstance(valor, bool) or valor is None:
+        return False
+    if isinstance(valor, str) and (not valor or valor != valor.strip()):
+        return False
+
+    try:
+        puntuacion = Decimal(str(valor))
+    except (InvalidOperation, ValueError, TypeError):
+        return False
+
+    if not puntuacion.is_finite() or puntuacion < 0 or puntuacion > Decimal("9999.99"):
+        return False
+    return puntuacion.as_tuple().exponent >= -2
+
+
+def validar_estado_temporal(estado_temporal):
+    """Indica si el estado temporal es uno de los cuatro valores canónicos."""
+    return isinstance(estado_temporal, str) and estado_temporal in ESTADOS_TEMPORALES
+
+
+def validar_combinacion_estados(*, herido=False, cazador=False, cazador_z=False, zombie=False):
+    """Valida los indicadores conceptuales de estado de un equipo.
+
+    ``zombie`` puede convivir con cualquier estado temporal. Entre ``herido``,
+    ``cazador`` y ``cazador_z`` solo puede haber como máximo uno activo.
+    """
+    indicadores = (herido, cazador, cazador_z, zombie)
+    if any(type(indicador) is not bool for indicador in indicadores):
+        return False
+    return sum((herido, cazador, cazador_z)) <= 1

--- a/tests/test_comunidades_constantes.py
+++ b/tests/test_comunidades_constantes.py
@@ -1,0 +1,177 @@
+from decimal import Decimal
+from itertools import product
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ComunidadesConstantes import (
+    EMOJI_CAZADOR,
+    EMOJI_CAZADOR_Z,
+    EMOJI_HERIDO,
+    EMOJI_ZOMBIE,
+    ESTADOS_ENFRENTAMIENTO,
+    ESTADOS_PARTIDO,
+    ESTADOS_RONDA,
+    ESTADOS_TEMPORALES,
+    ESTADOS_TORNEO,
+    ICONOS_POR_RAZA,
+    LIMITE_CANALES_POR_CATEGORIA,
+    ORIGENES_RESULTADO,
+    RAZAS,
+    RAZAS_VALIDAS,
+    TIPOS_ADMINISTRATIVOS,
+    validar_combinacion_estados,
+    validar_estado_temporal,
+    validar_puntuacion,
+    validar_raza,
+)
+
+
+RAZAS_ESPERADAS = (
+    "Alianza V. Mundo",
+    "Amazonas",
+    "Caos Elegido",
+    "Elfos Oscuros",
+    "Elfos Silvanos",
+    "Enanos del Caos",
+    "Enanos",
+    "Hombres Lagarto",
+    "Horror Nigromantico",
+    "Humanos",
+    "Inframundo",
+    "Khorne",
+    "No muertos",
+    "Nobleza Imperial",
+    "Nordicos",
+    "Nurgle",
+    "Orcos negros",
+    "Orcos",
+    "Renegados",
+    "Skaven",
+    "Stunty",
+    "Union Elfica",
+    "Vampiros",
+)
+
+
+@pytest.mark.parametrize("raza", RAZAS_ESPERADAS)
+def test_acepta_cada_raza_canónica(raza):
+    assert validar_raza(raza)
+
+
+def test_lista_exacta_de_23_razas_y_mapa_de_iconos():
+    assert RAZAS == RAZAS_ESPERADAS
+    assert RAZAS_VALIDAS == frozenset(RAZAS_ESPERADAS)
+    assert len(RAZAS) == len(RAZAS_VALIDAS) == 23
+    assert ICONOS_POR_RAZA == {
+        raza: f"Iconos/{raza}.png"
+        for raza in RAZAS_ESPERADAS
+    }
+    raiz_repositorio = Path(__file__).resolve().parents[1]
+    assert all((raiz_repositorio / ruta).is_file() for ruta in ICONOS_POR_RAZA.values())
+
+
+@pytest.mark.parametrize(
+    "raza",
+    [
+        "Unión Élfica",
+        "Khornne",
+        "Khorne ",
+        "khorne",
+        "Nórdicos",
+        "Horror Nigromántico",
+        "Elfo Osucros",
+        "Elfos oscuros",
+        "",
+        None,
+    ],
+)
+def test_rechaza_aliases_acentos_mayúsculas_espacios_y_erratas(raza):
+    assert not validar_raza(raza)
+
+
+def test_valores_canónicos_de_estados_orígenes_y_tipos_administrativos():
+    assert ESTADOS_TORNEO == {"CREADO", "EN_CURSO", "FINALIZADO"}
+    assert ESTADOS_RONDA == {"ABIERTA", "BLOQUEADA", "CERRADA"}
+    assert ESTADOS_ENFRENTAMIENTO == {
+        "PENDIENTE_ELECCIONES",
+        "PARTIDOS_CREADOS",
+        "EN_CURSO",
+        "CERRADO",
+        "ADMINISTRADO",
+    }
+    assert ESTADOS_PARTIDO == {"PENDIENTE", "EN_CURSO", "FINALIZADO", "ADMINISTRADO"}
+    assert ESTADOS_TEMPORALES == {"NEUTRO", "CAZADOR", "CAZADOR_Z", "HERIDO"}
+    assert ORIGENES_RESULTADO == {"API", "ADMIN"}
+    assert TIPOS_ADMINISTRATIVOS == {
+        "forfeit_local",
+        "forfeit_visitante",
+        "empate_admin",
+        "doble_forfeit",
+        "manual",
+    }
+
+
+@pytest.mark.parametrize("estado", ["NEUTRO", "CAZADOR", "CAZADOR_Z", "HERIDO"])
+def test_valida_estados_temporales_exactos(estado):
+    assert validar_estado_temporal(estado)
+
+
+@pytest.mark.parametrize("estado", ["cazador", "CAZADOR Z", "HERÍDO", "", None])
+def test_rechaza_variantes_de_estado_temporal(estado):
+    assert not validar_estado_temporal(estado)
+
+
+@pytest.mark.parametrize("herido,cazador,cazador_z,zombie", product((False, True), repeat=4))
+def test_valida_todas_las_combinaciones_de_estado(herido, cazador, cazador_z, zombie):
+    esperado = sum((herido, cazador, cazador_z)) <= 1
+    assert validar_combinacion_estados(
+        herido=herido,
+        cazador=cazador,
+        cazador_z=cazador_z,
+        zombie=zombie,
+    ) is esperado
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"herido": True, "cazador": True},
+        {"herido": True, "cazador_z": True},
+        {"cazador": True, "cazador_z": True},
+        {"herido": True, "cazador": True, "cazador_z": True, "zombie": True},
+    ],
+)
+def test_rechaza_combinaciones_temporales_incompatibles(kwargs):
+    assert not validar_combinacion_estados(**kwargs)
+
+
+def test_zombie_puede_coexistir_con_cualquier_estado_temporal_individual():
+    assert validar_combinacion_estados(zombie=True)
+    assert validar_combinacion_estados(zombie=True, herido=True)
+    assert validar_combinacion_estados(zombie=True, cazador=True)
+    assert validar_combinacion_estados(zombie=True, cazador_z=True)
+
+
+@pytest.mark.parametrize("valor", [0, 3, 1.5, "1.50", Decimal("9999.99")])
+def test_acepta_puntuaciones_validas(valor):
+    assert validar_puntuacion(valor)
+
+
+@pytest.mark.parametrize(
+    "valor",
+    [-1, "-0.01", "1.001", " 1", "1 ", "", "NaN", "Infinity", 10000, True, None, object()],
+)
+def test_rechaza_puntuaciones_invalidas(valor):
+    assert not validar_puntuacion(valor)
+
+
+def test_emojis_y_limite_de_canales():
+    assert EMOJI_CAZADOR == "🏹"
+    assert EMOJI_HERIDO == "🩸"
+    assert EMOJI_ZOMBIE == "🧟"
+    assert EMOJI_CAZADOR_Z == "🏹🧟"
+    assert LIMITE_CANALES_POR_CATEGORIA == 40


### PR DESCRIPTION
### Motivation

- Centralizar en un módulo independiente los nombres canónicos y validaciones puras que compartirán dominio, comandos y tests para el formato de torneo de comunidades según la especificación DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES.
- Evitar acoplamientos a Discord, a la base de datos o a `LombardBot.py` y garantizar validaciones exactas sin normalización automática de acentos, mayúsculas o errores ortográficos.

### Description

- Añadido `ComunidadesConstantes.py` que expone estados de torneo, ronda, enfrentamiento y partido, estados temporales, orígenes de resultado, tipos administrativos, emojis y el límite de 40 canales por categoría.
- Definida la lista exacta de 23 razas canónicas y un mapa explícito de cada raza a su icono aprobado en `Iconos/...` (sin aceptar aliases ni variantes con errores).
- Implementados validadores puros y sin efectos colaterales: `validar_raza`, `validar_puntuacion`, `validar_estado_temporal` y `validar_combinacion_estados` con la regla que permite coexistencia de `zombie` pero prohíbe más de un estado temporal entre `herido`, `cazador` y `cazador_z`.
- Añadidos tests parametrizados en `tests/test_comunidades_constantes.py` que cubren las 23 razas, casos negativos, validación de iconos, puntuaciones y todas las combinaciones de indicadores de estado.

### Testing

- Ejecutado `python -m pytest -q tests/test_comunidades_constantes.py` y todos los tests del nuevo módulo pasaron (83 passed).
- Ejecutada la suite completa con `python -m pytest -q` y pasó sin introducir regresiones (114 passed; aparecen 70 warnings deprecados preexistentes en el repositorio).
- Verificado que los módulos compilan (`compileall`) y que las rutas de iconos declaradas existen mediante los tests añadidos, sin errores detectados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24738965c0832a861623f2ac0c3201)