### PR TITLE
Añadir comandos de alta para torneos de comunidades

### DIFF
--- a/BD/comunidades_schema.sql
+++ b/BD/comunidades_schema.sql
@@ -9,6 +9,10 @@
 --   * cada equipo solo puede aparecer una vez por ronda, sin importar su lado;
 --   * las fechas y transiciones de estado deben respetar el ciclo del torneo.
 
+-- Los snowflakes de Discord superan el rango de INT; la tabla compartida de
+-- usuarios debe usar BIGINT antes de recibir altas automáticas de este formato.
+ALTER TABLE usuarios MODIFY COLUMN id_discord BIGINT NULL;
+
 CREATE TABLE IF NOT EXISTS comunidades_torneo (
   id INT AUTO_INCREMENT,
   nombre VARCHAR(120) NOT NULL,

--- a/ComunidadesCore.py
+++ b/ComunidadesCore.py
@@ -20,6 +20,7 @@ from ComunidadesConstantes import (
     ESTADO_TEMPORAL_NEUTRO,
     PLANTILLA_RONDA1_PENDIENTE,
     PLANTILLA_RONDAS_SIGUIENTES_PENDIENTE,
+    RAZAS_VALIDAS,
     TORNEO_CREADO,
     validar_puntuacion,
 )
@@ -109,6 +110,248 @@ def crear_torneo_comunidades(
     session.add(torneo)
     session.flush()
     return torneo
+
+
+def _validar_texto_alta(valor: object, nombre: str, longitud_maxima: int = 120) -> str:
+    if not isinstance(valor, str) or not valor.strip():
+        _error_configuracion("VALOR_INVALIDO", f"{nombre} no puede estar vacío.")
+    if valor != valor.strip():
+        _error_configuracion(
+            "VALOR_INVALIDO", f"{nombre} no puede tener espacios al principio o al final."
+        )
+    if len(valor) > longitud_maxima:
+        _error_configuracion(
+            "VALOR_INVALIDO", f"{nombre} no puede superar {longitud_maxima} caracteres."
+        )
+    return valor
+
+
+def _validar_discord_id(valor: object, nombre: str) -> int:
+    if type(valor) is not int or valor <= 0:
+        _error_configuracion("VALOR_INVALIDO", f"{nombre} debe ser un ID de Discord válido.")
+    return valor
+
+
+def anadir_comunidad_comunidades(session: Any, *, torneo_id: int, nombre: str):
+    """Añade una comunidad sin confirmar la transacción de la sesión."""
+    from GestorSQL import ComunidadesComunidad
+
+    torneo = _obtener_torneo_configurable(session, torneo_id)
+    nombre = _validar_texto_alta(nombre, "nombre")
+    duplicada = (
+        session.query(ComunidadesComunidad.id)
+        .filter(
+            ComunidadesComunidad.torneo_id == torneo.id,
+            ComunidadesComunidad.nombre == nombre,
+        )
+        .first()
+    )
+    if duplicada is not None:
+        _error_configuracion(
+            "COMUNIDAD_DUPLICADA",
+            f"La comunidad `{nombre}` ya existe en el torneo {torneo.id}.",
+        )
+
+    comunidad = ComunidadesComunidad(torneo_id=torneo.id, nombre=nombre)
+    session.add(comunidad)
+    session.flush()
+    return comunidad
+
+
+def _anadir_categoria_comunidades(
+    session: Any, *, torneo_id: int, categoria_discord_id: int, modelo: Any, tipo: str
+):
+    torneo = _obtener_torneo_configurable(session, torneo_id)
+    categoria_discord_id = _validar_discord_id(categoria_discord_id, "categoria_id")
+    duplicada = (
+        session.query(modelo.id)
+        .filter(
+            modelo.torneo_id == torneo.id,
+            modelo.categoria_discord_id == categoria_discord_id,
+        )
+        .first()
+    )
+    if duplicada is not None:
+        _error_configuracion(
+            "CATEGORIA_DUPLICADA",
+            f"La categoría de {tipo} {categoria_discord_id} ya está configurada en el torneo {torneo.id}.",
+        )
+
+    ultimo_orden = (
+        session.query(modelo.orden_alta)
+        .filter(modelo.torneo_id == torneo.id)
+        .order_by(modelo.orden_alta.desc())
+        .first()
+    )
+    categoria = modelo(
+        torneo_id=torneo.id,
+        categoria_discord_id=categoria_discord_id,
+        orden_alta=1 if ultimo_orden is None else ultimo_orden[0] + 1,
+    )
+    session.add(categoria)
+    session.flush()
+    return categoria
+
+
+def anadir_categoria_partidos_comunidades(
+    session: Any, *, torneo_id: int, categoria_discord_id: int
+):
+    """Añade una categoría de partidos conservando el orden de alta."""
+    from GestorSQL import ComunidadesCategoriaPartido
+
+    return _anadir_categoria_comunidades(
+        session,
+        torneo_id=torneo_id,
+        categoria_discord_id=categoria_discord_id,
+        modelo=ComunidadesCategoriaPartido,
+        tipo="partidos",
+    )
+
+
+def anadir_categoria_enfrentamientos_comunidades(
+    session: Any, *, torneo_id: int, categoria_discord_id: int
+):
+    """Añade una categoría de enfrentamientos conservando el orden de alta."""
+    from GestorSQL import ComunidadesCategoriaEnfrentamiento
+
+    return _anadir_categoria_comunidades(
+        session,
+        torneo_id=torneo_id,
+        categoria_discord_id=categoria_discord_id,
+        modelo=ComunidadesCategoriaEnfrentamiento,
+        tipo="enfrentamientos",
+    )
+
+
+def anadir_equipo_comunidades(
+    session: Any,
+    *,
+    torneo_id: int,
+    nombre: str,
+    comunidad_nombre: str,
+    jugador1_discord_id: int,
+    jugador1_nombre_discord: str,
+    raza1: str,
+    jugador2_discord_id: int,
+    jugador2_nombre_discord: str,
+    raza2: str,
+):
+    """Inscribe atómicamente un equipo y crea los usuarios que no existan.
+
+    La función hace ``flush`` para validar y devolver IDs, pero deja el ``commit``
+    o ``rollback`` al llamador, que actúa como frontera transaccional.
+    """
+    from GestorSQL import (
+        ComunidadesComunidad,
+        ComunidadesEquipo,
+        ComunidadesMiembro,
+        Usuario,
+    )
+
+    torneo = _obtener_torneo_configurable(session, torneo_id)
+    nombre = _validar_texto_alta(nombre, "nombre_equipo")
+    comunidad_nombre = _validar_texto_alta(comunidad_nombre, "comunidad")
+    jugador1_discord_id = _validar_discord_id(jugador1_discord_id, "jugador1")
+    jugador2_discord_id = _validar_discord_id(jugador2_discord_id, "jugador2")
+    jugador1_nombre_discord = _validar_texto_alta(
+        jugador1_nombre_discord, "nombre Discord del jugador 1", 255
+    )
+    jugador2_nombre_discord = _validar_texto_alta(
+        jugador2_nombre_discord, "nombre Discord del jugador 2", 255
+    )
+    if jugador1_discord_id == jugador2_discord_id:
+        _error_configuracion(
+            "MIEMBROS_REPETIDOS", "Un equipo debe contener dos usuarios distintos."
+        )
+    for raza, campo in ((raza1, "raza1"), (raza2, "raza2")):
+        if raza not in RAZAS_VALIDAS:
+            _error_configuracion(
+                "RAZA_INVALIDA",
+                f"{campo} debe coincidir exactamente con una raza válida: `{raza}` no es válida.",
+            )
+
+    comunidad = (
+        session.query(ComunidadesComunidad)
+        .filter(
+            ComunidadesComunidad.torneo_id == torneo.id,
+            ComunidadesComunidad.nombre == comunidad_nombre,
+        )
+        .first()
+    )
+    if comunidad is None:
+        _error_configuracion(
+            "COMUNIDAD_NO_EXISTE",
+            f"La comunidad `{comunidad_nombre}` no existe en el torneo {torneo.id}.",
+        )
+    if (
+        session.query(ComunidadesEquipo.id)
+        .filter(ComunidadesEquipo.torneo_id == torneo.id, ComunidadesEquipo.nombre == nombre)
+        .first()
+        is not None
+    ):
+        _error_configuracion(
+            "EQUIPO_DUPLICADO", f"El equipo `{nombre}` ya existe en el torneo {torneo.id}."
+        )
+
+    usuarios = []
+    for discord_id, nombre_discord in (
+        (jugador1_discord_id, jugador1_nombre_discord),
+        (jugador2_discord_id, jugador2_nombre_discord),
+    ):
+        usuario = session.query(Usuario).filter(Usuario.id_discord == discord_id).first()
+        if usuario is not None:
+            inscrito = (
+                session.query(ComunidadesMiembro.id)
+                .filter(
+                    ComunidadesMiembro.torneo_id == torneo.id,
+                    ComunidadesMiembro.usuario_id == usuario.idUsuarios,
+                )
+                .first()
+            )
+            if inscrito is not None:
+                _error_configuracion(
+                    "USUARIO_YA_INSCRITO",
+                    f"El usuario Discord {discord_id} ya pertenece a otro equipo del torneo {torneo.id}.",
+                )
+        usuarios.append((usuario, discord_id, nombre_discord))
+
+    for indice, (usuario, discord_id, nombre_discord) in enumerate(usuarios):
+        if usuario is None:
+            usuario = Usuario(
+                id_discord=discord_id,
+                nombre_discord=nombre_discord,
+                id_bloodbowl=None,
+                nombre_bloodbowl=None,
+            )
+            session.add(usuario)
+            session.flush()
+            usuarios[indice] = (usuario, discord_id, nombre_discord)
+
+    equipo = ComunidadesEquipo(
+        torneo_id=torneo.id, comunidad_id=comunidad.id, nombre=nombre
+    )
+    session.add(equipo)
+    session.flush()
+    session.add_all(
+        [
+            ComunidadesMiembro(
+                torneo_id=torneo.id,
+                equipo_id=equipo.id,
+                usuario_id=usuarios[0][0].idUsuarios,
+                raza=raza1,
+                posicion=1,
+            ),
+            ComunidadesMiembro(
+                torneo_id=torneo.id,
+                equipo_id=equipo.id,
+                usuario_id=usuarios[1][0].idUsuarios,
+                raza=raza2,
+                posicion=2,
+            ),
+        ]
+    )
+    session.flush()
+    return equipo
 
 
 def configurar_competicion_comunidades(session: Any, *, torneo_id: int, id_competicion_bbowl: str):

--- a/GestorSQL.py
+++ b/GestorSQL.py
@@ -17,7 +17,7 @@ class Usuario(Base):
     __tablename__ = 'usuarios'
     idUsuarios = Column(Integer, primary_key=True)
     nombre_discord = Column(String)
-    id_discord = Column(Integer)
+    id_discord = Column(BigInteger)
     nombre_bloodbowl = Column(String)
     id_bloodbowl = Column(Integer)
     jornada_actual = Column(Integer)

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -54,6 +54,10 @@ from SuizoCore import (
 )
 from ComunidadesCore import (
     ErrorConfiguracionComunidades,
+    anadir_categoria_enfrentamientos_comunidades,
+    anadir_categoria_partidos_comunidades,
+    anadir_comunidad_comunidades,
+    anadir_equipo_comunidades,
     configurar_competicion_comunidades,
     configurar_puntos_equipo_comunidades,
     configurar_puntos_individuales_comunidades,
@@ -4357,6 +4361,135 @@ async def comunidades_set_puntos_individuales(
             f"win: **{torneo.puntos_individuales_victoria}** | "
             f"draw: **{torneo.puntos_individuales_empate}** | "
             f"loss: **{torneo.puntos_individuales_derrota}**"
+        )
+
+
+def _categoria_del_guild(ctx, categoria_id: int):
+    if ctx.guild is None:
+        raise ValueError("Este comando solo puede ejecutarse dentro de un servidor.")
+    categoria = ctx.guild.get_channel(int(categoria_id))
+    if categoria is None:
+        raise ValueError(f"No existe un canal con ID {categoria_id} en este servidor.")
+    if not isinstance(categoria, discord.CategoryChannel):
+        raise ValueError(f"El canal {categoria_id} existe, pero no es una categoría de Discord.")
+    return categoria
+
+
+def _texto_discord_seguro(valor: object) -> str:
+    texto = discord.utils.escape_markdown(str(valor))
+    return discord.utils.escape_mentions(texto)
+
+
+@bot.command(name="comunidades_add_comunidad")
+async def comunidades_add_comunidad(ctx, torneo_id: int, *, nombre: str):
+    if not es_comisario(ctx):
+        await ctx.send("No tienes permiso. Este comando es exclusivo para Comisario.")
+        return
+
+    comunidad = await _ejecutar_configuracion_comunidades(
+        ctx,
+        lambda session: anadir_comunidad_comunidades(
+            session, torneo_id=torneo_id, nombre=nombre
+        ),
+        "No se pudo añadir la comunidad",
+    )
+    if comunidad is not None:
+        await ctx.send(
+            "✅ Comunidad añadida. "
+            f"Torneo ID: **{comunidad.torneo_id}** | "
+            f"Nombre: **{_texto_discord_seguro(comunidad.nombre)}**"
+        )
+
+
+async def _comunidades_add_categoria(ctx, torneo_id, categoria_id, servicio, tipo):
+    if not es_comisario(ctx):
+        await ctx.send("No tienes permiso. Este comando es exclusivo para Comisario.")
+        return
+    try:
+        categoria_discord = _categoria_del_guild(ctx, categoria_id)
+    except ValueError as exc:
+        await ctx.send(f"❌ {exc}")
+        return
+
+    categoria = await _ejecutar_configuracion_comunidades(
+        ctx,
+        lambda session: servicio(
+            session, torneo_id=torneo_id, categoria_discord_id=int(categoria_discord.id)
+        ),
+        f"No se pudo añadir la categoría de {tipo}",
+    )
+    if categoria is not None:
+        await ctx.send(
+            f"✅ Categoría de {tipo} añadida. "
+            f"Torneo ID: **{categoria.torneo_id}** | "
+            f"Categoría: **{_texto_discord_seguro(categoria_discord.name)}** "
+            f"(`{int(categoria_discord.id)}`) | Orden de alta: **{categoria.orden_alta}**"
+        )
+
+
+@bot.command(name="comunidades_add_categoria_partidos")
+async def comunidades_add_categoria_partidos(ctx, torneo_id: int, categoria_id: int):
+    await _comunidades_add_categoria(
+        ctx,
+        torneo_id,
+        categoria_id,
+        anadir_categoria_partidos_comunidades,
+        "partidos",
+    )
+
+
+@bot.command(name="comunidades_add_categoria_enfrentamientos")
+async def comunidades_add_categoria_enfrentamientos(
+    ctx, torneo_id: int, categoria_id: int
+):
+    await _comunidades_add_categoria(
+        ctx,
+        torneo_id,
+        categoria_id,
+        anadir_categoria_enfrentamientos_comunidades,
+        "enfrentamientos",
+    )
+
+
+@bot.command(name="comunidades_add_equipo")
+async def comunidades_add_equipo(
+    ctx,
+    torneo_id: int,
+    nombre_equipo: str,
+    comunidad: str,
+    jugador1: discord.Member,
+    raza1: str,
+    jugador2: discord.Member,
+    raza2: str,
+):
+    if not es_comisario(ctx):
+        await ctx.send("No tienes permiso. Este comando es exclusivo para Comisario.")
+        return
+
+    equipo = await _ejecutar_configuracion_comunidades(
+        ctx,
+        lambda session: anadir_equipo_comunidades(
+            session,
+            torneo_id=torneo_id,
+            nombre=nombre_equipo,
+            comunidad_nombre=comunidad,
+            jugador1_discord_id=int(jugador1.id),
+            jugador1_nombre_discord=jugador1.display_name,
+            raza1=raza1,
+            jugador2_discord_id=int(jugador2.id),
+            jugador2_nombre_discord=jugador2.display_name,
+            raza2=raza2,
+        ),
+        "No se pudo añadir el equipo",
+    )
+    if equipo is not None:
+        await ctx.send(
+            "✅ Equipo creado correctamente.\n"
+            f"ID: **{equipo.id}** | Torneo ID: **{equipo.torneo_id}**\n"
+            f"Equipo: **{_texto_discord_seguro(equipo.nombre)}** | "
+            f"Comunidad: **{_texto_discord_seguro(comunidad)}**\n"
+            f"1. {jugador1.mention} — **{_texto_discord_seguro(raza1)}**\n"
+            f"2. {jugador2.mention} — **{_texto_discord_seguro(raza2)}**"
         )
 
 

--- a/tests/test_comunidades_altas.py
+++ b/tests/test_comunidades_altas.py
@@ -1,0 +1,209 @@
+from datetime import datetime
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from sqlalchemy import BigInteger, create_engine
+from sqlalchemy.orm import Session
+
+from ComunidadesCore import (
+    ErrorConfiguracionComunidades,
+    anadir_categoria_enfrentamientos_comunidades,
+    anadir_categoria_partidos_comunidades,
+    anadir_comunidad_comunidades,
+    anadir_equipo_comunidades,
+    crear_torneo_comunidades,
+)
+from GestorSQL import (
+    Base,
+    ComunidadesCategoriaEnfrentamiento,
+    ComunidadesCategoriaPartido,
+    ComunidadesComunidad,
+    ComunidadesEquipo,
+    ComunidadesMiembro,
+    ComunidadesTorneo,
+    Usuario,
+)
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def _crear_torneo(session):
+    torneo = crear_torneo_comunidades(
+        session,
+        nombre="Copa",
+        rondas_totales=3,
+        fecha_fin_ronda1=datetime(2026, 7, 1, 23, 59),
+        dias_por_ronda=7,
+        canal_hub_id=1497290209505710120,
+        creado_por_discord_id=1497290209505710121,
+    )
+    session.commit()
+    return torneo
+
+
+def _anadir_equipo(session, torneo_id, **cambios):
+    argumentos = {
+        "torneo_id": torneo_id,
+        "nombre": "Los Rompecráneos",
+        "comunidad_nombre": "Butter",
+        "jugador1_discord_id": 1497290209505710122,
+        "jugador1_nombre_discord": "Jugador Uno",
+        "raza1": "Orcos",
+        "jugador2_discord_id": 1497290209505710123,
+        "jugador2_nombre_discord": "Jugador Dos",
+        "raza2": "Skaven",
+    }
+    argumentos.update(cambios)
+    return anadir_equipo_comunidades(session, **argumentos)
+
+
+def test_ids_discord_de_usuarios_usan_big_integer():
+    assert isinstance(Usuario.__table__.c.id_discord.type, BigInteger)
+
+
+def test_anade_comunidad_y_rechaza_duplicados_exactos():
+    with _session() as session:
+        torneo = _crear_torneo(session)
+        comunidad = anadir_comunidad_comunidades(
+            session, torneo_id=torneo.id, nombre="Butter League"
+        )
+        session.commit()
+
+        assert comunidad.nombre == "Butter League"
+        with pytest.raises(ErrorConfiguracionComunidades, match="ya existe"):
+            anadir_comunidad_comunidades(
+                session, torneo_id=torneo.id, nombre="Butter League"
+            )
+
+
+def test_categorias_conservan_orden_y_no_aceptan_duplicados():
+    with _session() as session:
+        torneo = _crear_torneo(session)
+        primera = anadir_categoria_partidos_comunidades(
+            session, torneo_id=torneo.id, categoria_discord_id=1497290209505710130
+        )
+        segunda = anadir_categoria_partidos_comunidades(
+            session, torneo_id=torneo.id, categoria_discord_id=1497290209505710131
+        )
+        enfrentamientos = anadir_categoria_enfrentamientos_comunidades(
+            session, torneo_id=torneo.id, categoria_discord_id=1497290209505710130
+        )
+        session.commit()
+
+        assert (primera.orden_alta, segunda.orden_alta) == (1, 2)
+        assert enfrentamientos.orden_alta == 1
+        with pytest.raises(ErrorConfiguracionComunidades, match="ya está configurada"):
+            anadir_categoria_partidos_comunidades(
+                session, torneo_id=torneo.id, categoria_discord_id=1497290209505710130
+            )
+
+
+def test_alta_equipo_crea_dos_miembros_y_usuarios_con_razas_exactas():
+    with _session() as session:
+        torneo = _crear_torneo(session)
+        anadir_comunidad_comunidades(session, torneo_id=torneo.id, nombre="Butter")
+        session.commit()
+
+        equipo = _anadir_equipo(session, torneo.id)
+        session.commit()
+
+        miembros = (
+            session.query(ComunidadesMiembro)
+            .filter(ComunidadesMiembro.equipo_id == equipo.id)
+            .order_by(ComunidadesMiembro.posicion)
+            .all()
+        )
+        assert equipo.nombre == "Los Rompecráneos"
+        assert [miembro.raza for miembro in miembros] == ["Orcos", "Skaven"]
+        assert session.query(Usuario).count() == 2
+        assert {usuario.id_discord for usuario in session.query(Usuario)} == {
+            1497290209505710122,
+            1497290209505710123,
+        }
+
+
+def test_alta_equipo_rechaza_nombre_usuario_y_raza_duplicados_o_invalidos():
+    with _session() as session:
+        torneo = _crear_torneo(session)
+        anadir_comunidad_comunidades(session, torneo_id=torneo.id, nombre="Butter")
+        session.commit()
+        _anadir_equipo(session, torneo.id)
+        session.commit()
+
+        with pytest.raises(ErrorConfiguracionComunidades, match="ya existe"):
+            _anadir_equipo(
+                session,
+                torneo.id,
+                jugador1_discord_id=1497290209505710200,
+                jugador2_discord_id=1497290209505710201,
+            )
+        session.rollback()
+        with pytest.raises(ErrorConfiguracionComunidades, match="ya pertenece"):
+            _anadir_equipo(
+                session,
+                torneo.id,
+                nombre="Otro equipo",
+                jugador2_discord_id=1497290209505710201,
+            )
+        session.rollback()
+        with pytest.raises(ErrorConfiguracionComunidades, match="no es válida"):
+            _anadir_equipo(
+                session,
+                torneo.id,
+                nombre="Raza inválida",
+                jugador1_discord_id=1497290209505710200,
+                jugador2_discord_id=1497290209505710201,
+                raza2="skaven",
+            )
+
+
+def test_error_de_alta_no_deja_registros_parciales():
+    with _session() as session:
+        torneo = _crear_torneo(session)
+        anadir_comunidad_comunidades(session, torneo_id=torneo.id, nombre="Butter")
+        session.commit()
+
+        with pytest.raises(ErrorConfiguracionComunidades):
+            _anadir_equipo(session, torneo.id, raza2="Raza inventada")
+        session.rollback()
+
+        assert session.query(Usuario).count() == 0
+        assert session.query(ComunidadesEquipo).count() == 0
+        assert session.query(ComunidadesMiembro).count() == 0
+
+
+@pytest.mark.parametrize("operacion", ["comunidad", "partidos", "enfrentamientos", "equipo"])
+def test_altas_se_bloquean_tras_iniciar_torneo(operacion):
+    with _session() as session:
+        torneo = _crear_torneo(session)
+        anadir_comunidad_comunidades(session, torneo_id=torneo.id, nombre="Butter")
+        session.commit()
+        torneo.estado = "EN_CURSO"
+        session.commit()
+
+        with pytest.raises(ErrorConfiguracionComunidades, match="estado CREADO"):
+            if operacion == "comunidad":
+                anadir_comunidad_comunidades(session, torneo_id=torneo.id, nombre="Hispana")
+            elif operacion == "partidos":
+                anadir_categoria_partidos_comunidades(
+                    session, torneo_id=torneo.id, categoria_discord_id=10
+                )
+            elif operacion == "enfrentamientos":
+                anadir_categoria_enfrentamientos_comunidades(
+                    session, torneo_id=torneo.id, categoria_discord_id=10
+                )
+            else:
+                _anadir_equipo(session, torneo.id)
+        session.rollback()
+
+        assert session.query(ComunidadesComunidad).count() == 1
+        assert session.query(ComunidadesCategoriaPartido).count() == 0
+        assert session.query(ComunidadesCategoriaEnfrentamiento).count() == 0
+        assert session.query(ComunidadesEquipo).count() == 0


### PR DESCRIPTION
### Motivation

- Implementar la interfaz administrativa para configurar comunidades, categorías y equipos según la especificación `DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES`. 
- Garantizar invariantes de inscripción (dos miembros, razas canónicas, sin duplicados) y operaciones atómicas para evitar estados parciales.

### Description

- Añadido servicio transaccional en `ComunidadesCore.py` para: `anadir_comunidad_comunidades`, `anadir_categoria_partidos_comunidades`, `anadir_categoria_enfrentamientos_comunidades` y `anadir_equipo_comunidades`, con validaciones de texto, `discord` IDs y razas canónicas. 
- Incorporados comandos exclusivos de comisarios en `LombardBot.py`: `!comunidades_add_comunidad`, `!comunidades_add_categoria_partidos`, `!comunidades_add_categoria_enfrentamientos` y `!comunidades_add_equipo`, resolviendo jugadores con `discord.Member`, validando que la categoría existe en el guild y es `discord.CategoryChannel` y mostrando un resumen seguro (escapando markdown y menciones). 
- Asegurada la conservación del orden de alta de categorías al insertar `orden_alta`, y prevención de duplicados y bloqueos si el torneo ya está iniciado. 
- Adaptado `GestorSQL.py` y el esquema SQL (`BD/comunidades_schema.sql`) para usar `BigInteger` en `usuarios.id_discord` y agregado un `ALTER TABLE` en el script para la compatibilidad con snowflakes. 
- Añadido test de altas en `tests/test_comunidades_altas.py` que cubre duplicados, orden de categorías, creación automática de usuarios, razas exactas, atomicidad y bloqueo tras iniciar el torneo.

### Testing

- Ejecutado `pytest -q` para la suite completa; todas las pruebas pasaron (418 passed). 
- Ejecutado `pytest -q tests/test_comunidades_altas.py`; 10 pruebas añadidas pasaron correctamente. 
- Verificación de compilación con `python -m py_compile ComunidadesCore.py GestorSQL.py LombardBot.py` completada sin errores. 
- Comprobación de presencia y firmas de los comandos y converters `discord.Member` mediante análisis AST: verificados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24a5b5e898832aad876f399f18cdec)