### PR TITLE
Generación atómica de rondas de comunidades

### DIFF
--- a/ComunidadesCore.py
+++ b/ComunidadesCore.py
@@ -6,7 +6,9 @@ recibida, sin depender de los modelos del torneo suizo individual.
 """
 
 from dataclasses import dataclass
+from datetime import timedelta
 from decimal import Decimal, InvalidOperation
+import json
 from enum import Enum
 from functools import cmp_to_key
 from typing import Any, Iterable, Optional
@@ -1001,6 +1003,318 @@ def generar_pairings_comunidades_backtracking(
             ),
         },
     }
+
+
+class ErrorGeneracionRondaComunidades(ValueError):
+    """Error funcional que cancela por completo la generación de una ronda."""
+
+    def __init__(self, codigo: str, detalle: str):
+        super().__init__(detalle)
+        self.codigo = codigo
+        self.detalle = detalle
+
+
+def _error_generacion(codigo: str, detalle: str) -> None:
+    raise ErrorGeneracionRondaComunidades(codigo, detalle)
+
+
+def _validar_generacion_ronda_comunidades(
+    session: Any,
+    torneo: Any,
+    ronda_numero: int,
+) -> Optional[Any]:
+    """Valida la secuencia y devuelve la ronda anterior cuando corresponde."""
+    from GestorSQL import ComunidadesEquipo, ComunidadesMiembro, ComunidadesRonda
+
+    if ronda_numero < 1 or ronda_numero > int(torneo.rondas_totales):
+        _error_generacion(
+            "NUMERO_RONDA_INVALIDO",
+            f"La ronda debe estar entre 1 y {int(torneo.rondas_totales)}.",
+        )
+
+    existente = (
+        session.query(ComunidadesRonda)
+        .filter(
+            ComunidadesRonda.torneo_id == torneo.id,
+            ComunidadesRonda.numero == ronda_numero,
+        )
+        .one_or_none()
+    )
+    if existente is not None:
+        _error_generacion("RONDA_DUPLICADA", "La ronda solicitada ya existe.")
+
+    incompatible = (
+        session.query(ComunidadesRonda)
+        .filter(
+            ComunidadesRonda.torneo_id == torneo.id,
+            ComunidadesRonda.estado.in_(["ABIERTA", "BLOQUEADA"]),
+        )
+        .first()
+    )
+    if incompatible is not None:
+        _error_generacion(
+            "RONDA_ABIERTA_INCOMPATIBLE",
+            f"La ronda {int(incompatible.numero)} todavía no está cerrada.",
+        )
+
+    if ronda_numero == 1:
+        if torneo.estado != "CREADO":
+            _error_generacion(
+                "ESTADO_TORNEO_INVALIDO",
+                "La ronda 1 solo puede generarse con el torneo en estado CREADO.",
+            )
+        ronda_anterior = None
+    else:
+        if torneo.estado != "EN_CURSO":
+            _error_generacion(
+                "ESTADO_TORNEO_INVALIDO",
+                "Las rondas posteriores requieren un torneo EN_CURSO.",
+            )
+        ronda_anterior = (
+            session.query(ComunidadesRonda)
+            .filter(
+                ComunidadesRonda.torneo_id == torneo.id,
+                ComunidadesRonda.numero == ronda_numero - 1,
+            )
+            .one_or_none()
+        )
+        if ronda_anterior is None:
+            _error_generacion(
+                "RONDA_ANTERIOR_INEXISTENTE",
+                f"No existe la ronda {ronda_numero - 1}.",
+            )
+        if ronda_anterior.estado != "CERRADA":
+            _error_generacion(
+                "RONDA_ANTERIOR_NO_CERRADA",
+                f"La ronda {ronda_numero - 1} no está cerrada.",
+            )
+
+    equipos = (
+        session.query(ComunidadesEquipo)
+        .filter(ComunidadesEquipo.torneo_id == torneo.id)
+        .with_for_update()
+        .all()
+    )
+    if not equipos:
+        _error_generacion("SIN_EQUIPOS", "El torneo no tiene equipos inscritos.")
+
+    # Se comprueba explícitamente para conservar la invariante incluso en bases
+    # creadas antes de los constraints actuales.
+    for equipo in equipos:
+        cantidad = (
+            session.query(ComunidadesMiembro)
+            .filter(ComunidadesMiembro.equipo_id == equipo.id)
+            .count()
+        )
+        if cantidad != 2:
+            _error_generacion(
+                "EQUIPO_INCOMPLETO",
+                f"El equipo {int(equipo.id)} debe tener exactamente dos miembros.",
+            )
+    return ronda_anterior
+
+
+def _guardar_traza_generacion(
+    session: Any,
+    torneo_id: int,
+    ronda_id: int,
+    pairings: list[PairingComunidades],
+    traza: TrazaPairingsComunidades,
+) -> None:
+    from GestorSQL import ComunidadesTrazaEmparejamiento
+
+    secuencia = 1
+    for intento in traza.get("intentos", []):
+        bye_id = intento.get("bye_equipo_id")
+        session.add(
+            ComunidadesTrazaEmparejamiento(
+                torneo_id=torneo_id,
+                ronda_id=ronda_id,
+                secuencia=secuencia,
+                etapa=intento["etapa"],
+                equipo_a_id=bye_id,
+                detalle=json.dumps(intento, ensure_ascii=False, default=str),
+            )
+        )
+        secuencia += 1
+
+    for pairing in pairings:
+        es_bye = bool(pairing["es_bye"])
+        detalle = {
+            "tipo": "BYE" if es_bye else "PAIRING",
+            "nivel_fallback": traza.get("nivel_fallback"),
+            "fallback_utilizado": traza.get("etapa"),
+            "mesa_numero": pairing["mesa_numero"],
+        }
+        session.add(
+            ComunidadesTrazaEmparejamiento(
+                torneo_id=torneo_id,
+                ronda_id=ronda_id,
+                secuencia=secuencia,
+                etapa="SELECCION_BYE" if es_bye else "SELECCION_FINAL",
+                equipo_a_id=pairing["equipo_a_id"],
+                equipo_b_id=pairing["equipo_b_id"],
+                diferencia_puntos=pairing["diferencia_puntos"],
+                es_mirror=pairing["es_mirror"],
+                es_rival_repetido=pairing["es_rival_repetido"],
+                prioridad_estado=pairing["prioridad_estado"],
+                detalle=json.dumps(detalle, ensure_ascii=False),
+            )
+        )
+        secuencia += 1
+
+
+def generar_ronda_comunidades(
+    session: Any,
+    torneo_id: int,
+    ronda_numero: int,
+    generada_por_discord_id: int,
+    rng: Any = None,
+    *,
+    on_enfrentamiento_persistido: Any = None,
+) -> dict[str, Any]:
+    """Genera y confirma una ronda completa sin realizar operaciones Discord.
+
+    El servicio es la frontera transaccional: confirma únicamente después de
+    crear ronda, enfrentamientos, dos fotografías por enfrentamiento, traza y
+    efectos del bye. Ante cualquier excepción revierte la sesión completa.
+    ``on_enfrentamiento_persistido`` permite instrumentar la operación y probar
+    fallos intermedios; se ejecuta después de cada enfrentamiento completo.
+    """
+    from GestorSQL import (
+        ComunidadesEnfrentamiento,
+        ComunidadesEquipo,
+        ComunidadesFotografiaEstado,
+        ComunidadesHistorialTransicion,
+        ComunidadesRonda,
+        ComunidadesTorneo,
+    )
+
+    try:
+        torneo = (
+            session.query(ComunidadesTorneo)
+            .filter(ComunidadesTorneo.id == torneo_id)
+            .with_for_update()
+            .one_or_none()
+        )
+        if torneo is None:
+            _error_generacion("TORNEO_INEXISTENTE", "El torneo no existe.")
+
+        ronda_anterior = _validar_generacion_ronda_comunidades(
+            session, torneo, ronda_numero
+        )
+        pairings, traza = generar_pairings_comunidades_backtracking(
+            session, torneo_id, ronda_numero, rng
+        )
+        if not pairings:
+            error = traza.get("error") or {}
+            _error_generacion(
+                error.get("codigo", "SIN_SOLUCION_COMPLETA"),
+                error.get("detalle", "No existe una solución completa."),
+            )
+
+        if ronda_numero == 1:
+            fecha_fin = torneo.fecha_fin_ronda1
+            fecha_inicio = fecha_fin - timedelta(days=int(torneo.dias_por_ronda))
+        else:
+            fecha_inicio = ronda_anterior.fecha_fin
+            fecha_fin = fecha_inicio + timedelta(days=int(torneo.dias_por_ronda))
+
+        ronda = ComunidadesRonda(
+            torneo_id=torneo_id,
+            numero=ronda_numero,
+            estado="ABIERTA",
+            fecha_inicio=fecha_inicio,
+            fecha_fin=fecha_fin,
+            generada_por_discord_id=generada_por_discord_id,
+        )
+        session.add(ronda)
+        session.flush()
+
+        equipos = {
+            int(equipo.id): equipo
+            for equipo in session.query(ComunidadesEquipo)
+            .filter(ComunidadesEquipo.torneo_id == torneo_id)
+            .with_for_update()
+            .all()
+        }
+        enfrentamiento_ids: list[int] = []
+        bye_equipo_id: Optional[int] = None
+
+        for pairing in pairings:
+            equipo_a = equipos[int(pairing["equipo_a_id"])]
+            if pairing["es_bye"]:
+                bye_equipo_id = int(equipo_a.id)
+                estado_anterior = equipo_a.estado_temporal
+                zombie_anterior = bool(equipo_a.es_zombie)
+                equipo_a.estado_temporal = EstadoTemporal.NEUTRO.value
+                equipo_a.cantidad_byes = int(equipo_a.cantidad_byes or 0) + 1
+                equipo_a.puntos_clasificacion = _decimal(
+                    equipo_a.puntos_clasificacion
+                ) + _decimal(torneo.puntos_clasificacion_bye)
+                session.add(
+                    ComunidadesHistorialTransicion(
+                        torneo_id=torneo_id,
+                        ronda_id=ronda.id,
+                        enfrentamiento_id=None,
+                        equipo_id=equipo_a.id,
+                        estado_temporal_anterior=estado_anterior,
+                        es_zombie_anterior=zombie_anterior,
+                        estado_temporal_posterior=EstadoTemporal.NEUTRO.value,
+                        es_zombie_posterior=zombie_anterior,
+                        motivo="BYE",
+                    )
+                )
+                continue
+
+            equipo_b = equipos[int(pairing["equipo_b_id"])]
+            enfrentamiento = ComunidadesEnfrentamiento(
+                torneo_id=torneo_id,
+                ronda_id=ronda.id,
+                mesa_numero=pairing["mesa_numero"],
+                equipo_a_id=equipo_a.id,
+                equipo_b_id=equipo_b.id,
+                estado="PENDIENTE_ELECCIONES",
+            )
+            session.add(enfrentamiento)
+            session.flush()
+            enfrentamiento_ids.append(int(enfrentamiento.id))
+
+            for equipo in (equipo_a, equipo_b):
+                session.add(
+                    ComunidadesFotografiaEstado(
+                        torneo_id=torneo_id,
+                        ronda_id=ronda.id,
+                        enfrentamiento_id=enfrentamiento.id,
+                        equipo_id=equipo.id,
+                        comunidad_id=equipo.comunidad_id,
+                        es_zombie=bool(equipo.es_zombie),
+                        estado_temporal=equipo.estado_temporal,
+                    )
+                )
+            session.flush()
+            if on_enfrentamiento_persistido is not None:
+                on_enfrentamiento_persistido(enfrentamiento)
+
+        _guardar_traza_generacion(session, torneo_id, ronda.id, pairings, traza)
+        if ronda_numero == 1:
+            torneo.estado = "EN_CURSO"
+
+        session.flush()
+        resultado = {
+            "torneo_id": int(torneo_id),
+            "ronda_id": int(ronda.id),
+            "ronda_numero": int(ronda_numero),
+            "enfrentamiento_ids": enfrentamiento_ids,
+            "bye_equipo_id": bye_equipo_id,
+            "nivel_fallback": traza.get("nivel_fallback"),
+            "etapa": traza.get("etapa"),
+        }
+        session.commit()
+        return resultado
+    except Exception:
+        session.rollback()
+        raise
 
 
 # Alias legible para consumidores que prefieran el orden verbo-ámbito-técnica.

--- a/tests/test_comunidades_generacion_ronda.py
+++ b/tests/test_comunidades_generacion_ronda.py
@@ -1,0 +1,263 @@
+import json
+import random
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from ComunidadesCore import (
+    ErrorGeneracionRondaComunidades,
+    generar_ronda_comunidades,
+)
+from GestorSQL import (
+    Base,
+    ComunidadesComunidad,
+    ComunidadesEnfrentamiento,
+    ComunidadesEquipo,
+    ComunidadesFotografiaEstado,
+    ComunidadesHistorialTransicion,
+    ComunidadesMiembro,
+    ComunidadesRonda,
+    ComunidadesTorneo,
+    ComunidadesTrazaEmparejamiento,
+    Usuario,
+)
+
+
+def _session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _foreign_keys(dbapi_connection, _):
+        dbapi_connection.execute("PRAGMA foreign_keys=ON")
+
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def _torneo(session, rondas=3):
+    torneo = ComunidadesTorneo(
+        nombre="Comunidades",
+        rondas_totales=rondas,
+        fecha_fin_ronda1=datetime(2026, 7, 8),
+        dias_por_ronda=7,
+        puntos_clasificacion_bye=Decimal("1.50"),
+        plantilla_mensaje_ronda1="R1",
+        plantilla_mensaje_rondas_siguientes="R{ronda}",
+        creado_por_discord_id=1,
+    )
+    session.add(torneo)
+    session.flush()
+    return torneo
+
+
+def _equipo(
+    session,
+    torneo,
+    equipo_id,
+    comunidad_nombre,
+    *,
+    estado="NEUTRO",
+    zombie=False,
+    razas=("Humanos", "Orcos"),
+):
+    comunidad = ComunidadesComunidad(
+        torneo_id=torneo.id, nombre=comunidad_nombre
+    )
+    session.add(comunidad)
+    session.flush()
+    equipo = ComunidadesEquipo(
+        id=equipo_id,
+        torneo_id=torneo.id,
+        comunidad_id=comunidad.id,
+        nombre=f"Equipo {equipo_id}",
+        estado_temporal=estado,
+        es_zombie=zombie,
+    )
+    session.add(equipo)
+    session.flush()
+    for posicion, raza in enumerate(razas, start=1):
+        usuario_id = equipo_id * 10 + posicion
+        usuario = Usuario(idUsuarios=usuario_id, nombre_discord=f"U{usuario_id}")
+        session.add(usuario)
+        session.flush()
+        session.add(
+            ComunidadesMiembro(
+                torneo_id=torneo.id,
+                equipo_id=equipo.id,
+                usuario_id=usuario.idUsuarios,
+                posicion=posicion,
+                raza=raza,
+            )
+        )
+    session.flush()
+    return equipo
+
+
+def test_genera_ronda_completa_con_fotografias_traza_e_inicio_del_torneo():
+    session = _session()
+    torneo = _torneo(session)
+    equipos = [
+        _equipo(session, torneo, 1, "A", estado="CAZADOR", razas=("R1", "R2")),
+        _equipo(session, torneo, 2, "B", estado="HERIDO", razas=("R3", "R4")),
+        _equipo(session, torneo, 3, "C", estado="CAZADOR_Z", razas=("R5", "R6")),
+        _equipo(
+            session, torneo, 4, "D", estado="HERIDO", zombie=True, razas=("R7", "R8")
+        ),
+    ]
+    session.commit()
+
+    resultado = generar_ronda_comunidades(
+        session, torneo.id, 1, 99, random.Random(4)
+    )
+
+    ronda = session.get(ComunidadesRonda, resultado["ronda_id"])
+    enfrentamientos = session.query(ComunidadesEnfrentamiento).all()
+    fotografias = session.query(ComunidadesFotografiaEstado).all()
+    assert ronda.estado == "ABIERTA"
+    assert ronda.fecha_inicio == datetime(2026, 7, 1)
+    assert ronda.fecha_fin == datetime(2026, 7, 8)
+    assert session.get(ComunidadesTorneo, torneo.id).estado == "EN_CURSO"
+    assert len(enfrentamientos) == 2
+    assert len(fotografias) == 4
+    assert all(len(enfrentamiento.fotografias_estado) == 2 for enfrentamiento in enfrentamientos)
+
+    fotografias_iniciales = {
+        foto.equipo_id: (foto.estado_temporal, foto.es_zombie, foto.comunidad_id)
+        for foto in fotografias
+    }
+    equipos[0].estado_temporal = "NEUTRO"
+    equipos[1].es_zombie = True
+    session.commit()
+    session.expire_all()
+    assert {
+        foto.equipo_id: (foto.estado_temporal, foto.es_zombie, foto.comunidad_id)
+        for foto in session.query(ComunidadesFotografiaEstado).all()
+    } == fotografias_iniciales
+
+    finales = (
+        session.query(ComunidadesTrazaEmparejamiento)
+        .filter(ComunidadesTrazaEmparejamiento.etapa == "SELECCION_FINAL")
+        .all()
+    )
+    assert len(finales) == 2
+    assert all(json.loads(fila.detalle)["fallback_utilizado"] == "BASE" for fila in finales)
+
+
+def test_bye_se_resuelve_aplica_puntos_limpia_temporal_y_conserva_zombie():
+    session = _session()
+    torneo = _torneo(session)
+    bye = _equipo(session, torneo, 1, "A", zombie=True)
+    _equipo(session, torneo, 2, "B", estado="CAZADOR")
+    _equipo(session, torneo, 3, "C", estado="HERIDO")
+    session.commit()
+
+    resultado = generar_ronda_comunidades(
+        session, torneo.id, 1, 99, random.Random(7)
+    )
+
+    assert resultado["bye_equipo_id"] == bye.id
+    bye_actual = session.get(ComunidadesEquipo, bye.id)
+    assert bye_actual.estado_temporal == "NEUTRO"
+    assert bye_actual.es_zombie is True
+    assert bye_actual.cantidad_byes == 1
+    assert bye_actual.puntos_clasificacion == Decimal("1.50")
+    transicion = session.query(ComunidadesHistorialTransicion).one()
+    assert transicion.motivo == "BYE"
+    assert transicion.enfrentamiento_id is None
+    assert transicion.es_zombie_anterior is True
+    assert transicion.es_zombie_posterior is True
+    assert transicion.estado_temporal_posterior == "NEUTRO"
+    assert session.query(ComunidadesEnfrentamiento).count() == 1
+    assert session.query(ComunidadesFotografiaEstado).count() == 2
+
+
+def test_fallo_intermedio_revierte_ronda_enfrentamientos_fotos_traza_y_estado():
+    session = _session()
+    torneo = _torneo(session)
+    for equipo_id, comunidad in enumerate(("A", "B", "C", "D"), start=1):
+        _equipo(session, torneo, equipo_id, comunidad)
+    session.commit()
+
+    def fallar(_):
+        raise RuntimeError("fallo simulado")
+
+    with pytest.raises(RuntimeError, match="fallo simulado"):
+        generar_ronda_comunidades(
+            session,
+            torneo.id,
+            1,
+            99,
+            random.Random(3),
+            on_enfrentamiento_persistido=fallar,
+        )
+
+    assert session.query(ComunidadesRonda).count() == 0
+    assert session.query(ComunidadesEnfrentamiento).count() == 0
+    assert session.query(ComunidadesFotografiaEstado).count() == 0
+    assert session.query(ComunidadesTrazaEmparejamiento).count() == 0
+    assert session.get(ComunidadesTorneo, torneo.id).estado == "CREADO"
+
+
+def test_rechaza_ronda_duplicada_sin_alterar_la_generada():
+    session = _session()
+    torneo = _torneo(session)
+    _equipo(session, torneo, 1, "A")
+    _equipo(session, torneo, 2, "B")
+    session.commit()
+    generar_ronda_comunidades(session, torneo.id, 1, 99, random.Random(1))
+
+    with pytest.raises(ErrorGeneracionRondaComunidades) as error:
+        generar_ronda_comunidades(session, torneo.id, 1, 99, random.Random(1))
+
+    assert error.value.codigo == "RONDA_DUPLICADA"
+    assert session.query(ComunidadesRonda).count() == 1
+    assert session.query(ComunidadesEnfrentamiento).count() == 1
+    assert session.query(ComunidadesFotografiaEstado).count() == 2
+
+
+def test_traza_persistida_identifica_el_fallback_utilizado():
+    session = _session()
+    torneo = _torneo(session)
+    _equipo(session, torneo, 1, "A", razas=("Orcos", "Skaven"))
+    _equipo(session, torneo, 2, "B", razas=("Humanos", "Skaven"))
+    session.commit()
+
+    resultado = generar_ronda_comunidades(
+        session, torneo.id, 1, 99, random.Random(1)
+    )
+
+    assert resultado["etapa"] == "PERMITIR_MIRRORS"
+    trazas = session.query(ComunidadesTrazaEmparejamiento).order_by(
+        ComunidadesTrazaEmparejamiento.secuencia
+    ).all()
+    assert [traza.etapa for traza in trazas[:2]] == ["BASE", "PERMITIR_MIRRORS"]
+    seleccion = trazas[-1]
+    assert seleccion.etapa == "SELECCION_FINAL"
+    assert json.loads(seleccion.detalle)["fallback_utilizado"] == "PERMITIR_MIRRORS"
+
+
+def test_valida_numero_y_no_permite_otra_ronda_mientras_hay_una_abierta():
+    session = _session()
+    torneo = _torneo(session, rondas=2)
+    _equipo(session, torneo, 1, "A")
+    _equipo(session, torneo, 2, "B")
+    session.commit()
+
+    with pytest.raises(ErrorGeneracionRondaComunidades) as numero_error:
+        generar_ronda_comunidades(session, torneo.id, 3, 99, random.Random(1))
+    assert numero_error.value.codigo == "NUMERO_RONDA_INVALIDO"
+    assert session.query(ComunidadesRonda).count() == 0
+
+    generar_ronda_comunidades(session, torneo.id, 1, 99, random.Random(1))
+    with pytest.raises(ErrorGeneracionRondaComunidades) as abierta_error:
+        generar_ronda_comunidades(session, torneo.id, 2, 99, random.Random(1))
+    assert abierta_error.value.codigo == "RONDA_ABIERTA_INCOMPATIBLE"
+    assert session.query(ComunidadesRonda).count() == 1


### PR DESCRIPTION
### Motivation
- Garantizar que la salida del motor de pairings se materialice en registros de base de datos consistentes y atómicos, preservando fotografías inmutables antes de cualquier transferencia o resultado. 
- Aplicar inmediatamente los efectos del `bye`, marcar el torneo `EN_CURSO` al generar la ronda 1 y evitar rondas parcialmente persistidas o duplicadas.

### Description
- Añadido un servicio de aplicación `generar_ronda_comunidades(session, torneo_id, ronda_numero, generada_por_discord_id, ...)` que valida condiciones previas y persiste la ronda, enfrentamientos, dos fotografías por enfrentamiento, trazas y efectos de bye en una sola transacción; la operación hace `commit` solo si todo se completa y hace `rollback` ante cualquier error. (`ComunidadesCore.py`) 
- Implementadas validaciones de existencia de torneo, rango de ronda, duplicados, incompatibilidad con rondas abiertas, estado del torneo y que cada equipo tenga exactamente dos miembros; devuelve errores funcionales estructurados (`ErrorGeneracionRondaComunidades`). (`ComunidadesCore.py`) 
- Persistida la traza del algoritmo de pairings (intentos y selección final) con detalle del fallback utilizado, y almacenamiento de fotografías inmutables (`ComunidadesTrazaEmparejamiento`, `ComunidadesFotografiaEstado`). (`ComunidadesCore.py`) 
- Aplicados los efectos inmediatos del `bye`: aumento de `cantidad_byes`, suma de puntos de clasificación de `bye`, limpieza del estado temporal a `NEUTRO` conservando la condición `es_zombie`, y registro en `ComunidadesHistorialTransicion`. (`ComunidadesCore.py`) 
- Al generarse la ronda 1 correctamente, el torneo se marca `EN_CURSO`; la implementación evita cualquier dependencia de Discord para facilitar pruebas y recuperación. (`ComunidadesCore.py`) 
- Añadido conjunto de pruebas de aceptación y casos transaccionales en `tests/test_comunidades_generacion_ronda.py` que cubren generación completa, fotografías inmutables, bye, rollback ante fallo intermedio, rechazo de ronda duplicada y trazabilidad de fallback. (`tests/test_comunidades_generacion_ronda.py`) 

### Testing
- Se ejecutaron las pruebas de aceptación nuevas con `PYTHONPATH=. pytest -q tests/test_comunidades_generacion_ronda.py` y pasaron (6 tests OK). 
- Se ejecutó la suite completa con `PYTHONPATH=. pytest -q` y todas las pruebas existentes pasaron (383 passed, con warnings deprecación no relacionados). 
- Se verificó la compilación de los módulos relevantes con `python -m py_compile` y se comprobaron diferencias estáticas (`git diff --check`) sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a249ff45f0c832a8b7d1cb6034c1fb5)