### PR TITLE
Communities tournament: core config, Discord commands, parsers and tests

### DIFF
--- a/ComunidadesConstantes.py
+++ b/ComunidadesConstantes.py
@@ -156,6 +156,13 @@ EMOJIS_ESTADO_TEMPORAL = {
 
 LIMITE_CANALES_POR_CATEGORIA = 40
 
+# Las plantillas son obligatorias en el esquema, pero en la v1 se configuran
+# directamente en base de datos después de crear el torneo.
+PLANTILLA_RONDA1_PENDIENTE = "PENDIENTE_CONFIGURACION_BD_MENSAJE_INICIAL"
+PLANTILLA_RONDAS_SIGUIENTES_PENDIENTE = (
+    "PENDIENTE_CONFIGURACION_BD_MENSAJES_SUBSIGUIENTES"
+)
+
 
 def validar_raza(raza):
     """Indica si ``raza`` coincide exactamente con un nombre canónico."""

--- a/ComunidadesCore.py
+++ b/ComunidadesCore.py
@@ -6,7 +6,7 @@ recibida, sin depender de los modelos del torneo suizo individual.
 """
 
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
 from decimal import Decimal, InvalidOperation
 import json
 from enum import Enum
@@ -18,7 +18,151 @@ from ComunidadesConstantes import (
     ESTADO_TEMPORAL_CAZADOR_Z,
     ESTADO_TEMPORAL_HERIDO,
     ESTADO_TEMPORAL_NEUTRO,
+    PLANTILLA_RONDA1_PENDIENTE,
+    PLANTILLA_RONDAS_SIGUIENTES_PENDIENTE,
+    TORNEO_CREADO,
+    validar_puntuacion,
 )
+
+
+class ErrorConfiguracionComunidades(ValueError):
+    """Error de dominio legible para configurar un torneo de comunidades."""
+
+    def __init__(self, codigo: str, detalle: str):
+        super().__init__(detalle)
+        self.codigo = codigo
+        self.detalle = detalle
+
+
+def _error_configuracion(codigo: str, detalle: str) -> None:
+    raise ErrorConfiguracionComunidades(codigo, detalle)
+
+
+def _validar_entero_positivo(valor: object, nombre: str) -> int:
+    if type(valor) is not int or valor <= 0:
+        _error_configuracion("VALOR_INVALIDO", f"{nombre} debe ser un entero mayor que 0.")
+    return valor
+
+
+def _normalizar_puntuacion(valor: object, nombre: str) -> Decimal:
+    if not validar_puntuacion(valor):
+        _error_configuracion(
+            "PUNTUACION_INVALIDA",
+            f"{nombre} debe ser un decimal entre 0 y 9999.99 con un máximo de dos decimales.",
+        )
+    return Decimal(str(valor))
+
+
+def _obtener_torneo_configurable(session: Any, torneo_id: int):
+    from GestorSQL import ComunidadesTorneo
+
+    _validar_entero_positivo(torneo_id, "torneo_id")
+    torneo = session.query(ComunidadesTorneo).filter(ComunidadesTorneo.id == torneo_id).first()
+    if torneo is None:
+        _error_configuracion(
+            "TORNEO_NO_EXISTE", f"No existe un torneo de comunidades con ID {torneo_id}."
+        )
+    if torneo.estado != TORNEO_CREADO:
+        _error_configuracion(
+            "TORNEO_INICIADO",
+            "La configuración solo puede modificarse mientras el torneo está en estado CREADO.",
+        )
+    return torneo
+
+
+def crear_torneo_comunidades(
+    session: Any,
+    *,
+    nombre: str,
+    rondas_totales: int,
+    fecha_fin_ronda1: datetime,
+    dias_por_ronda: int,
+    canal_hub_id: int,
+    creado_por_discord_id: int,
+):
+    """Crea, sin confirmar la transacción, un torneo con valores iniciales seguros."""
+    from GestorSQL import ComunidadesTorneo
+
+    if not isinstance(nombre, str) or not nombre.strip():
+        _error_configuracion("NOMBRE_INVALIDO", "El nombre del torneo no puede estar vacío.")
+    nombre = nombre.strip()
+    if len(nombre) > 120:
+        _error_configuracion("NOMBRE_INVALIDO", "El nombre del torneo no puede superar 120 caracteres.")
+    _validar_entero_positivo(rondas_totales, "rondas_totales")
+    if not isinstance(fecha_fin_ronda1, datetime):
+        _error_configuracion("FECHA_INVALIDA", "fecha_fin_ronda1 debe ser una fecha y hora válidas.")
+    _validar_entero_positivo(dias_por_ronda, "dias_por_ronda")
+    _validar_entero_positivo(canal_hub_id, "canal_hub_id")
+    _validar_entero_positivo(creado_por_discord_id, "creado_por_discord_id")
+
+    torneo = ComunidadesTorneo(
+        nombre=nombre,
+        estado=TORNEO_CREADO,
+        rondas_totales=rondas_totales,
+        fecha_fin_ronda1=fecha_fin_ronda1,
+        dias_por_ronda=dias_por_ronda,
+        canal_hub_id=canal_hub_id,
+        plantilla_mensaje_ronda1=PLANTILLA_RONDA1_PENDIENTE,
+        plantilla_mensaje_rondas_siguientes=PLANTILLA_RONDAS_SIGUIENTES_PENDIENTE,
+        creado_por_discord_id=creado_por_discord_id,
+    )
+    session.add(torneo)
+    session.flush()
+    return torneo
+
+
+def configurar_competicion_comunidades(session: Any, *, torneo_id: int, id_competicion_bbowl: str):
+    """Guarda el ID de competición mientras el torneo siga sin iniciar."""
+    torneo = _obtener_torneo_configurable(session, torneo_id)
+    valor = str(id_competicion_bbowl).strip() if id_competicion_bbowl is not None else ""
+    if not valor or len(valor) > 45:
+        _error_configuracion(
+            "COMPETICION_INVALIDA",
+            "idCompBbowl debe tener entre 1 y 45 caracteres.",
+        )
+    torneo.id_competicion_bbowl = valor
+    session.flush()
+    return torneo
+
+
+def configurar_puntos_equipo_comunidades(
+    session: Any, *, torneo_id: int, victoria: object, empate: object, derrota: object, bye: object
+):
+    """Configura exclusivamente la puntuación de clasificación por equipos."""
+    torneo = _obtener_torneo_configurable(session, torneo_id)
+    valores = {
+        "victoria": _normalizar_puntuacion(victoria, "win"),
+        "empate": _normalizar_puntuacion(empate, "draw"),
+        "derrota": _normalizar_puntuacion(derrota, "loss"),
+        "bye": _normalizar_puntuacion(bye, "bye"),
+    }
+    if not valores["victoria"] > valores["empate"] >= valores["derrota"]:
+        _error_configuracion("PUNTUACION_INVALIDA", "Debe cumplirse win > draw >= loss.")
+    torneo.puntos_clasificacion_victoria = valores["victoria"]
+    torneo.puntos_clasificacion_empate = valores["empate"]
+    torneo.puntos_clasificacion_derrota = valores["derrota"]
+    torneo.puntos_clasificacion_bye = valores["bye"]
+    session.flush()
+    return torneo
+
+
+def configurar_puntos_individuales_comunidades(
+    session: Any, *, torneo_id: int, victoria: object, empate: object, derrota: object
+):
+    """Configura exclusivamente los puntos internos de los partidos BO1."""
+    torneo = _obtener_torneo_configurable(session, torneo_id)
+    valores = {
+        "victoria": _normalizar_puntuacion(victoria, "win"),
+        "empate": _normalizar_puntuacion(empate, "draw"),
+        "derrota": _normalizar_puntuacion(derrota, "loss"),
+    }
+    if not valores["victoria"] > valores["empate"] >= valores["derrota"]:
+        _error_configuracion("PUNTUACION_INVALIDA", "Debe cumplirse win > draw >= loss.")
+    torneo.puntos_individuales_victoria = valores["victoria"]
+    torneo.puntos_individuales_empate = valores["empate"]
+    torneo.puntos_individuales_derrota = valores["derrota"]
+    session.flush()
+    return torneo
 
 
 class Equipo(str, Enum):

--- a/ComunidadesDiscord.py
+++ b/ComunidadesDiscord.py
@@ -1,0 +1,24 @@
+"""Parsing de argumentos Discord para los comandos del torneo de comunidades."""
+
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+
+
+def parsear_fecha_limite(fecha: str, hora: str) -> datetime:
+    """Convierte exclusivamente ``YYYY-MM-DD HH:MM`` a ``datetime``."""
+    texto = f"{fecha} {hora}"
+    try:
+        resultado = datetime.strptime(texto, "%Y-%m-%d %H:%M")
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Usa el formato de fecha y hora `YYYY-MM-DD HH:MM`.") from exc
+    if resultado.strftime("%Y-%m-%d %H:%M") != texto:
+        raise ValueError("Usa el formato de fecha y hora `YYYY-MM-DD HH:MM`.")
+    return resultado
+
+
+def parsear_decimal(valor: str, nombre: str) -> Decimal:
+    """Convierte un argumento en Decimal; las reglas de negocio se validan en core."""
+    try:
+        return Decimal(valor)
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise ValueError(f"`{nombre}` debe ser un número decimal válido.") from exc

--- a/DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES.md
+++ b/DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES.md
@@ -338,6 +338,8 @@ Argumentos:
 
 El torneo se crea en estado `CREADO`. La creación no exige informar todavía el ID de competición de Blood Bowl.
 
+Como los dos campos de plantilla son obligatorios, el sistema los inicializa con valores técnicos pendientes de configuración. El mensaje de confirmación recuerda que, antes de generar la ronda 1, deben rellenarse directamente en base de datos `plantilla_mensaje_ronda1` y `plantilla_mensaje_rondas_siguientes`. En la v1 no existe un comando para editar estas plantillas.
+
 ### 6.2. Configurar competición de Blood Bowl
 
 ```text
@@ -373,6 +375,8 @@ Ejemplo:
 ```
 
 Estos valores solo se suman para decidir qué equipo ganó el enfrentamiento. No se publican como puntos de clasificación individual.
+
+Las dos configuraciones de puntuación solo pueden modificarse mientras el torneo esté en estado `CREADO`. Una vez iniciada la ronda 1, cualquier intento debe rechazarse sin alterar los valores persistidos.
 
 ### 6.5. Añadir comunidad
 

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -52,6 +52,14 @@ from SuizoCore import (
     procesar_cierre_ronda_si_corresponde,
     obtener_raza_suizo_o_usuario,
 )
+from ComunidadesCore import (
+    ErrorConfiguracionComunidades,
+    configurar_competicion_comunidades,
+    configurar_puntos_equipo_comunidades,
+    configurar_puntos_individuales_comunidades,
+    crear_torneo_comunidades,
+)
+from ComunidadesDiscord import parsear_decimal, parsear_fecha_limite
 
 
 # Cargar las variables de entorno desde .env
@@ -4192,6 +4200,164 @@ async def crear_peticiones_razas(ctx):
         await ctx.send(f"Error al crear el mensaje de peticiones de razas: {e}")
     finally:
         session.close()
+
+
+async def _ejecutar_configuracion_comunidades(ctx, operacion, mensaje_error: str):
+    Session = sessionmaker(bind=GestorSQL.conexionEngine())
+    session = Session()
+    try:
+        resultado = operacion(session)
+        session.commit()
+        session.refresh(resultado)
+        return resultado
+    except ErrorConfiguracionComunidades as exc:
+        session.rollback()
+        await ctx.send(f"❌ {exc.detalle}")
+    except Exception as exc:
+        session.rollback()
+        await ctx.send(f"❌ {mensaje_error}: {exc}")
+    finally:
+        session.close()
+    return None
+
+
+@bot.command(name="comunidades_crear")
+async def comunidades_crear(
+    ctx,
+    nombre: str,
+    rondas: int,
+    fecha_fin: str,
+    hora_fin: str,
+    dias_por_ronda: int,
+    canal_hub_id: int,
+):
+    if not es_comisario(ctx):
+        await ctx.send("No tienes permiso. Este comando es exclusivo para Comisario.")
+        return
+
+    try:
+        fecha_fin_ronda1 = parsear_fecha_limite(fecha_fin, hora_fin)
+    except ValueError as exc:
+        await ctx.send(f"❌ Fecha inválida. {exc}")
+        return
+
+    torneo = await _ejecutar_configuracion_comunidades(
+        ctx,
+        lambda session: crear_torneo_comunidades(
+            session,
+            nombre=nombre,
+            rondas_totales=rondas,
+            fecha_fin_ronda1=fecha_fin_ronda1,
+            dias_por_ronda=dias_por_ronda,
+            canal_hub_id=canal_hub_id,
+            creado_por_discord_id=ctx.author.id,
+        ),
+        "No se pudo crear el torneo de comunidades",
+    )
+    if torneo is None:
+        return
+
+    await ctx.send(
+        "✅ Torneo de comunidades creado correctamente en estado `CREADO`.\n"
+        f"ID torneo: **{torneo.id}** | Nombre: **{torneo.nombre}**\n"
+        f"Rondas: **{torneo.rondas_totales}** | Fin ronda 1: "
+        f"**{torneo.fecha_fin_ronda1.strftime('%Y-%m-%d %H:%M')}** | "
+        f"Días por ronda: **{torneo.dias_por_ronda}**\n"
+        f"Canal hub: **{torneo.canal_hub_id}**\n"
+        "⚠️ Antes de generar la ronda 1, rellena directamente en BD "
+        "`plantilla_mensaje_ronda1` y `plantilla_mensaje_rondas_siguientes`. "
+        "En esta versión no existe un comando para editarlas."
+    )
+
+
+@bot.command(name="comunidades_set_competicion")
+async def comunidades_set_competicion(ctx, torneo_id: int, idCompBbowl: str):
+    if not es_comisario(ctx):
+        await ctx.send("No tienes permiso. Este comando es exclusivo para Comisario.")
+        return
+
+    torneo = await _ejecutar_configuracion_comunidades(
+        ctx,
+        lambda session: configurar_competicion_comunidades(
+            session, torneo_id=torneo_id, id_competicion_bbowl=idCompBbowl
+        ),
+        "No se pudo configurar la competición de Blood Bowl",
+    )
+    if torneo is not None:
+        await ctx.send(
+            "✅ Competición de Blood Bowl configurada.\n"
+            f"Torneo ID: **{torneo.id}** | idCompBbowl: **{torneo.id_competicion_bbowl}**"
+        )
+
+
+@bot.command(name="comunidades_set_puntos_equipo")
+async def comunidades_set_puntos_equipo(
+    ctx, torneo_id: int, win: str, draw: str, loss: str, bye: str
+):
+    if not es_comisario(ctx):
+        await ctx.send("No tienes permiso. Este comando es exclusivo para Comisario.")
+        return
+
+    try:
+        valores = {
+            "victoria": parsear_decimal(win, "win"),
+            "empate": parsear_decimal(draw, "draw"),
+            "derrota": parsear_decimal(loss, "loss"),
+            "bye": parsear_decimal(bye, "bye"),
+        }
+    except ValueError as exc:
+        await ctx.send(f"❌ {exc}")
+        return
+
+    torneo = await _ejecutar_configuracion_comunidades(
+        ctx,
+        lambda session: configurar_puntos_equipo_comunidades(
+            session, torneo_id=torneo_id, **valores
+        ),
+        "No se pudo configurar la puntuación por equipos",
+    )
+    if torneo is not None:
+        await ctx.send(
+            "✅ Puntuación por equipos configurada.\n"
+            f"win: **{torneo.puntos_clasificacion_victoria}** | "
+            f"draw: **{torneo.puntos_clasificacion_empate}** | "
+            f"loss: **{torneo.puntos_clasificacion_derrota}** | "
+            f"bye: **{torneo.puntos_clasificacion_bye}**"
+        )
+
+
+@bot.command(name="comunidades_set_puntos_individuales")
+async def comunidades_set_puntos_individuales(
+    ctx, torneo_id: int, win: str, draw: str, loss: str
+):
+    if not es_comisario(ctx):
+        await ctx.send("No tienes permiso. Este comando es exclusivo para Comisario.")
+        return
+
+    try:
+        valores = {
+            "victoria": parsear_decimal(win, "win"),
+            "empate": parsear_decimal(draw, "draw"),
+            "derrota": parsear_decimal(loss, "loss"),
+        }
+    except ValueError as exc:
+        await ctx.send(f"❌ {exc}")
+        return
+
+    torneo = await _ejecutar_configuracion_comunidades(
+        ctx,
+        lambda session: configurar_puntos_individuales_comunidades(
+            session, torneo_id=torneo_id, **valores
+        ),
+        "No se pudo configurar la puntuación individual",
+    )
+    if torneo is not None:
+        await ctx.send(
+            "✅ Puntuación individual configurada.\n"
+            f"win: **{torneo.puntos_individuales_victoria}** | "
+            f"draw: **{torneo.puntos_individuales_empate}** | "
+            f"loss: **{torneo.puntos_individuales_derrota}**"
+        )
 
 
 @bot.command(name="suizo_crear")

--- a/tests/test_comunidades_configuracion.py
+++ b/tests/test_comunidades_configuracion.py
@@ -1,0 +1,230 @@
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from ComunidadesConstantes import (
+    PLANTILLA_RONDA1_PENDIENTE,
+    PLANTILLA_RONDAS_SIGUIENTES_PENDIENTE,
+)
+from ComunidadesCore import (
+    ErrorConfiguracionComunidades,
+    configurar_competicion_comunidades,
+    configurar_puntos_equipo_comunidades,
+    configurar_puntos_individuales_comunidades,
+    crear_torneo_comunidades,
+)
+from ComunidadesDiscord import parsear_decimal, parsear_fecha_limite
+from GestorSQL import Base, ComunidadesTorneo
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def _crear(session):
+    return crear_torneo_comunidades(
+        session,
+        nombre="Copa de Comunidades",
+        rondas_totales=5,
+        fecha_fin_ronda1=datetime(2026, 7, 1, 23, 59),
+        dias_por_ronda=7,
+        canal_hub_id=1497290209505710120,
+        creado_por_discord_id=123,
+    )
+
+
+def test_crea_torneo_en_estado_creado_con_plantillas_pendientes():
+    with _session() as session:
+        torneo = _crear(session)
+        session.commit()
+
+        guardado = session.get(ComunidadesTorneo, torneo.id)
+        assert guardado.estado == "CREADO"
+        assert guardado.rondas_totales == 5
+        assert guardado.dias_por_ronda == 7
+        assert guardado.id_competicion_bbowl is None
+        assert guardado.plantilla_mensaje_ronda1 == PLANTILLA_RONDA1_PENDIENTE
+        assert (
+            guardado.plantilla_mensaje_rondas_siguientes
+            == PLANTILLA_RONDAS_SIGUIENTES_PENDIENTE
+        )
+
+
+@pytest.mark.parametrize("campo,valor", [("rondas_totales", 0), ("rondas_totales", -1), ("dias_por_ronda", 0), ("dias_por_ronda", -2)])
+def test_rechaza_rondas_y_dias_invalidos(campo, valor):
+    argumentos = {
+        "nombre": "Copa",
+        "rondas_totales": 5,
+        "fecha_fin_ronda1": datetime(2026, 7, 1, 23, 59),
+        "dias_por_ronda": 7,
+        "canal_hub_id": 10,
+        "creado_por_discord_id": 20,
+    }
+    argumentos[campo] = valor
+    with _session() as session, pytest.raises(ErrorConfiguracionComunidades):
+        crear_torneo_comunidades(session, **argumentos)
+
+
+@pytest.mark.parametrize(
+    "fecha,hora",
+    [
+        ("2026-02-30", "23:59"),
+        ("2026-7-01", "23:59"),
+        ("2026-07-01", "3:05"),
+        ("01-07-2026", "23:59"),
+        ("2026-07-01", "24:00"),
+    ],
+)
+def test_parsear_fecha_rechaza_valores_invalidos_o_no_estrictos(fecha, hora):
+    with pytest.raises(ValueError, match="YYYY-MM-DD HH:MM"):
+        parsear_fecha_limite(fecha, hora)
+
+
+def test_parsear_fecha_acepta_formato_documentado():
+    assert parsear_fecha_limite("2026-07-01", "23:59") == datetime(2026, 7, 1, 23, 59)
+
+
+@pytest.mark.parametrize("valor", ["abc", "", None])
+def test_parsear_decimal_rechaza_textos_no_numericos(valor):
+    with pytest.raises(ValueError, match="decimal válido"):
+        parsear_decimal(valor, "win")
+
+
+@pytest.mark.parametrize("valor", ["NaN", "Infinity", "-1", "1.001", "10000"])
+def test_core_rechaza_decimales_fuera_del_dominio(valor):
+    with _session() as session:
+        torneo = _crear(session)
+        session.commit()
+        with pytest.raises(ErrorConfiguracionComunidades):
+            configurar_puntos_equipo_comunidades(
+                session,
+                torneo_id=torneo.id,
+                victoria=valor,
+                empate=Decimal("1"),
+                derrota=Decimal("0"),
+                bye=Decimal("1.5"),
+            )
+
+
+def test_guarda_las_dos_puntuaciones_sin_mezclarlas():
+    with _session() as session:
+        torneo = _crear(session)
+        session.commit()
+
+        configurar_puntos_equipo_comunidades(
+            session,
+            torneo_id=torneo.id,
+            victoria=Decimal("5"),
+            empate=Decimal("2"),
+            derrota=Decimal("1"),
+            bye=Decimal("2.5"),
+        )
+        configurar_puntos_individuales_comunidades(
+            session,
+            torneo_id=torneo.id,
+            victoria=Decimal("3"),
+            empate=Decimal("1"),
+            derrota=Decimal("0"),
+        )
+        session.commit()
+
+        guardado = session.get(ComunidadesTorneo, torneo.id)
+        assert (
+            guardado.puntos_clasificacion_victoria,
+            guardado.puntos_clasificacion_empate,
+            guardado.puntos_clasificacion_derrota,
+            guardado.puntos_clasificacion_bye,
+        ) == (Decimal("5.00"), Decimal("2.00"), Decimal("1.00"), Decimal("2.50"))
+        assert (
+            guardado.puntos_individuales_victoria,
+            guardado.puntos_individuales_empate,
+            guardado.puntos_individuales_derrota,
+        ) == (Decimal("3.00"), Decimal("1.00"), Decimal("0.00"))
+
+
+def test_configura_competicion_y_permite_reemplazarla_antes_del_inicio():
+    with _session() as session:
+        torneo = _crear(session)
+        session.commit()
+        configurar_competicion_comunidades(
+            session, torneo_id=torneo.id, id_competicion_bbowl="primera"
+        )
+        configurar_competicion_comunidades(
+            session, torneo_id=torneo.id, id_competicion_bbowl="segunda"
+        )
+        session.commit()
+        assert session.get(ComunidadesTorneo, torneo.id).id_competicion_bbowl == "segunda"
+
+
+@pytest.mark.parametrize("operacion", ["competicion", "equipos", "individuales"])
+def test_rechaza_cualquier_configuracion_despues_del_inicio_sin_modificarla(operacion):
+    with _session() as session:
+        torneo = _crear(session)
+        session.commit()
+        torneo.estado = "EN_CURSO"
+        session.commit()
+
+        valores_antes = (
+            torneo.id_competicion_bbowl,
+            torneo.puntos_clasificacion_victoria,
+            torneo.puntos_individuales_victoria,
+        )
+        with pytest.raises(ErrorConfiguracionComunidades, match="estado CREADO"):
+            if operacion == "competicion":
+                configurar_competicion_comunidades(
+                    session, torneo_id=torneo.id, id_competicion_bbowl="nueva"
+                )
+            elif operacion == "equipos":
+                configurar_puntos_equipo_comunidades(
+                    session, torneo_id=torneo.id, victoria=4, empate=2, derrota=0, bye=1
+                )
+            else:
+                configurar_puntos_individuales_comunidades(
+                    session, torneo_id=torneo.id, victoria=4, empate=2, derrota=0
+                )
+        session.rollback()
+        guardado = session.get(ComunidadesTorneo, torneo.id)
+        assert (
+            guardado.id_competicion_bbowl,
+            guardado.puntos_clasificacion_victoria,
+            guardado.puntos_individuales_victoria,
+        ) == valores_antes
+
+
+def test_error_en_puntuacion_no_deja_actualizacion_parcial():
+    with _session() as session:
+        torneo = _crear(session)
+        session.commit()
+        originales = (
+            torneo.puntos_clasificacion_victoria,
+            torneo.puntos_clasificacion_empate,
+            torneo.puntos_clasificacion_derrota,
+            torneo.puntos_clasificacion_bye,
+        )
+
+        with pytest.raises(ErrorConfiguracionComunidades):
+            configurar_puntos_equipo_comunidades(
+                session,
+                torneo_id=torneo.id,
+                victoria=Decimal("5"),
+                empate=Decimal("2"),
+                derrota=Decimal("1"),
+                bye=Decimal("1.001"),
+            )
+        session.rollback()
+        guardado = session.get(ComunidadesTorneo, torneo.id)
+        assert (
+            guardado.puntos_clasificacion_victoria,
+            guardado.puntos_clasificacion_empate,
+            guardado.puntos_clasificacion_derrota,
+            guardado.puntos_clasificacion_bye,
+        ) == originales


### PR DESCRIPTION
### Motivation

- Introduce server-side configuration primitives and safe defaults to create and configure "comunidades" tournaments from Discord while preventing invalid values and edits after the tournament starts.
- Provide small parsing helpers for Discord arguments and domain validation to ensure inputs conform to expected formats and numeric ranges.

### Description

- Add placeholder template constants `PLANTILLA_RONDA1_PENDIENTE` and `PLANTILLA_RONDAS_SIGUIENTES_PENDIENTE` to `ComunidadesConstantes.py` for DB-initialized templates.
- Implement `ComunidadesCore.py` which defines `ErrorConfiguracionComunidades`, validation helpers, and the configuration API functions `crear_torneo_comunidades`, `configurar_competicion_comunidades`, `configurar_puntos_equipo_comunidades`, and `configurar_puntos_individuales_comunidades` with transactional safety and domain checks.
- Add `ComunidadesDiscord.py` with `parsear_fecha_limite` and `parsear_decimal` to validate and convert command arguments from Discord.
- Wire the new functionality into `LombardBot.py` by registering Discord commands `!comunidades_crear`, `!comunidades_set_competicion`, `!comunidades_set_puntos_equipo`, and `!comunidades_set_puntos_individuales` and a helper `_ejecutar_configuracion_comunidades` to centralize error handling and commits.

### Testing

- Add comprehensive unit tests in `tests/test_comunidades_configuracion.py` that cover tournament creation, input parsing, numeric validation boundaries, configuration immutability after start, and transactional rollback on invalid updates.
- Ran `pytest -q tests/test_comunidades_configuracion.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24a1cdcc08832a90ce3dae36755dd1)