### PR TITLE
Implementar clasificaciones de equipos y comunidades

### DIFF
--- a/ComunidadesCore.py
+++ b/ComunidadesCore.py
@@ -1,14 +1,15 @@
-"""Cálculos puros de resultados para enfrentamientos de comunidades.
+"""Cálculos de resultados y clasificaciones del torneo de comunidades.
 
-Este módulo no conoce SQLAlchemy, Discord ni estados del torneo. Todos los
-marcadores se expresan desde la perspectiva estable de los equipos A y B del
-enfrentamiento, independientemente de quién figure como local en Blood Bowl.
+La resolución de marcadores y estados se mantiene pura. Las funciones de
+clasificación consultan los modelos propios de comunidades mediante la sesión
+recibida, sin depender de los modelos del torneo suizo individual.
 """
 
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from enum import Enum
-from typing import Iterable
+from functools import cmp_to_key
+from typing import Any, Iterable, Optional
 
 from ComunidadesConstantes import (
     ESTADO_TEMPORAL_CAZADOR,
@@ -646,3 +647,334 @@ def _validar_salida_transicion(
         raise AssertionError("el punto de zombificación no coincide con la fotografía")
     if (transicion.kill == efecto_esperado) != kill_esperada:
         raise AssertionError("la kill no coincide con la fotografía")
+
+
+# ---------------------------------------------------------------------------
+# Clasificaciones acumuladas
+# ---------------------------------------------------------------------------
+
+FilaClasificacion = dict[str, Any]
+
+
+def _decimal(valor: Any) -> Decimal:
+    """Normaliza valores numéricos de ORM/diccionarios sin perder precisión."""
+    if isinstance(valor, Decimal):
+        return valor
+    return Decimal(str(valor or 0))
+
+
+def _valor(registro: Any, campo: str, default: Any = None) -> Any:
+    if isinstance(registro, dict):
+        return registro.get(campo, default)
+    return getattr(registro, campo, default)
+
+
+def calcular_h2h_equipos(
+    clasificacion: list[FilaClasificacion],
+    enfrentamientos_cerrados: Iterable[Any],
+) -> dict[int, Optional[Decimal]]:
+    """Calcula el enfrentamiento directo dentro de cada empate a puntos.
+
+    Un equipo solo recibe valor si disputó al menos un enfrentamiento real
+    contra otro integrante de su grupo empatado. Los byes no se representan
+    como enfrentamientos y, por tanto, nunca participan en este cálculo.
+    """
+    h2h: dict[int, Optional[Decimal]] = {
+        int(fila["equipo_id"]): None for fila in clasificacion
+    }
+    empatados: dict[Decimal, list[int]] = {}
+    for fila in clasificacion:
+        empatados.setdefault(_decimal(fila.get("puntos")), []).append(
+            int(fila["equipo_id"])
+        )
+
+    for equipos in empatados.values():
+        if len(equipos) < 2:
+            continue
+        conjunto = set(equipos)
+        acumulado = {equipo_id: Decimal("0") for equipo_id in equipos}
+        aplicable = {equipo_id: False for equipo_id in equipos}
+
+        for enfrentamiento in enfrentamientos_cerrados:
+            equipo_a_id = _valor(enfrentamiento, "equipo_a_id")
+            equipo_b_id = _valor(enfrentamiento, "equipo_b_id")
+            if equipo_a_id is None or equipo_b_id is None:
+                continue
+            equipo_a_id = int(equipo_a_id)
+            equipo_b_id = int(equipo_b_id)
+            if equipo_a_id not in conjunto or equipo_b_id not in conjunto:
+                continue
+
+            acumulado[equipo_a_id] += _decimal(
+                _valor(enfrentamiento, "puntos_clasificacion_a")
+            )
+            acumulado[equipo_b_id] += _decimal(
+                _valor(enfrentamiento, "puntos_clasificacion_b")
+            )
+            aplicable[equipo_a_id] = True
+            aplicable[equipo_b_id] = True
+
+        for equipo_id in equipos:
+            if aplicable[equipo_id]:
+                h2h[equipo_id] = acumulado[equipo_id]
+
+    return h2h
+
+
+def ordenar_clasificacion_equipos(
+    clasificacion: list[FilaClasificacion],
+) -> list[FilaClasificacion]:
+    """Ordena la clasificación publicada y asigna posiciones consecutivas.
+
+    El ID es exclusivamente el último desempate determinista de esta
+    clasificación publicada. No debe reutilizarse como desempate de pairing.
+    """
+
+    def comparar(a: FilaClasificacion, b: FilaClasificacion) -> int:
+        for campo in ("puntos", "buchholz_cut"):
+            valor_a = _decimal(a.get(campo))
+            valor_b = _decimal(b.get(campo))
+            if valor_a != valor_b:
+                return -1 if valor_a > valor_b else 1
+
+        h2h_a = a.get("h2h_valor")
+        h2h_b = b.get("h2h_valor")
+        if h2h_a is not None and h2h_b is not None:
+            valor_a = _decimal(h2h_a)
+            valor_b = _decimal(h2h_b)
+            if valor_a != valor_b:
+                return -1 if valor_a > valor_b else 1
+
+        diferencia_a = int(a.get("diferencia_td") or 0)
+        diferencia_b = int(b.get("diferencia_td") or 0)
+        if diferencia_a != diferencia_b:
+            return -1 if diferencia_a > diferencia_b else 1
+
+        equipo_a = int(a["equipo_id"])
+        equipo_b = int(b["equipo_id"])
+        if equipo_a != equipo_b:
+            return -1 if equipo_a < equipo_b else 1
+        return 0
+
+    ordenada = sorted(clasificacion, key=cmp_to_key(comparar))
+    for posicion, fila in enumerate(ordenada, start=1):
+        fila["posicion"] = posicion
+    return ordenada
+
+
+def calcular_clasificacion_equipos(
+    session: Any,
+    torneo_id: int,
+    hasta_ronda: Optional[int] = None,
+) -> list[FilaClasificacion]:
+    """Calcula estadísticas y desempates actuales de todos los equipos.
+
+    Solo cuentan enfrentamientos ``CERRADO`` o ``ADMINISTRADO``. Los byes se
+    reconstruyen desde las transiciones con motivo ``BYE``: suman la
+    puntuación configurada y el contador de byes, pero no PJ, PG, PE ni PP,
+    no añaden TD, rival, Buchholz directo ni H2H.
+    """
+    from GestorSQL import (
+        ComunidadesEnfrentamiento,
+        ComunidadesEquipo,
+        ComunidadesHistorialTransicion,
+        ComunidadesRonda,
+        ComunidadesTorneo,
+    )
+
+    torneo = (
+        session.query(ComunidadesTorneo)
+        .filter(ComunidadesTorneo.id == torneo_id)
+        .one_or_none()
+    )
+    if torneo is None:
+        return []
+
+    equipos = (
+        session.query(ComunidadesEquipo)
+        .filter(ComunidadesEquipo.torneo_id == torneo_id)
+        .all()
+    )
+    filas: dict[int, FilaClasificacion] = {}
+    rivales: dict[int, list[int]] = {}
+    for equipo in equipos:
+        filas[equipo.id] = {
+            "equipo_id": int(equipo.id),
+            "comunidad_id": int(equipo.comunidad_id),
+            "nombre": equipo.nombre,
+            "pj": 0,
+            "pg": 0,
+            "pe": 0,
+            "pp": 0,
+            "cantidad_byes": 0,
+            "puntos": Decimal("0"),
+            "td_favor": 0,
+            "td_contra": 0,
+            "diferencia_td": 0,
+            "buchholz_cut": Decimal("0"),
+            "h2h_valor": None,
+        }
+        rivales[equipo.id] = []
+
+    consulta = (
+        session.query(ComunidadesEnfrentamiento)
+        .join(ComunidadesRonda, ComunidadesRonda.id == ComunidadesEnfrentamiento.ronda_id)
+        .filter(
+            ComunidadesEnfrentamiento.torneo_id == torneo_id,
+            ComunidadesEnfrentamiento.estado.in_(["CERRADO", "ADMINISTRADO"]),
+        )
+    )
+    if hasta_ronda is not None:
+        consulta = consulta.filter(ComunidadesRonda.numero <= hasta_ronda)
+    enfrentamientos = consulta.all()
+
+    for enfrentamiento in enfrentamientos:
+        equipo_a_id = int(enfrentamiento.equipo_a_id)
+        equipo_b_id = int(enfrentamiento.equipo_b_id)
+        if equipo_a_id not in filas or equipo_b_id not in filas:
+            continue
+        fila_a = filas[equipo_a_id]
+        fila_b = filas[equipo_b_id]
+        fila_a["pj"] += 1
+        fila_b["pj"] += 1
+        fila_a["puntos"] += _decimal(enfrentamiento.puntos_clasificacion_a)
+        fila_b["puntos"] += _decimal(enfrentamiento.puntos_clasificacion_b)
+        fila_a["td_favor"] += int(enfrentamiento.td_favor_a or 0)
+        fila_a["td_contra"] += int(enfrentamiento.td_contra_a or 0)
+        fila_b["td_favor"] += int(enfrentamiento.td_favor_b or 0)
+        fila_b["td_contra"] += int(enfrentamiento.td_contra_b or 0)
+        rivales[equipo_a_id].append(equipo_b_id)
+        rivales[equipo_b_id].append(equipo_a_id)
+
+        ganador_id = enfrentamiento.ganador_equipo_id
+        if ganador_id is None:
+            fila_a["pe"] += 1
+            fila_b["pe"] += 1
+        elif int(ganador_id) == equipo_a_id:
+            fila_a["pg"] += 1
+            fila_b["pp"] += 1
+        elif int(ganador_id) == equipo_b_id:
+            fila_b["pg"] += 1
+            fila_a["pp"] += 1
+
+    consulta_byes = (
+        session.query(ComunidadesHistorialTransicion)
+        .join(ComunidadesRonda, ComunidadesRonda.id == ComunidadesHistorialTransicion.ronda_id)
+        .filter(
+            ComunidadesHistorialTransicion.torneo_id == torneo_id,
+            ComunidadesHistorialTransicion.motivo == "BYE",
+        )
+    )
+    if hasta_ronda is not None:
+        consulta_byes = consulta_byes.filter(ComunidadesRonda.numero <= hasta_ronda)
+    for transicion in consulta_byes.all():
+        equipo_id = int(transicion.equipo_id)
+        if equipo_id in filas:
+            filas[equipo_id]["cantidad_byes"] += 1
+            filas[equipo_id]["puntos"] += _decimal(
+                torneo.puntos_clasificacion_bye
+            )
+
+    for equipo_id, fila in filas.items():
+        fila["diferencia_td"] = fila["td_favor"] - fila["td_contra"]
+        puntos_rivales = [filas[rival]["puntos"] for rival in rivales[equipo_id]]
+        if len(puntos_rivales) >= 2:
+            fila["buchholz_cut"] = sum(
+                puntos_rivales, Decimal("0")
+            ) - min(puntos_rivales)
+
+    clasificacion = list(filas.values())
+    h2h = calcular_h2h_equipos(clasificacion, enfrentamientos)
+    for fila in clasificacion:
+        fila["h2h_valor"] = h2h[fila["equipo_id"]]
+    return ordenar_clasificacion_equipos(clasificacion)
+
+
+def calcular_clasificacion_comunidades(
+    session: Any,
+    torneo_id: int,
+    hasta_ronda: Optional[int] = None,
+    clasificacion_equipos: Optional[list[FilaClasificacion]] = None,
+) -> list[FilaClasificacion]:
+    """Calcula la clasificación comunitaria con posiciones compartidas."""
+    from GestorSQL import (
+        ComunidadesComunidad,
+        ComunidadesEquipo,
+        ComunidadesHistorialTransicion,
+        ComunidadesRonda,
+    )
+
+    comunidades = (
+        session.query(ComunidadesComunidad)
+        .filter(ComunidadesComunidad.torneo_id == torneo_id)
+        .all()
+    )
+    if not comunidades:
+        return []
+
+    if clasificacion_equipos is None:
+        clasificacion_equipos = calcular_clasificacion_equipos(
+            session, torneo_id, hasta_ronda
+        )
+
+    filas: dict[int, FilaClasificacion] = {
+        comunidad.id: {
+            "comunidad_id": int(comunidad.id),
+            "nombre": comunidad.nombre,
+            "puntos_zombificaciones": Decimal("0"),
+            "zombies_matados": 0,
+            "suma_puntos_equipos": Decimal("0"),
+        }
+        for comunidad in comunidades
+    }
+    for equipo in clasificacion_equipos:
+        comunidad_id = int(equipo["comunidad_id"])
+        if comunidad_id in filas:
+            filas[comunidad_id]["suma_puntos_equipos"] += _decimal(
+                equipo.get("puntos")
+            )
+
+    consulta = (
+        session.query(ComunidadesHistorialTransicion, ComunidadesEquipo.comunidad_id)
+        .join(
+            ComunidadesEquipo,
+            (ComunidadesEquipo.id == ComunidadesHistorialTransicion.equipo_id)
+            & (ComunidadesEquipo.torneo_id == ComunidadesHistorialTransicion.torneo_id),
+        )
+        .join(ComunidadesRonda, ComunidadesRonda.id == ComunidadesHistorialTransicion.ronda_id)
+        .filter(ComunidadesHistorialTransicion.torneo_id == torneo_id)
+    )
+    if hasta_ronda is not None:
+        consulta = consulta.filter(ComunidadesRonda.numero <= hasta_ronda)
+    for transicion, comunidad_id in consulta.all():
+        comunidad_id = int(comunidad_id)
+        if comunidad_id not in filas:
+            continue
+        filas[comunidad_id]["puntos_zombificaciones"] += _decimal(
+            transicion.puntos_comunitarios_generados
+        )
+        filas[comunidad_id]["zombies_matados"] += int(
+            transicion.kills_generadas or 0
+        )
+
+    ordenada = sorted(
+        filas.values(),
+        key=lambda fila: (
+            -fila["puntos_zombificaciones"],
+            -fila["zombies_matados"],
+            -fila["suma_puntos_equipos"],
+            fila["comunidad_id"],
+        ),
+    )
+    criterio_anterior: Optional[tuple[Decimal, int, Decimal]] = None
+    for indice, fila in enumerate(ordenada, start=1):
+        criterio = (
+            fila["puntos_zombificaciones"],
+            fila["zombies_matados"],
+            fila["suma_puntos_equipos"],
+        )
+        if criterio != criterio_anterior:
+            posicion = indice
+            criterio_anterior = criterio
+        fila["posicion"] = posicion
+    return ordenada

--- a/tests/test_comunidades_standings.py
+++ b/tests/test_comunidades_standings.py
@@ -1,0 +1,353 @@
+from datetime import datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+import sys
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ComunidadesCore import (
+    calcular_clasificacion_comunidades,
+    calcular_clasificacion_equipos,
+    calcular_h2h_equipos,
+    ordenar_clasificacion_equipos,
+)
+from GestorSQL import (
+    Base,
+    ComunidadesComunidad,
+    ComunidadesEnfrentamiento,
+    ComunidadesEquipo,
+    ComunidadesHistorialTransicion,
+    ComunidadesRonda,
+    ComunidadesTorneo,
+)
+
+
+def _session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def _crear_torneo(session, torneo_id=1, puntos_bye="1.5"):
+    torneo = ComunidadesTorneo(
+        id=torneo_id,
+        nombre=f"Torneo {torneo_id}",
+        rondas_totales=5,
+        fecha_fin_ronda1=datetime(2026, 7, 8),
+        dias_por_ronda=7,
+        puntos_clasificacion_bye=Decimal(puntos_bye),
+        plantilla_mensaje_ronda1="Ronda 1",
+        plantilla_mensaje_rondas_siguientes="Ronda {ronda}",
+        creado_por_discord_id=1,
+    )
+    session.add(torneo)
+    return torneo
+
+
+def _crear_comunidad(session, torneo, nombre):
+    comunidad = ComunidadesComunidad(torneo=torneo, nombre=nombre)
+    session.add(comunidad)
+    session.flush()
+    return comunidad
+
+
+def _crear_equipo(session, torneo, comunidad, equipo_id, nombre=None):
+    equipo = ComunidadesEquipo(
+        id=equipo_id,
+        torneo=torneo,
+        comunidad=comunidad,
+        nombre=nombre or f"Equipo {equipo_id}",
+    )
+    session.add(equipo)
+    session.flush()
+    return equipo
+
+
+def _crear_ronda(session, torneo, numero):
+    inicio = datetime(2026, 7, 1) + timedelta(days=7 * (numero - 1))
+    ronda = ComunidadesRonda(
+        torneo=torneo,
+        numero=numero,
+        fecha_inicio=inicio,
+        fecha_fin=inicio + timedelta(days=7),
+        generada_por_discord_id=1,
+    )
+    session.add(ronda)
+    session.flush()
+    return ronda
+
+
+def _enfrentamiento(
+    session,
+    torneo,
+    ronda,
+    mesa,
+    equipo_a,
+    equipo_b,
+    puntos_a,
+    puntos_b,
+    td_a=0,
+    td_b=0,
+    estado="CERRADO",
+    origen="API",
+):
+    if Decimal(str(puntos_a)) > Decimal(str(puntos_b)):
+        ganador_id = equipo_a.id
+    elif Decimal(str(puntos_b)) > Decimal(str(puntos_a)):
+        ganador_id = equipo_b.id
+    else:
+        ganador_id = None
+    enfrentamiento = ComunidadesEnfrentamiento(
+        torneo=torneo,
+        ronda=ronda,
+        mesa_numero=mesa,
+        equipo_a=equipo_a,
+        equipo_b=equipo_b,
+        estado=estado,
+        puntos_clasificacion_a=Decimal(str(puntos_a)),
+        puntos_clasificacion_b=Decimal(str(puntos_b)),
+        td_favor_a=td_a,
+        td_contra_a=td_b,
+        td_favor_b=td_b,
+        td_contra_b=td_a,
+        ganador_equipo_id=ganador_id,
+        resultado_origen=origen,
+    )
+    session.add(enfrentamiento)
+    session.flush()
+    return enfrentamiento
+
+
+def _transicion(
+    session,
+    torneo,
+    ronda,
+    equipo,
+    motivo,
+    puntos_comunitarios="0",
+    kills=0,
+):
+    session.add(
+        ComunidadesHistorialTransicion(
+            torneo_id=torneo.id,
+            ronda_id=ronda.id,
+            equipo_id=equipo.id,
+            estado_temporal_anterior="NEUTRO",
+            es_zombie_anterior=False,
+            estado_temporal_posterior="NEUTRO",
+            es_zombie_posterior=False,
+            motivo=motivo,
+            puntos_comunitarios_generados=Decimal(puntos_comunitarios),
+            kills_generadas=kills,
+        )
+    )
+
+
+def test_h2h_solo_es_aplicable_si_hay_enfrentamiento_directo_en_el_empate():
+    clasificacion = [
+        {"equipo_id": 1, "puntos": Decimal("3")},
+        {"equipo_id": 2, "puntos": Decimal("3")},
+        {"equipo_id": 3, "puntos": Decimal("3")},
+        {"equipo_id": 4, "puntos": Decimal("0")},
+    ]
+    enfrentamientos = [
+        {
+            "equipo_a_id": 1,
+            "equipo_b_id": 2,
+            "puntos_clasificacion_a": Decimal("3"),
+            "puntos_clasificacion_b": Decimal("0"),
+        },
+        {
+            "equipo_a_id": 1,
+            "equipo_b_id": 4,
+            "puntos_clasificacion_a": Decimal("0"),
+            "puntos_clasificacion_b": Decimal("0"),
+        },
+    ]
+
+    assert calcular_h2h_equipos(clasificacion, enfrentamientos) == {
+        1: Decimal("3"),
+        2: Decimal("0"),
+        3: None,
+        4: None,
+    }
+
+
+def test_orden_publicado_respeta_puntos_buchholz_h2h_td_e_id():
+    base = {
+        "puntos": Decimal("6"),
+        "buchholz_cut": Decimal("9"),
+        "h2h_valor": Decimal("1"),
+        "diferencia_td": 2,
+    }
+    filas = [
+        {**base, "equipo_id": 6, "puntos": Decimal("7")},
+        {**base, "equipo_id": 5, "buchholz_cut": Decimal("10")},
+        {**base, "equipo_id": 4, "h2h_valor": Decimal("3")},
+        {**base, "equipo_id": 3, "diferencia_td": 3},
+        {**base, "equipo_id": 2},
+        {**base, "equipo_id": 1},
+    ]
+
+    ordenada = ordenar_clasificacion_equipos(filas)
+
+    assert [fila["equipo_id"] for fila in ordenada] == [6, 5, 4, 3, 1, 2]
+    assert [fila["posicion"] for fila in ordenada] == [1, 2, 3, 4, 5, 6]
+
+
+def test_calcula_estadisticas_buchholz_cut_y_resultados_administrativos():
+    session = _session()
+    torneo = _crear_torneo(session)
+    comunidades = [_crear_comunidad(session, torneo, f"C{i}") for i in range(4)]
+    equipos = [
+        _crear_equipo(session, torneo, comunidades[i], i + 1) for i in range(4)
+    ]
+    r1 = _crear_ronda(session, torneo, 1)
+    _enfrentamiento(session, torneo, r1, 1, equipos[0], equipos[1], 3, 0, 3, 1)
+    _enfrentamiento(session, torneo, r1, 2, equipos[2], equipos[3], 3, 0, 2, 0)
+    r2 = _crear_ronda(session, torneo, 2)
+    _enfrentamiento(
+        session, torneo, r2, 1, equipos[0], equipos[2], 3, 0, 1, 0, origen="ADMIN"
+    )
+    _enfrentamiento(session, torneo, r2, 2, equipos[1], equipos[3], 3, 0, 2, 2)
+    session.commit()
+
+    filas = {fila["equipo_id"]: fila for fila in calcular_clasificacion_equipos(session, torneo.id)}
+
+    assert (filas[1]["pj"], filas[1]["pg"], filas[1]["pe"], filas[1]["pp"]) == (2, 2, 0, 0)
+    assert (filas[1]["td_favor"], filas[1]["td_contra"], filas[1]["diferencia_td"]) == (4, 1, 3)
+    assert filas[1]["puntos"] == Decimal("6")
+    assert filas[1]["buchholz_cut"] == Decimal("3")
+    assert filas[2]["buchholz_cut"] == Decimal("6")
+
+
+def test_bye_suma_puntos_y_buchholz_del_rival_pero_no_partido_ni_h2h():
+    session = _session()
+    torneo = _crear_torneo(session, puntos_bye="1.5")
+    comunidades = [_crear_comunidad(session, torneo, f"C{i}") for i in range(3)]
+    equipos = [
+        _crear_equipo(session, torneo, comunidades[i], i + 1) for i in range(3)
+    ]
+    r1 = _crear_ronda(session, torneo, 1)
+    _enfrentamiento(session, torneo, r1, 1, equipos[0], equipos[1], 3, 0, 1, 0)
+    _transicion(session, torneo, r1, equipos[2], "BYE")
+    r2 = _crear_ronda(session, torneo, 2)
+    _enfrentamiento(session, torneo, r2, 1, equipos[0], equipos[2], 3, 0, 1, 0)
+    _transicion(session, torneo, r2, equipos[1], "BYE")
+    session.commit()
+
+    filas = {fila["equipo_id"]: fila for fila in calcular_clasificacion_equipos(session, torneo.id)}
+
+    assert filas[2]["puntos"] == Decimal("1.5")
+    assert (filas[2]["pj"], filas[2]["pg"], filas[2]["pe"], filas[2]["pp"]) == (1, 0, 0, 1)
+    assert filas[2]["cantidad_byes"] == 1
+    assert (filas[2]["td_favor"], filas[2]["td_contra"]) == (0, 1)
+    assert filas[1]["buchholz_cut"] == Decimal("1.5")
+    assert filas[2]["h2h_valor"] is None
+
+
+def test_h2h_multiple_suma_solo_partidos_del_grupo_empatado():
+    clasificacion = [
+        {"equipo_id": 1, "puntos": Decimal("6")},
+        {"equipo_id": 2, "puntos": Decimal("6")},
+        {"equipo_id": 3, "puntos": Decimal("6")},
+    ]
+    enfrentamientos = [
+        {
+            "equipo_a_id": 1,
+            "equipo_b_id": 2,
+            "puntos_clasificacion_a": 3,
+            "puntos_clasificacion_b": 0,
+        },
+        {
+            "equipo_a_id": 2,
+            "equipo_b_id": 3,
+            "puntos_clasificacion_a": 1,
+            "puntos_clasificacion_b": 1,
+        },
+        {
+            "equipo_a_id": 1,
+            "equipo_b_id": 9,
+            "puntos_clasificacion_a": 3,
+            "puntos_clasificacion_b": 0,
+        },
+    ]
+
+    assert calcular_h2h_equipos(clasificacion, enfrentamientos) == {
+        1: Decimal("3"),
+        2: Decimal("1"),
+        3: Decimal("1"),
+    }
+
+
+def test_clasificacion_hasta_ronda_excluye_resultados_y_byes_posteriores():
+    session = _session()
+    torneo = _crear_torneo(session)
+    comunidades = [_crear_comunidad(session, torneo, f"C{i}") for i in range(3)]
+    equipos = [_crear_equipo(session, torneo, comunidades[i], i + 1) for i in range(3)]
+    r1 = _crear_ronda(session, torneo, 1)
+    _enfrentamiento(session, torneo, r1, 1, equipos[0], equipos[1], 3, 0, 2, 0)
+    _transicion(session, torneo, r1, equipos[2], "BYE")
+    r2 = _crear_ronda(session, torneo, 2)
+    _enfrentamiento(session, torneo, r2, 1, equipos[1], equipos[2], 3, 0, 1, 0)
+    _transicion(session, torneo, r2, equipos[0], "BYE")
+    session.commit()
+
+    filas = {
+        fila["equipo_id"]: fila
+        for fila in calcular_clasificacion_equipos(
+            session, torneo.id, hasta_ronda=1
+        )
+    }
+
+    assert filas[1]["puntos"] == Decimal("3")
+    assert filas[1]["cantidad_byes"] == 0
+    assert filas[2]["pj"] == 1
+    assert filas[3]["puntos"] == Decimal("1.5")
+    assert filas[3]["pj"] == 0
+
+
+def test_comunidades_ordenan_por_efectos_y_puntos_y_comparten_posicion():
+    session = _session()
+    torneo = _crear_torneo(session)
+    comunidades = [_crear_comunidad(session, torneo, nombre) for nombre in ("A", "B", "C", "D")]
+    equipos = [_crear_equipo(session, torneo, comunidades[i], i + 1) for i in range(4)]
+    r1 = _crear_ronda(session, torneo, 1)
+    _enfrentamiento(session, torneo, r1, 1, equipos[0], equipos[2], 3, 0, 1, 0)
+    _enfrentamiento(session, torneo, r1, 2, equipos[1], equipos[3], 3, 0, 1, 0, origen="ADMIN")
+    _transicion(session, torneo, r1, equipos[0], "ZOMBIFICACION", "1", 0)
+    _transicion(session, torneo, r1, equipos[1], "ZOMBIFICACION", "1", 0)
+    r2 = _crear_ronda(session, torneo, 2)
+    _transicion(session, torneo, r2, equipos[2], "KILL", "0", 1)
+    _transicion(session, torneo, r2, equipos[0], "BYE")
+    r3 = _crear_ronda(session, torneo, 3)
+    _transicion(session, torneo, r3, equipos[1], "BYE")
+    session.commit()
+
+    ronda_1 = calcular_clasificacion_comunidades(session, torneo.id, hasta_ronda=1)
+    completa = calcular_clasificacion_comunidades(session, torneo.id)
+
+    assert [(fila["nombre"], fila["posicion"]) for fila in ronda_1] == [
+        ("A", 1),
+        ("B", 1),
+        ("C", 3),
+        ("D", 3),
+    ]
+    assert ronda_1[0]["suma_puntos_equipos"] == Decimal("3")
+    assert [(fila["nombre"], fila["posicion"]) for fila in completa] == [
+        ("A", 1),
+        ("B", 1),
+        ("C", 3),
+        ("D", 4),
+    ]
+    assert completa[0]["suma_puntos_equipos"] == Decimal("4.5")
+    assert completa[1]["suma_puntos_equipos"] == Decimal("4.5")
+    assert completa[2]["zombies_matados"] == 1


### PR DESCRIPTION
### Motivation

- Implementar la lógica de clasificación publicada y comunitaria para el formato de comunidades siguiendo la especificación DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES, sin reutilizar modelos ni funciones del suizo individual.
- Reproducir exactamente el orden de desempates requerido: puntos, Buchholz Cut (con corte), H2H aplicable, diferencia de TD e ID interno como último desempate en la clasificación publicada.
- Tratar el `bye` igual que el suizo actual (suma puntos de bye, no incrementa PJ, no añade TD ni rival) y calcular posiciones comunitarias por zombificaciones, kills y suma de puntos de equipos con posiciones compartidas.

### Description

- Añade en `ComunidadesCore.py` las funciones de clasificación y utilidades: `calcular_clasificacion_equipos`, `calcular_clasificacion_comunidades`, `calcular_h2h_equipos` y `ordenar_clasificacion_equipos`, y helpers serializables para uso por comandos y snapshots.
- Calcula por equipo `pj/pg/pe/pp`, `puntos`, `td_favor/td_contra`, `diferencia_td`, `cantidad_byes` y `buchholz_cut` (con corte), reconociendo enfrentamientos `CERRADO`/`ADMINISTRADO` y reconstruyendo byes desde el historial de transiciones.
- Implementa H2H solo dentro de grupos empatados y sólo si existe enfrentamiento directo dentro del grupo, y aplica el desempate determinista en el orden exacto especificado; el `equipo_id` se usa únicamente como último desempate de la clasificación publicada.
- Implementa la clasificación comunitaria que suma `puntos_zombificaciones`, `zombies_matados` y `suma_puntos_equipos`, respeta el parámetro `hasta_ronda` y asigna posiciones compartidas cuando corresponda; todo devuelve estructuras simples (diccionarios) listas para serializar.

### Testing

- Se añadió `tests/test_comunidades_standings.py` con casos de H2H aplicable/no aplicable, H2H múltiple, Buchholz Cut con/ sin bye, efectos de resultados administrativos, comportamiento de byes y corte por ronda, además de la clasificación comunitaria con posiciones compartidas.
- Se ejecutó la batería de pruebas: `pytest -q` y la suite completa pasó correctamente con `369 passed` (ninguna prueba falló).
- Se verificó que los cambios no rompen tests existentes del suizo y del esquema de comunidades incluidos en el repositorio y que las funciones devuelven estructuras consumibles por snapshots/consultas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2479cfce08832a86d053228eefb4a3)