### PR TITLE
Implementar emparejamientos por backtracking para el suizo de comunidades

### DIFF
--- a/ComunidadesCore.py
+++ b/ComunidadesCore.py
@@ -650,6 +650,364 @@ def _validar_salida_transicion(
 
 
 # ---------------------------------------------------------------------------
+# Emparejamientos de comunidades
+# ---------------------------------------------------------------------------
+
+PairingComunidades = dict[str, Any]
+TrazaPairingsComunidades = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _EquipoPairing:
+    equipo_id: int
+    comunidad_id: int
+    puntos: Decimal
+    posicion: int
+    estado_temporal: EstadoTemporal
+    es_zombie: bool
+    cantidad_byes: int
+    razas: frozenset[str]
+
+
+_ETAPAS_PAIRING = (
+    ("BASE", False, False, 0),
+    ("PERMITIR_MIRRORS", True, False, 1),
+    ("PERMITIR_ESTADOS_NO_DESEADOS", True, True, 2),
+    ("PERMITIR_REPETIDOS", True, True, 3),
+)
+
+
+def _normalizar_raza(raza: object) -> str:
+    return " ".join(str(raza or "").strip().casefold().split())
+
+
+def _es_objetivo_caza(a: _EquipoPairing, b: _EquipoPairing) -> bool:
+    return (
+        a.estado_temporal is EstadoTemporal.CAZADOR
+        and b.estado_temporal is EstadoTemporal.HERIDO
+        and not b.es_zombie
+    ) or (
+        a.estado_temporal is EstadoTemporal.CAZADOR_Z
+        and b.estado_temporal is EstadoTemporal.HERIDO
+        and b.es_zombie
+    )
+
+
+def _prioridad_estado_pairing(a: _EquipoPairing, b: _EquipoPairing) -> int:
+    """Devuelve 0 para cazas prioritarias, 1 para neutros y 2 para fallback."""
+    if _es_objetivo_caza(a, b) or _es_objetivo_caza(b, a):
+        return 0
+    if (
+        a.estado_temporal is EstadoTemporal.NEUTRO
+        and b.estado_temporal is EstadoTemporal.NEUTRO
+    ):
+        return 1
+    return 2
+
+
+def _es_mirror_pairing(a: _EquipoPairing, b: _EquipoPairing) -> bool:
+    return bool(a.razas.intersection(b.razas))
+
+
+def generar_pairings_comunidades_backtracking(
+    session: Any,
+    torneo_id: int,
+    ronda_numero: int,
+    rng: Any = None,
+) -> tuple[list[PairingComunidades], TrazaPairingsComunidades]:
+    """Calcula una ronda completa sin persistirla.
+
+    La función devuelve ``(pairings, traza)``. Cada intento conserva como
+    restricciones absolutas la comunidad distinta y la solución completa, y
+    relaja en orden mirrors, estados no deseados y rivales repetidos. Si no hay
+    solución, ``pairings`` es una lista vacía y la traza contiene un error
+    estructurado con código ``SIN_SOLUCION_COMPLETA``.
+    """
+    import random
+
+    from GestorSQL import (
+        ComunidadesEnfrentamiento,
+        ComunidadesEquipo,
+        ComunidadesMiembro,
+        ComunidadesRonda,
+    )
+
+    if rng is None:
+        rng = random.Random()
+    if not hasattr(rng, "random"):
+        raise TypeError("rng debe proporcionar un método random()")
+    if ronda_numero < 1:
+        raise ValueError("ronda_numero debe ser mayor que cero")
+
+    clasificacion = calcular_clasificacion_equipos(
+        session, torneo_id, hasta_ronda=ronda_numero - 1
+    )
+    if not clasificacion:
+        return [], {
+            "nivel_fallback": None,
+            "etapa": "CANCELACION",
+            "intentos": [],
+            "error": {
+                "codigo": "SIN_EQUIPOS",
+                "detalle": "No hay equipos disponibles para emparejar.",
+            },
+        }
+
+    filas = {int(fila["equipo_id"]): fila for fila in clasificacion}
+    equipos_orm = (
+        session.query(ComunidadesEquipo)
+        .filter(ComunidadesEquipo.torneo_id == torneo_id)
+        .all()
+    )
+    razas_por_equipo: dict[int, set[str]] = {int(e.id): set() for e in equipos_orm}
+    for equipo_id, raza in (
+        session.query(ComunidadesMiembro.equipo_id, ComunidadesMiembro.raza)
+        .filter(ComunidadesMiembro.torneo_id == torneo_id)
+        .all()
+    ):
+        normalizada = _normalizar_raza(raza)
+        if normalizada:
+            razas_por_equipo.setdefault(int(equipo_id), set()).add(normalizada)
+
+    equipos: dict[int, _EquipoPairing] = {}
+    for equipo in equipos_orm:
+        fila = filas[int(equipo.id)]
+        equipos[int(equipo.id)] = _EquipoPairing(
+            equipo_id=int(equipo.id),
+            comunidad_id=int(equipo.comunidad_id),
+            puntos=_decimal(fila["puntos"]),
+            posicion=int(fila.get("posicion", len(filas))),
+            estado_temporal=EstadoTemporal(equipo.estado_temporal),
+            es_zombie=bool(equipo.es_zombie),
+            cantidad_byes=int(fila.get("cantidad_byes", equipo.cantidad_byes or 0)),
+            razas=frozenset(razas_por_equipo.get(int(equipo.id), set())),
+        )
+
+    historial = (
+        session.query(
+            ComunidadesEnfrentamiento.equipo_a_id,
+            ComunidadesEnfrentamiento.equipo_b_id,
+        )
+        .join(ComunidadesRonda, ComunidadesRonda.id == ComunidadesEnfrentamiento.ronda_id)
+        .filter(
+            ComunidadesEnfrentamiento.torneo_id == torneo_id,
+            ComunidadesRonda.numero < ronda_numero,
+        )
+        .all()
+    )
+    rivales_previos = {equipo_id: set() for equipo_id in equipos}
+    for equipo_a_id, equipo_b_id in historial:
+        a, b = int(equipo_a_id), int(equipo_b_id)
+        if a in rivales_previos and b in rivales_previos:
+            rivales_previos[a].add(b)
+            rivales_previos[b].add(a)
+
+    ids = tuple(equipos)
+    azar_pareja = {
+        frozenset((a, b)): rng.random()
+        for indice, a in enumerate(ids)
+        for b in ids[indice + 1 :]
+    }
+    azar_bye = {equipo_id: rng.random() for equipo_id in ids}
+
+    def ordenar_byes() -> list[Optional[int]]:
+        if len(ids) % 2 == 0:
+            return [None]
+        return sorted(
+            ids,
+            key=lambda equipo_id: (
+                equipos[equipo_id].estado_temporal is not EstadoTemporal.NEUTRO,
+                equipos[equipo_id].cantidad_byes > 0,
+                -equipos[equipo_id].posicion,
+                azar_bye[equipo_id],
+            ),
+        )
+
+    def resolver_etapa(
+        permite_mirror: bool,
+        permite_estados: bool,
+        permite_repetidos: bool,
+        bye_id: Optional[int],
+    ) -> tuple[Optional[list[tuple[int, int]]], int]:
+        pendientes_iniciales = tuple(e for e in ids if e != bye_id)
+        mejor: Optional[list[tuple[int, int]]] = None
+        mejor_coste: Optional[tuple[Any, ...]] = None
+        exploradas = 0
+
+        def backtrack(
+            pendientes: tuple[int, ...],
+            parejas: list[tuple[int, int]],
+            estados_no_deseados: int,
+            diferencia_puntos: Decimal,
+            mirrors: int,
+            azar_total: float,
+        ) -> None:
+            nonlocal mejor, mejor_coste, exploradas
+            if not pendientes:
+                exploradas += 1
+                coste = (
+                    estados_no_deseados,
+                    diferencia_puntos,
+                    mirrors,
+                    azar_total,
+                )
+                if mejor_coste is None or coste < mejor_coste:
+                    mejor_coste = coste
+                    mejor = list(parejas)
+                return
+
+            # Elegir primero el equipo más restringido reduce drásticamente la
+            # búsqueda sin convertir el orden de clasificación en una regla.
+            def cantidad_candidatos(equipo_id: int) -> int:
+                equipo = equipos[equipo_id]
+                return sum(
+                    equipos[otro].comunidad_id != equipo.comunidad_id
+                    for otro in pendientes
+                    if otro != equipo_id
+                )
+
+            a_id = min(
+                pendientes,
+                key=lambda equipo_id: (
+                    cantidad_candidatos(equipo_id),
+                    equipos[equipo_id].estado_temporal is EstadoTemporal.NEUTRO,
+                    equipos[equipo_id].posicion,
+                    equipo_id,
+                ),
+            )
+            a = equipos[a_id]
+            resto = tuple(e for e in pendientes if e != a_id)
+            candidatos = []
+            for b_id in resto:
+                b = equipos[b_id]
+                if a.comunidad_id == b.comunidad_id:
+                    continue
+                repetido = b_id in rivales_previos[a_id]
+                if repetido and not permite_repetidos:
+                    continue
+                prioridad = _prioridad_estado_pairing(a, b)
+                if prioridad == 2 and not permite_estados:
+                    continue
+                mirror = _es_mirror_pairing(a, b)
+                if mirror and not permite_mirror:
+                    continue
+                candidatos.append(
+                    (
+                        prioridad,
+                        abs(a.puntos - b.puntos),
+                        mirror,
+                        azar_pareja[frozenset((a_id, b_id))],
+                        b_id,
+                    )
+                )
+            candidatos.sort(key=lambda candidato: candidato[:-1])
+
+            for prioridad, diferencia, mirror, azar, b_id in candidatos:
+                nuevo_no_deseado = estados_no_deseados + (prioridad == 2)
+                nueva_diferencia = diferencia_puntos + diferencia
+                nuevos_mirrors = mirrors + int(mirror)
+                coste_parcial = (
+                    nuevo_no_deseado,
+                    nueva_diferencia,
+                    nuevos_mirrors,
+                    azar_total + azar,
+                )
+                if mejor_coste is not None and coste_parcial >= mejor_coste:
+                    continue
+                parejas.append((a_id, b_id))
+                backtrack(
+                    tuple(e for e in resto if e != b_id),
+                    parejas,
+                    nuevo_no_deseado,
+                    nueva_diferencia,
+                    nuevos_mirrors,
+                    azar_total + azar,
+                )
+                parejas.pop()
+
+        backtrack(pendientes_iniciales, [], 0, Decimal("0"), 0, 0.0)
+        return mejor, exploradas
+
+    intentos: list[dict[str, Any]] = []
+    # El orden del bye es una prioridad propia y absoluta: para cada candidato
+    # se agotan los fallbacks de emparejamiento antes de considerar el siguiente.
+    for bye_id in ordenar_byes():
+        for etapa, permite_mirror, permite_estados, nivel in _ETAPAS_PAIRING:
+            permite_repetidos = etapa == "PERMITIR_REPETIDOS"
+            solucion, soluciones_exploradas = resolver_etapa(
+                permite_mirror,
+                permite_estados,
+                permite_repetidos,
+                bye_id,
+            )
+            intento = {
+                "etapa": etapa,
+                "nivel_fallback": nivel,
+                "bye_equipo_id": bye_id,
+                "permite_mirrors": permite_mirror,
+                "permite_estados_no_deseados": permite_estados,
+                "permite_repetidos": permite_repetidos,
+                "soluciones_completas_exploradas": soluciones_exploradas,
+                "encontrada": solucion is not None,
+            }
+            intentos.append(intento)
+            if solucion is None:
+                continue
+
+            pairings: list[PairingComunidades] = []
+            for mesa, (a_id, b_id) in enumerate(solucion, start=1):
+                a, b = equipos[a_id], equipos[b_id]
+                pairings.append(
+                    {
+                        "mesa_numero": mesa,
+                        "equipo_a_id": a_id,
+                        "equipo_b_id": b_id,
+                        "es_bye": False,
+                        "diferencia_puntos": abs(a.puntos - b.puntos),
+                        "prioridad_estado": _prioridad_estado_pairing(a, b),
+                        "es_mirror": _es_mirror_pairing(a, b),
+                        "es_rival_repetido": b_id in rivales_previos[a_id],
+                    }
+                )
+            if bye_id is not None:
+                pairings.append(
+                    {
+                        "mesa_numero": len(pairings) + 1,
+                        "equipo_a_id": bye_id,
+                        "equipo_b_id": None,
+                        "es_bye": True,
+                        "diferencia_puntos": None,
+                        "prioridad_estado": None,
+                        "es_mirror": False,
+                        "es_rival_repetido": False,
+                    }
+                )
+            return pairings, {
+                "nivel_fallback": nivel,
+                "etapa": etapa,
+                "intentos": intentos,
+                "error": None,
+            }
+
+    return [], {
+        "nivel_fallback": None,
+        "etapa": "CANCELACION",
+        "intentos": intentos,
+        "error": {
+            "codigo": "SIN_SOLUCION_COMPLETA",
+            "detalle": (
+                "No existe una ronda completa sin enfrentar equipos de la "
+                "misma comunidad."
+            ),
+        },
+    }
+
+
+# Alias legible para consumidores que prefieran el orden verbo-ámbito-técnica.
+generar_pairings_backtracking_comunidades = generar_pairings_comunidades_backtracking
+
+
+# ---------------------------------------------------------------------------
 # Clasificaciones acumuladas
 # ---------------------------------------------------------------------------
 

--- a/tests/test_comunidades_pairings.py
+++ b/tests/test_comunidades_pairings.py
@@ -1,0 +1,291 @@
+from datetime import datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+import random
+import sys
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ComunidadesCore import generar_pairings_comunidades_backtracking
+from GestorSQL import (
+    Base,
+    ComunidadesComunidad,
+    ComunidadesEnfrentamiento,
+    ComunidadesEquipo,
+    ComunidadesMiembro,
+    ComunidadesRonda,
+    ComunidadesTorneo,
+    Usuario,
+)
+
+
+def _session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def _torneo(session):
+    torneo = ComunidadesTorneo(
+        nombre="Comunidades",
+        rondas_totales=6,
+        fecha_fin_ronda1=datetime(2026, 7, 8),
+        dias_por_ronda=7,
+        plantilla_mensaje_ronda1="R1",
+        plantilla_mensaje_rondas_siguientes="R{ronda}",
+        creado_por_discord_id=1,
+    )
+    session.add(torneo)
+    session.flush()
+    return torneo
+
+
+def _equipo(
+    session,
+    torneo,
+    equipo_id,
+    comunidad,
+    estado="NEUTRO",
+    zombie=False,
+    razas=("Humanos", "Orcos"),
+    byes=0,
+):
+    comunidad_orm = (
+        session.query(ComunidadesComunidad)
+        .filter_by(torneo_id=torneo.id, nombre=comunidad)
+        .one_or_none()
+    )
+    if comunidad_orm is None:
+        comunidad_orm = ComunidadesComunidad(torneo=torneo, nombre=comunidad)
+        session.add(comunidad_orm)
+        session.flush()
+    equipo = ComunidadesEquipo(
+        id=equipo_id,
+        torneo=torneo,
+        comunidad=comunidad_orm,
+        nombre=f"Equipo {equipo_id}",
+        estado_temporal=estado,
+        es_zombie=zombie,
+        cantidad_byes=byes,
+    )
+    for posicion, raza in enumerate(razas, start=1):
+        usuario_id = equipo_id * 10 + posicion
+        usuario = Usuario(idUsuarios=usuario_id, nombre_discord=f"U{usuario_id}")
+        session.add(usuario)
+        equipo.miembros.append(
+            ComunidadesMiembro(
+                torneo_id=torneo.id,
+                usuario=usuario,
+                posicion=posicion,
+                raza=raza,
+            )
+        )
+    session.add(equipo)
+    session.flush()
+    return equipo
+
+
+def _ronda(session, torneo, numero):
+    inicio = datetime(2026, 7, 1) + timedelta(days=7 * (numero - 1))
+    ronda = ComunidadesRonda(
+        torneo=torneo,
+        numero=numero,
+        fecha_inicio=inicio,
+        fecha_fin=inicio + timedelta(days=7),
+        generada_por_discord_id=1,
+    )
+    session.add(ronda)
+    session.flush()
+    return ronda
+
+
+def _enfrentamiento_previo(session, torneo, ronda, a, b, puntos_a=3, puntos_b=0):
+    session.add(
+        ComunidadesEnfrentamiento(
+            torneo=torneo,
+            ronda=ronda,
+            mesa_numero=len(ronda.enfrentamientos) + 1,
+            equipo_a=a,
+            equipo_b=b,
+            estado="CERRADO",
+            ganador_equipo_id=a.id if puntos_a > puntos_b else None,
+            puntos_clasificacion_a=Decimal(str(puntos_a)),
+            puntos_clasificacion_b=Decimal(str(puntos_b)),
+        )
+    )
+    session.flush()
+
+
+def _parejas(pairings):
+    return {
+        frozenset((p["equipo_a_id"], p["equipo_b_id"]))
+        for p in pairings
+        if not p["es_bye"]
+    }
+
+
+def test_solucion_estricta_prioriza_ambos_tipos_de_caza_y_comunidades_distintas():
+    session = _session()
+    torneo = _torneo(session)
+    _equipo(session, torneo, 1, "A", "CAZADOR", razas=("R1", "X1"))
+    _equipo(session, torneo, 2, "B", "HERIDO", zombie=False, razas=("R2", "X2"))
+    _equipo(session, torneo, 3, "C", "CAZADOR_Z", razas=("R3", "X3"))
+    _equipo(session, torneo, 4, "D", "HERIDO", zombie=True, razas=("R4", "X4"))
+
+    pairings, traza = generar_pairings_comunidades_backtracking(
+        session, torneo.id, 1, random.Random(4)
+    )
+
+    assert _parejas(pairings) == {frozenset((1, 2)), frozenset((3, 4))}
+    assert all(p["prioridad_estado"] == 0 for p in pairings)
+    assert traza["etapa"] == "BASE"
+
+
+def test_mirror_es_el_primer_fallback_y_detecta_cualquier_raza_compartida():
+    session = _session()
+    torneo = _torneo(session)
+    _equipo(session, torneo, 1, "A", razas=("Orcos", "Skaven"))
+    _equipo(session, torneo, 2, "B", razas=("Humanos", "Skaven"))
+
+    pairings, traza = generar_pairings_comunidades_backtracking(
+        session, torneo.id, 1, random.Random(1)
+    )
+
+    assert pairings[0]["es_mirror"] is True
+    assert traza["etapa"] == "PERMITIR_MIRRORS"
+    assert traza["nivel_fallback"] == 1
+
+
+def test_estados_no_deseados_solo_se_permiten_despues_de_mirrors():
+    session = _session()
+    torneo = _torneo(session)
+    _equipo(session, torneo, 1, "A", estado="CAZADOR", razas=("Orcos", "Skaven"))
+    _equipo(session, torneo, 2, "B", estado="NEUTRO", razas=("Humanos", "Enanos"))
+
+    pairings, traza = generar_pairings_comunidades_backtracking(
+        session, torneo.id, 1, random.Random(2)
+    )
+
+    assert pairings[0]["prioridad_estado"] == 2
+    assert traza["etapa"] == "PERMITIR_ESTADOS_NO_DESEADOS"
+    assert [i["etapa"] for i in traza["intentos"]] == [
+        "BASE",
+        "PERMITIR_MIRRORS",
+        "PERMITIR_ESTADOS_NO_DESEADOS",
+    ]
+
+
+def test_rival_repetido_solo_se_permite_en_ultimo_fallback():
+    session = _session()
+    torneo = _torneo(session)
+    a = _equipo(session, torneo, 1, "A", razas=("Orcos", "Skaven"))
+    b = _equipo(session, torneo, 2, "B", razas=("Humanos", "Enanos"))
+    ronda = _ronda(session, torneo, 1)
+    _enfrentamiento_previo(session, torneo, ronda, a, b)
+
+    pairings, traza = generar_pairings_comunidades_backtracking(
+        session, torneo.id, 2, random.Random(3)
+    )
+
+    assert pairings[0]["es_rival_repetido"] is True
+    assert traza["etapa"] == "PERMITIR_REPETIDOS"
+    assert traza["nivel_fallback"] == 3
+
+
+def test_distribucion_imposible_no_persiste_ni_devuelve_ronda_parcial():
+    session = _session()
+    torneo = _torneo(session)
+    _equipo(session, torneo, 1, "A")
+    _equipo(session, torneo, 2, "A")
+    _equipo(session, torneo, 3, "A")
+    _equipo(session, torneo, 4, "B")
+    antes = len(session.new)
+
+    pairings, traza = generar_pairings_comunidades_backtracking(
+        session, torneo.id, 1, random.Random(4)
+    )
+
+    assert pairings == []
+    assert traza["etapa"] == "CANCELACION"
+    assert traza["error"]["codigo"] == "SIN_SOLUCION_COMPLETA"
+    assert len(session.new) == antes
+    assert session.query(ComunidadesEnfrentamiento).count() == 0
+
+
+def test_bye_prioriza_neutro_sin_bye_previo_y_peor_clasificado(monkeypatch):
+    session = _session()
+    torneo = _torneo(session)
+    _equipo(session, torneo, 1, "A", estado="HERIDO")
+    _equipo(session, torneo, 2, "B", byes=0)
+    _equipo(session, torneo, 3, "C", byes=1)
+    _equipo(session, torneo, 4, "D", byes=0)
+    _equipo(session, torneo, 5, "E", byes=0)
+
+    import ComunidadesCore
+
+    posiciones = {1: 5, 2: 1, 3: 5, 4: 4, 5: 2}
+    original = ComunidadesCore.calcular_clasificacion_equipos
+
+    def clasificacion(*args, **kwargs):
+        filas = original(*args, **kwargs)
+        for fila in filas:
+            fila["posicion"] = posiciones[fila["equipo_id"]]
+            fila["cantidad_byes"] = 1 if fila["equipo_id"] == 3 else 0
+        return filas
+
+    monkeypatch.setattr(ComunidadesCore, "calcular_clasificacion_equipos", clasificacion)
+    pairings, _ = generar_pairings_comunidades_backtracking(
+        session, torneo.id, 1, random.Random(5)
+    )
+
+    bye = next(p for p in pairings if p["es_bye"])
+    assert bye["equipo_a_id"] == 4
+
+
+def test_azar_inyectado_hace_la_salida_determinista():
+    def generar(seed):
+        session = _session()
+        torneo = _torneo(session)
+        for equipo_id, comunidad in enumerate(("A", "B", "C", "D", "E", "F"), start=1):
+            _equipo(session, torneo, equipo_id, comunidad, razas=(f"R{equipo_id}", f"X{equipo_id}"))
+        return generar_pairings_comunidades_backtracking(
+            session, torneo.id, 1, random.Random(seed)
+        )[0]
+
+    assert generar(99) == generar(99)
+
+
+def test_dentro_de_la_prioridad_minimiza_diferencia_de_puntos(monkeypatch):
+    session = _session()
+    torneo = _torneo(session)
+    _equipo(session, torneo, 1, "A", estado="CAZADOR", razas=("R1", "X1"))
+    _equipo(session, torneo, 2, "B", estado="CAZADOR", razas=("R2", "X2"))
+    _equipo(session, torneo, 3, "C", estado="HERIDO", razas=("R3", "X3"))
+    _equipo(session, torneo, 4, "D", estado="HERIDO", razas=("R4", "X4"))
+
+    import ComunidadesCore
+
+    puntos = {1: Decimal("10"), 2: Decimal("2"), 3: Decimal("9"), 4: Decimal("1")}
+    original = ComunidadesCore.calcular_clasificacion_equipos
+
+    def clasificacion(*args, **kwargs):
+        filas = original(*args, **kwargs)
+        for fila in filas:
+            fila["puntos"] = puntos[fila["equipo_id"]]
+        return filas
+
+    monkeypatch.setattr(ComunidadesCore, "calcular_clasificacion_equipos", clasificacion)
+    pairings, traza = generar_pairings_comunidades_backtracking(
+        session, torneo.id, 1, random.Random(7)
+    )
+
+    assert _parejas(pairings) == {frozenset((1, 3)), frozenset((2, 4))}
+    assert traza["etapa"] == "BASE"


### PR DESCRIPTION
### Motivation
- Implementar generación completa de una ronda de emparejamientos para el formato por comunidades respetando las restricciones y orden de relajación definido en la especificación.
- Evitar emparejamientos entre equipos de la misma comunidad y no persistir resultados parciales cuando no exista solución completa.

### Description
- Añade `generar_pairings_comunidades_backtracking` en `ComunidadesCore.py` que calcula una ronda completa por backtracking y devuelve `(pairings, traza)` sin persistir nada si no hay solución completa.
- Implementa prioridades de emparejamiento por estado (cazador→herido no zombie y cazador Z→zombie herido), minimización de diferencia de puntos, evitado de mirrors y desempate aleatorio inyectable mediante `rng`.
- Integra detección de mirror por cualquier raza compartida (normalizando cadenas), historial de rivales previos, y selección de `bye` por estado temporal, byes previos, peor clasificación y azar; agota los fallbacks en el orden mirrors → estados no deseados → repetidos.
- Devuelve traza estructurada con el nivel de fallback o un error estructurado (`SIN_SOLUCION_COMPLETA`) cuando no existe una solución completa; no se escriben enfrentamientos parciales en la base.
- Añade pruebas de aceptación en `tests/test_comunidades_pairings.py` cubriendo casos estrictos, cada fallback, distribución imposible, asignación de bye, reserva de zombie herido y determinismo con `random.Random(seed)`.

### Testing
- Ejecutado `pytest -q tests/test_comunidades_pairings.py`, resultado: 8 tests passed.
- Ejecutado `pytest -q` contra la suite completa del repositorio, resultado: 377 tests passed.
- Código compilado con `python -m py_compile ComunidadesCore.py` sin errores y no se dejó persistencia parcial en los escenarios imposibles según las pruebas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a247bcdb3b0832a84d6c3a38bb7900e)