### PR TITLE
Implementar la máquina exhaustiva de estados de comunidades

### DIFF
--- a/ComunidadesCore.py
+++ b/ComunidadesCore.py
@@ -10,6 +10,13 @@ from decimal import Decimal, InvalidOperation
 from enum import Enum
 from typing import Iterable
 
+from ComunidadesConstantes import (
+    ESTADO_TEMPORAL_CAZADOR,
+    ESTADO_TEMPORAL_CAZADOR_Z,
+    ESTADO_TEMPORAL_HERIDO,
+    ESTADO_TEMPORAL_NEUTRO,
+)
+
 
 class Equipo(str, Enum):
     """Lado de un equipo dentro de un enfrentamiento."""
@@ -24,6 +31,89 @@ class ResultadoGlobal(str, Enum):
     VICTORIA_A = "VICTORIA_A"
     VICTORIA_B = "VICTORIA_B"
     EMPATE = "EMPATE"
+
+
+class EstadoTemporal(str, Enum):
+    """Estado temporal canónico fotografiado para un equipo."""
+
+    NEUTRO = ESTADO_TEMPORAL_NEUTRO
+    CAZADOR = ESTADO_TEMPORAL_CAZADOR
+    CAZADOR_Z = ESTADO_TEMPORAL_CAZADOR_Z
+    HERIDO = ESTADO_TEMPORAL_HERIDO
+
+
+class MotivoTransicion(str, Enum):
+    """Motivo persistible que explica la transición de un equipo."""
+
+    VICTORIA = "VICTORIA"
+    DERROTA = "DERROTA"
+    EMPATE = "EMPATE"
+    ZOMBIFICACION = "ZOMBIFICACION"
+    KILL = "KILL"
+    DOBLE_FORFAIT = "DOBLE_FORFAIT"
+
+
+@dataclass(frozen=True)
+class EstadoFotografiado:
+    """Estado inmutable de un equipo al generarse la ronda."""
+
+    estado_temporal: EstadoTemporal
+    es_zombie: bool
+
+    def __post_init__(self) -> None:
+        try:
+            estado = EstadoTemporal(self.estado_temporal)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("estado temporal fotografiado desconocido") from exc
+        if type(self.es_zombie) is not bool:
+            raise TypeError("es_zombie debe ser booleano")
+        object.__setattr__(self, "estado_temporal", estado)
+
+
+@dataclass(frozen=True)
+class EfectoComunitario:
+    """Efecto especial concedido al equipo y comunidad vencedores."""
+
+    equipo: Equipo
+    comunidad: object
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "equipo", Equipo(self.equipo))
+        if self.comunidad is None:
+            raise ValueError("la comunidad beneficiaria no puede ser None")
+
+
+@dataclass(frozen=True)
+class TransicionEstados:
+    """Resultado completo de aplicar la máquina de estados a un cruce."""
+
+    estado_final_a: EstadoFotografiado
+    estado_final_b: EstadoFotografiado
+    cambio_zombie_a: bool
+    cambio_zombie_b: bool
+    punto_zombificacion: EfectoComunitario | None
+    kill: EfectoComunitario | None
+    motivo_a: MotivoTransicion
+    motivo_b: MotivoTransicion
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.estado_final_a, EstadoFotografiado):
+            raise TypeError("estado_final_a debe ser EstadoFotografiado")
+        if not isinstance(self.estado_final_b, EstadoFotografiado):
+            raise TypeError("estado_final_b debe ser EstadoFotografiado")
+        if (
+            type(self.cambio_zombie_a) is not bool
+            or type(self.cambio_zombie_b) is not bool
+        ):
+            raise TypeError("los cambios zombie deben ser booleanos")
+        if self.punto_zombificacion is not None and not isinstance(
+            self.punto_zombificacion, EfectoComunitario
+        ):
+            raise TypeError("punto_zombificacion debe ser EfectoComunitario o None")
+        if self.kill is not None and not isinstance(self.kill, EfectoComunitario):
+            raise TypeError("kill debe ser EfectoComunitario o None")
+        object.__setattr__(self, "motivo_a", MotivoTransicion(self.motivo_a))
+        object.__setattr__(self, "motivo_b", MotivoTransicion(self.motivo_b))
 
 
 class CriterioDesempate(str, Enum):
@@ -330,3 +420,229 @@ def calcular_resultado_enfrentamiento(
         puntos_clasificacion_a=clasificacion_a,
         puntos_clasificacion_b=clasificacion_b,
     )
+
+
+def resolver_transicion_estados(
+    estado_inicial_a: EstadoFotografiado,
+    estado_inicial_b: EstadoFotografiado,
+    resultado_global: ResultadoGlobal,
+    doble_forfait: bool,
+    comunidad_a: object,
+    comunidad_b: object,
+) -> TransicionEstados:
+    """Resuelve exhaustivamente la sección 12 desde la fotografía inicial.
+
+    La función no consulta estados vivos: tanto las transiciones ordinarias como
+    los efectos especiales se calculan exclusivamente con los dos estados
+    fotografiados recibidos.
+    """
+    _validar_entrada_transicion(
+        estado_inicial_a,
+        estado_inicial_b,
+        resultado_global,
+        doble_forfait,
+        comunidad_a,
+        comunidad_b,
+    )
+    resultado = ResultadoGlobal(resultado_global)
+
+    if doble_forfait:
+        transicion = TransicionEstados(
+            estado_final_a=estado_inicial_a,
+            estado_final_b=estado_inicial_b,
+            cambio_zombie_a=False,
+            cambio_zombie_b=False,
+            punto_zombificacion=None,
+            kill=None,
+            motivo_a=MotivoTransicion.DOBLE_FORFAIT,
+            motivo_b=MotivoTransicion.DOBLE_FORFAIT,
+        )
+    elif resultado is ResultadoGlobal.EMPATE:
+        transicion = TransicionEstados(
+            estado_final_a=EstadoFotografiado(
+                EstadoTemporal.NEUTRO, estado_inicial_a.es_zombie
+            ),
+            estado_final_b=EstadoFotografiado(
+                EstadoTemporal.NEUTRO, estado_inicial_b.es_zombie
+            ),
+            cambio_zombie_a=False,
+            cambio_zombie_b=False,
+            punto_zombificacion=None,
+            kill=None,
+            motivo_a=MotivoTransicion.EMPATE,
+            motivo_b=MotivoTransicion.EMPATE,
+        )
+    else:
+        ganador = Equipo.A if resultado is ResultadoGlobal.VICTORIA_A else Equipo.B
+        if ganador is Equipo.A:
+            transicion = _resolver_victoria(
+                ganador=Equipo.A,
+                estado_ganador=estado_inicial_a,
+                estado_perdedor=estado_inicial_b,
+                comunidad_ganador=comunidad_a,
+            )
+        else:
+            invertida = _resolver_victoria(
+                ganador=Equipo.B,
+                estado_ganador=estado_inicial_b,
+                estado_perdedor=estado_inicial_a,
+                comunidad_ganador=comunidad_b,
+            )
+            transicion = TransicionEstados(
+                estado_final_a=invertida.estado_final_b,
+                estado_final_b=invertida.estado_final_a,
+                cambio_zombie_a=invertida.cambio_zombie_b,
+                cambio_zombie_b=invertida.cambio_zombie_a,
+                punto_zombificacion=invertida.punto_zombificacion,
+                kill=invertida.kill,
+                motivo_a=invertida.motivo_b,
+                motivo_b=invertida.motivo_a,
+            )
+
+    _validar_salida_transicion(
+        estado_inicial_a,
+        estado_inicial_b,
+        resultado,
+        doble_forfait,
+        comunidad_a,
+        comunidad_b,
+        transicion,
+    )
+    return transicion
+
+
+def _resolver_victoria(
+    *,
+    ganador: Equipo,
+    estado_ganador: EstadoFotografiado,
+    estado_perdedor: EstadoFotografiado,
+    comunidad_ganador: object,
+) -> TransicionEstados:
+    """Resuelve una victoria colocando al ganador en la primera posición."""
+    punto = None
+    kill = None
+    motivo_ganador = MotivoTransicion.VICTORIA
+    motivo_perdedor = MotivoTransicion.DERROTA
+
+    if estado_perdedor.estado_temporal is EstadoTemporal.HERIDO:
+        estado_final_ganador = EstadoFotografiado(
+            EstadoTemporal.NEUTRO, estado_ganador.es_zombie
+        )
+        estado_final_perdedor = EstadoFotografiado(EstadoTemporal.NEUTRO, True)
+        cambio_zombie_perdedor = not estado_perdedor.es_zombie
+
+        if not estado_perdedor.es_zombie:
+            motivo_perdedor = MotivoTransicion.ZOMBIFICACION
+            if estado_ganador.estado_temporal is EstadoTemporal.CAZADOR:
+                punto = EfectoComunitario(ganador, comunidad_ganador)
+        elif estado_ganador.estado_temporal is EstadoTemporal.CAZADOR_Z:
+            motivo_ganador = MotivoTransicion.KILL
+            kill = EfectoComunitario(ganador, comunidad_ganador)
+    else:
+        estado_final_ganador = EstadoFotografiado(
+            (
+                EstadoTemporal.CAZADOR_Z
+                if estado_perdedor.es_zombie
+                else EstadoTemporal.CAZADOR
+            ),
+            estado_ganador.es_zombie,
+        )
+        estado_final_perdedor = EstadoFotografiado(
+            EstadoTemporal.HERIDO, estado_perdedor.es_zombie
+        )
+        cambio_zombie_perdedor = False
+
+    return TransicionEstados(
+        estado_final_a=estado_final_ganador,
+        estado_final_b=estado_final_perdedor,
+        cambio_zombie_a=False,
+        cambio_zombie_b=cambio_zombie_perdedor,
+        punto_zombificacion=punto,
+        kill=kill,
+        motivo_a=motivo_ganador,
+        motivo_b=motivo_perdedor,
+    )
+
+
+def _validar_entrada_transicion(
+    estado_a: object,
+    estado_b: object,
+    resultado: object,
+    doble_forfait: object,
+    comunidad_a: object,
+    comunidad_b: object,
+) -> None:
+    if not isinstance(estado_a, EstadoFotografiado) or not isinstance(
+        estado_b, EstadoFotografiado
+    ):
+        raise TypeError("los estados iniciales deben ser EstadoFotografiado")
+    try:
+        resultado = ResultadoGlobal(resultado)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("resultado global desconocido") from exc
+    if type(doble_forfait) is not bool:
+        raise TypeError("doble_forfait debe ser booleano")
+    if doble_forfait and resultado is not ResultadoGlobal.EMPATE:
+        raise ValueError("un doble forfait global debe tener resultado EMPATE")
+    if comunidad_a is None or comunidad_b is None:
+        raise ValueError("ambas comunidades son obligatorias")
+    if comunidad_a == comunidad_b:
+        raise ValueError(
+            "los equipos enfrentados deben pertenecer a comunidades distintas"
+        )
+
+
+def _validar_salida_transicion(
+    estado_inicial_a: EstadoFotografiado,
+    estado_inicial_b: EstadoFotografiado,
+    resultado: ResultadoGlobal,
+    doble_forfait: bool,
+    comunidad_a: object,
+    comunidad_b: object,
+    transicion: TransicionEstados,
+) -> None:
+    for inicial, final, cambio in (
+        (estado_inicial_a, transicion.estado_final_a, transicion.cambio_zombie_a),
+        (estado_inicial_b, transicion.estado_final_b, transicion.cambio_zombie_b),
+    ):
+        if inicial.es_zombie and not final.es_zombie:
+            raise AssertionError("la condición zombie no puede desaparecer")
+        if cambio != (not inicial.es_zombie and final.es_zombie):
+            raise AssertionError(
+                "el indicador de cambio zombie no coincide con los estados"
+            )
+
+    if transicion.punto_zombificacion and transicion.kill:
+        raise AssertionError("una transición no puede conceder punto y kill a la vez")
+
+    if doble_forfait or resultado is ResultadoGlobal.EMPATE:
+        if transicion.punto_zombificacion or transicion.kill:
+            raise AssertionError("un empate no puede generar efectos comunitarios")
+        return
+
+    if resultado is ResultadoGlobal.VICTORIA_A:
+        ganador = estado_inicial_a
+        perdedor = estado_inicial_b
+        equipo_ganador = Equipo.A
+        comunidad_ganador = comunidad_a
+    else:
+        ganador = estado_inicial_b
+        perdedor = estado_inicial_a
+        equipo_ganador = Equipo.B
+        comunidad_ganador = comunidad_b
+
+    punto_esperado = (
+        ganador.estado_temporal is EstadoTemporal.CAZADOR
+        and perdedor.estado_temporal is EstadoTemporal.HERIDO
+        and not perdedor.es_zombie
+    )
+    kill_esperada = (
+        ganador.estado_temporal is EstadoTemporal.CAZADOR_Z
+        and perdedor.estado_temporal is EstadoTemporal.HERIDO
+        and perdedor.es_zombie
+    )
+    efecto_esperado = EfectoComunitario(equipo_ganador, comunidad_ganador)
+    if (transicion.punto_zombificacion == efecto_esperado) != punto_esperado:
+        raise AssertionError("el punto de zombificación no coincide con la fotografía")
+    if (transicion.kill == efecto_esperado) != kill_esperada:
+        raise AssertionError("la kill no coincide con la fotografía")

--- a/tests/test_comunidades_estados.py
+++ b/tests/test_comunidades_estados.py
@@ -1,0 +1,465 @@
+from itertools import product
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ComunidadesCore import (
+    EfectoComunitario,
+    Equipo,
+    EstadoFotografiado,
+    EstadoTemporal,
+    MotivoTransicion,
+    ResultadoGlobal,
+    resolver_transicion_estados,
+)
+
+COMUNIDAD_A = "Butter"
+COMUNIDAD_B = "Hispana"
+
+
+def estado(temporal, zombie=False):
+    return EstadoFotografiado(temporal, zombie)
+
+
+@pytest.mark.parametrize(
+    (
+        "caso",
+        "inicial_a",
+        "inicial_b",
+        "resultado",
+        "final_a",
+        "final_b",
+        "punto",
+        "kill",
+        "motivos",
+    ),
+    [
+        (
+            "12.2 victoria contra normal",
+            estado(EstadoTemporal.NEUTRO),
+            estado(EstadoTemporal.NEUTRO),
+            ResultadoGlobal.VICTORIA_A,
+            estado(EstadoTemporal.CAZADOR),
+            estado(EstadoTemporal.HERIDO),
+            None,
+            None,
+            (MotivoTransicion.VICTORIA, MotivoTransicion.DERROTA),
+        ),
+        (
+            "12.2 cazador renovado",
+            estado(EstadoTemporal.CAZADOR),
+            estado(EstadoTemporal.CAZADOR_Z),
+            ResultadoGlobal.VICTORIA_A,
+            estado(EstadoTemporal.CAZADOR),
+            estado(EstadoTemporal.HERIDO),
+            None,
+            None,
+            (MotivoTransicion.VICTORIA, MotivoTransicion.DERROTA),
+        ),
+        (
+            "12.7 victoria contra zombie sano",
+            estado(EstadoTemporal.NEUTRO),
+            estado(EstadoTemporal.CAZADOR, True),
+            ResultadoGlobal.VICTORIA_A,
+            estado(EstadoTemporal.CAZADOR_Z),
+            estado(EstadoTemporal.HERIDO, True),
+            None,
+            None,
+            (MotivoTransicion.VICTORIA, MotivoTransicion.DERROTA),
+        ),
+        (
+            "12.7 cazador Z renovado",
+            estado(EstadoTemporal.CAZADOR_Z),
+            estado(EstadoTemporal.NEUTRO, True),
+            ResultadoGlobal.VICTORIA_A,
+            estado(EstadoTemporal.CAZADOR_Z),
+            estado(EstadoTemporal.HERIDO, True),
+            None,
+            None,
+            (MotivoTransicion.VICTORIA, MotivoTransicion.DERROTA),
+        ),
+        (
+            "12.4 cazador inicial zombifica y puntua",
+            estado(EstadoTemporal.CAZADOR),
+            estado(EstadoTemporal.HERIDO),
+            ResultadoGlobal.VICTORIA_A,
+            estado(EstadoTemporal.NEUTRO),
+            estado(EstadoTemporal.NEUTRO, True),
+            EfectoComunitario(Equipo.A, COMUNIDAD_A),
+            None,
+            (MotivoTransicion.VICTORIA, MotivoTransicion.ZOMBIFICACION),
+        ),
+        (
+            "12.4 neutro zombifica sin punto",
+            estado(EstadoTemporal.NEUTRO),
+            estado(EstadoTemporal.HERIDO),
+            ResultadoGlobal.VICTORIA_A,
+            estado(EstadoTemporal.NEUTRO),
+            estado(EstadoTemporal.NEUTRO, True),
+            None,
+            None,
+            (MotivoTransicion.VICTORIA, MotivoTransicion.ZOMBIFICACION),
+        ),
+        (
+            "12.4 cazador Z zombifica sin punto",
+            estado(EstadoTemporal.CAZADOR_Z),
+            estado(EstadoTemporal.HERIDO),
+            ResultadoGlobal.VICTORIA_A,
+            estado(EstadoTemporal.NEUTRO),
+            estado(EstadoTemporal.NEUTRO, True),
+            None,
+            None,
+            (MotivoTransicion.VICTORIA, MotivoTransicion.ZOMBIFICACION),
+        ),
+        (
+            "12.5 cazador Z mata zombie herido",
+            estado(EstadoTemporal.CAZADOR_Z),
+            estado(EstadoTemporal.HERIDO, True),
+            ResultadoGlobal.VICTORIA_A,
+            estado(EstadoTemporal.NEUTRO),
+            estado(EstadoTemporal.NEUTRO, True),
+            None,
+            EfectoComunitario(Equipo.A, COMUNIDAD_A),
+            (MotivoTransicion.KILL, MotivoTransicion.DERROTA),
+        ),
+        (
+            "12.6 cazador normal no mata zombie herido",
+            estado(EstadoTemporal.CAZADOR),
+            estado(EstadoTemporal.HERIDO, True),
+            ResultadoGlobal.VICTORIA_A,
+            estado(EstadoTemporal.NEUTRO),
+            estado(EstadoTemporal.NEUTRO, True),
+            None,
+            None,
+            (MotivoTransicion.VICTORIA, MotivoTransicion.DERROTA),
+        ),
+        (
+            "12.8 zombie herido gana a no zombie",
+            estado(EstadoTemporal.HERIDO, True),
+            estado(EstadoTemporal.NEUTRO),
+            ResultadoGlobal.VICTORIA_A,
+            estado(EstadoTemporal.CAZADOR, True),
+            estado(EstadoTemporal.HERIDO),
+            None,
+            None,
+            (MotivoTransicion.VICTORIA, MotivoTransicion.DERROTA),
+        ),
+        (
+            "12.8 zombie herido gana a zombie",
+            estado(EstadoTemporal.HERIDO, True),
+            estado(EstadoTemporal.NEUTRO, True),
+            ResultadoGlobal.VICTORIA_A,
+            estado(EstadoTemporal.CAZADOR_Z, True),
+            estado(EstadoTemporal.HERIDO, True),
+            None,
+            None,
+            (MotivoTransicion.VICTORIA, MotivoTransicion.DERROTA),
+        ),
+    ],
+)
+def test_tabla_de_transiciones_documentadas(
+    caso,
+    inicial_a,
+    inicial_b,
+    resultado,
+    final_a,
+    final_b,
+    punto,
+    kill,
+    motivos,
+):
+    transicion = resolver_transicion_estados(
+        inicial_a, inicial_b, resultado, False, COMUNIDAD_A, COMUNIDAD_B
+    )
+
+    assert transicion.estado_final_a == final_a, caso
+    assert transicion.estado_final_b == final_b, caso
+    assert transicion.punto_zombificacion == punto, caso
+    assert transicion.kill == kill, caso
+    assert (transicion.motivo_a, transicion.motivo_b) == motivos, caso
+    assert transicion.cambio_zombie_a == (not inicial_a.es_zombie and final_a.es_zombie)
+    assert transicion.cambio_zombie_b == (not inicial_b.es_zombie and final_b.es_zombie)
+
+
+@pytest.mark.parametrize(
+    "inicial_a,inicial_b",
+    [
+        (estado(EstadoTemporal.CAZADOR), estado(EstadoTemporal.HERIDO)),
+        (estado(EstadoTemporal.HERIDO, True), estado(EstadoTemporal.CAZADOR_Z, True)),
+        (estado(EstadoTemporal.CAZADOR_Z), estado(EstadoTemporal.NEUTRO, True)),
+    ],
+)
+def test_empate_limpia_estados_temporales_y_conserva_zombies(inicial_a, inicial_b):
+    transicion = resolver_transicion_estados(
+        inicial_a,
+        inicial_b,
+        ResultadoGlobal.EMPATE,
+        False,
+        COMUNIDAD_A,
+        COMUNIDAD_B,
+    )
+
+    assert transicion.estado_final_a == estado(
+        EstadoTemporal.NEUTRO, inicial_a.es_zombie
+    )
+    assert transicion.estado_final_b == estado(
+        EstadoTemporal.NEUTRO, inicial_b.es_zombie
+    )
+    assert transicion.punto_zombificacion is None
+    assert transicion.kill is None
+    assert transicion.motivo_a is MotivoTransicion.EMPATE
+    assert transicion.motivo_b is MotivoTransicion.EMPATE
+
+
+def test_doble_forfait_global_no_cambia_estados_ni_genera_efectos():
+    inicial_a = estado(EstadoTemporal.HERIDO)
+    inicial_b = estado(EstadoTemporal.CAZADOR_Z, True)
+
+    transicion = resolver_transicion_estados(
+        inicial_a,
+        inicial_b,
+        ResultadoGlobal.EMPATE,
+        True,
+        COMUNIDAD_A,
+        COMUNIDAD_B,
+    )
+
+    assert transicion.estado_final_a is inicial_a
+    assert transicion.estado_final_b is inicial_b
+    assert not transicion.cambio_zombie_a
+    assert not transicion.cambio_zombie_b
+    assert transicion.punto_zombificacion is None
+    assert transicion.kill is None
+    assert transicion.motivo_a is MotivoTransicion.DOBLE_FORFAIT
+    assert transicion.motivo_b is MotivoTransicion.DOBLE_FORFAIT
+
+
+def _intercambiar_equipo(efecto):
+    if efecto is None:
+        return None
+    return EfectoComunitario(
+        Equipo.B if efecto.equipo is Equipo.A else Equipo.A,
+        efecto.comunidad,
+    )
+
+
+@pytest.mark.parametrize(
+    "inicial_a,inicial_b,resultado",
+    [
+        (
+            estado(EstadoTemporal.CAZADOR),
+            estado(EstadoTemporal.HERIDO),
+            ResultadoGlobal.VICTORIA_A,
+        ),
+        (
+            estado(EstadoTemporal.CAZADOR_Z),
+            estado(EstadoTemporal.HERIDO, True),
+            ResultadoGlobal.VICTORIA_A,
+        ),
+        (
+            estado(EstadoTemporal.HERIDO, True),
+            estado(EstadoTemporal.NEUTRO),
+            ResultadoGlobal.VICTORIA_B,
+        ),
+        (
+            estado(EstadoTemporal.CAZADOR),
+            estado(EstadoTemporal.CAZADOR_Z, True),
+            ResultadoGlobal.EMPATE,
+        ),
+    ],
+)
+def test_simetria_entre_lados_a_y_b(inicial_a, inicial_b, resultado):
+    original = resolver_transicion_estados(
+        inicial_a, inicial_b, resultado, False, COMUNIDAD_A, COMUNIDAD_B
+    )
+    resultado_invertido = {
+        ResultadoGlobal.VICTORIA_A: ResultadoGlobal.VICTORIA_B,
+        ResultadoGlobal.VICTORIA_B: ResultadoGlobal.VICTORIA_A,
+        ResultadoGlobal.EMPATE: ResultadoGlobal.EMPATE,
+    }[resultado]
+    invertida = resolver_transicion_estados(
+        inicial_b,
+        inicial_a,
+        resultado_invertido,
+        False,
+        COMUNIDAD_B,
+        COMUNIDAD_A,
+    )
+
+    assert invertida.estado_final_a == original.estado_final_b
+    assert invertida.estado_final_b == original.estado_final_a
+    assert invertida.cambio_zombie_a == original.cambio_zombie_b
+    assert invertida.cambio_zombie_b == original.cambio_zombie_a
+    assert invertida.punto_zombificacion == _intercambiar_equipo(
+        original.punto_zombificacion
+    )
+    assert invertida.kill == _intercambiar_equipo(original.kill)
+    assert invertida.motivo_a == original.motivo_b
+    assert invertida.motivo_b == original.motivo_a
+
+
+ESTADOS_POSIBLES = tuple(
+    estado(temporal, zombie)
+    for temporal, zombie in product(EstadoTemporal, (False, True))
+)
+
+
+@pytest.mark.parametrize(
+    "inicial_a,inicial_b,resultado",
+    product(ESTADOS_POSIBLES, ESTADOS_POSIBLES, ResultadoGlobal),
+)
+def test_matriz_exhaustiva_siempre_respeta_invariantes(inicial_a, inicial_b, resultado):
+    transicion = resolver_transicion_estados(
+        inicial_a, inicial_b, resultado, False, COMUNIDAD_A, COMUNIDAD_B
+    )
+
+    assert inicial_a.es_zombie <= transicion.estado_final_a.es_zombie
+    assert inicial_b.es_zombie <= transicion.estado_final_b.es_zombie
+    assert isinstance(transicion.estado_final_a.estado_temporal, EstadoTemporal)
+    assert isinstance(transicion.estado_final_b.estado_temporal, EstadoTemporal)
+    assert not (transicion.punto_zombificacion and transicion.kill)
+
+    if transicion.punto_zombificacion:
+        ganador, perdedor = (
+            (inicial_a, inicial_b)
+            if resultado is ResultadoGlobal.VICTORIA_A
+            else (inicial_b, inicial_a)
+        )
+        assert ganador.estado_temporal is EstadoTemporal.CAZADOR
+        assert perdedor == estado(EstadoTemporal.HERIDO)
+
+    if transicion.kill:
+        ganador, perdedor = (
+            (inicial_a, inicial_b)
+            if resultado is ResultadoGlobal.VICTORIA_A
+            else (inicial_b, inicial_a)
+        )
+        assert ganador.estado_temporal is EstadoTemporal.CAZADOR_Z
+        assert perdedor == estado(EstadoTemporal.HERIDO, True)
+
+
+@pytest.mark.parametrize(
+    "ganador,perdedor",
+    [
+        (estado(EstadoTemporal.CAZADOR_Z), estado(EstadoTemporal.HERIDO)),
+        (estado(EstadoTemporal.CAZADOR), estado(EstadoTemporal.HERIDO, True)),
+        (estado(EstadoTemporal.NEUTRO), estado(EstadoTemporal.HERIDO, True)),
+        (estado(EstadoTemporal.HERIDO), estado(EstadoTemporal.HERIDO)),
+    ],
+)
+def test_cruces_no_deseados_tienen_fallback_sin_punto_ni_kill(ganador, perdedor):
+    transicion = resolver_transicion_estados(
+        ganador,
+        perdedor,
+        ResultadoGlobal.VICTORIA_A,
+        False,
+        COMUNIDAD_A,
+        COMUNIDAD_B,
+    )
+
+    assert transicion.estado_final_a.estado_temporal is EstadoTemporal.NEUTRO
+    assert transicion.estado_final_b == estado(EstadoTemporal.NEUTRO, True)
+    assert transicion.punto_zombificacion is None
+    assert transicion.kill is None
+
+
+def test_una_transferencia_posterior_no_altera_el_calculo_de_la_fotografia():
+    fotografia_a = estado(EstadoTemporal.NEUTRO)
+    fotografia_b = estado(EstadoTemporal.HERIDO)
+    estado_vivo_a_tras_transferencia = estado(EstadoTemporal.CAZADOR)
+
+    antes = resolver_transicion_estados(
+        fotografia_a,
+        fotografia_b,
+        ResultadoGlobal.VICTORIA_A,
+        False,
+        COMUNIDAD_A,
+        COMUNIDAD_B,
+    )
+    despues = resolver_transicion_estados(
+        fotografia_a,
+        fotografia_b,
+        ResultadoGlobal.VICTORIA_A,
+        False,
+        COMUNIDAD_A,
+        COMUNIDAD_B,
+    )
+
+    assert estado_vivo_a_tras_transferencia != fotografia_a
+    assert antes == despues
+    assert despues.punto_zombificacion is None
+    assert despues.estado_final_b == estado(EstadoTemporal.NEUTRO, True)
+
+
+@pytest.mark.parametrize(
+    "args,error",
+    [
+        (
+            (
+                "NEUTRO",
+                estado(EstadoTemporal.NEUTRO),
+                ResultadoGlobal.EMPATE,
+                False,
+                COMUNIDAD_A,
+                COMUNIDAD_B,
+            ),
+            TypeError,
+        ),
+        (
+            (
+                estado(EstadoTemporal.NEUTRO),
+                estado(EstadoTemporal.NEUTRO),
+                "DESCONOCIDO",
+                False,
+                COMUNIDAD_A,
+                COMUNIDAD_B,
+            ),
+            ValueError,
+        ),
+        (
+            (
+                estado(EstadoTemporal.NEUTRO),
+                estado(EstadoTemporal.NEUTRO),
+                ResultadoGlobal.EMPATE,
+                1,
+                COMUNIDAD_A,
+                COMUNIDAD_B,
+            ),
+            TypeError,
+        ),
+        (
+            (
+                estado(EstadoTemporal.NEUTRO),
+                estado(EstadoTemporal.NEUTRO),
+                ResultadoGlobal.VICTORIA_A,
+                True,
+                COMUNIDAD_A,
+                COMUNIDAD_B,
+            ),
+            ValueError,
+        ),
+        (
+            (
+                estado(EstadoTemporal.NEUTRO),
+                estado(EstadoTemporal.NEUTRO),
+                ResultadoGlobal.EMPATE,
+                False,
+                COMUNIDAD_A,
+                COMUNIDAD_A,
+            ),
+            ValueError,
+        ),
+    ],
+)
+def test_valida_invariantes_de_entrada(args, error):
+    with pytest.raises(error):
+        resolver_transicion_estados(*args)
+
+
+@pytest.mark.parametrize("zombie", [None, 0, 1, "si"])
+def test_estado_fotografiado_exige_condicion_zombie_booleana(zombie):
+    with pytest.raises(TypeError):
+        estado(EstadoTemporal.NEUTRO, zombie)


### PR DESCRIPTION
### Motivation
- Implementar la sección 12 de la especificación como una función pura que resuelva transiciones a partir de la fotografía inicial de estados y respete que la condición zombie es permanente.
- Devolver un objeto de transición completo (estados finales, cambios zombie, punto de zombificación, kill y motivos) para evitar duplicar reglas en persistencia/notifications.
- Cubrir todas las ramas documentadas en la especificación (victoria, empate, zombificación, kill, doble forfait y los casos fallback).

### Description
- Añadidos tipos inmutables y enums: `EstadoTemporal`, `EstadoFotografiado`, `MotivoTransicion`, `EfectoComunitario` y `TransicionEstados` en `ComunidadesCore.py` para representar la fotografía y el resultado de la transición.
- Implementada `resolver_transicion_estados(estado_inicial_a, estado_inicial_b, resultado_global, doble_forfait, comunidad_a, comunidad_b)` que aplica las reglas de las secciones 12.2–12.10 usando únicamente la fotografía inicial y devuelve un `TransicionEstados` completo.
- Reglas especiales implementadas: zombificación de heridos no-zombie, concesión de punto comunitario solo si el ganador era `CAZADOR` en la fotografía, `KILL` solo si ganador era `CAZADOR_Z` y perdedor era `HERIDO`+`es_zombie`, limpieza de estados en empates y el tratamiento explícito de `doble_forfait` (sin cambios de estado ni efectos).
- Validaciones previas y post-condiciones añadidas que comprueban entradas válidas, la permanencia de `es_zombie`, la coherencia del indicador de cambio zombie y la exclusividad/consistencia de `punto_zombificacion` y `kill`.
- Nuevo conjunto de pruebas en `tests/test_comunidades_estados.py` que incluye la tabla parametrizada de las secciones 12.2–12.8, tests de empate, doble forfait, simetría local/visitante, matrix exhaustiva (todas las combinaciones de estados) y validaciones de entrada y casos no deseados.

### Testing
- `ruff check ComunidadesCore.py tests/test_comunidades_estados.py` se ejecutó sin errores.
- `pytest -q tests/test_comunidades_estados.py tests/test_comunidades_resultados.py tests/test_comunidades_constantes.py` pasó correctamente (331 pruebas sobre ese subset).
- `pytest -q` sobre la suite del repositorio pasó correctamente con 362 passed and preexisting warnings (70 warnings); todas las pruebas automatizadas verdes.
- Se añadieron tests que cubren la tabla parametrizada, simetría, matriz exhaustiva, fallbacks y validaciones, y todos ellos pasaron en la ejecución automatizada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24773eff30832a92733a95de1bec78)