### PR TITLE
Añadir selector reutilizable de categorías de comunidades

### DIFF
--- a/ComunidadesCore.py
+++ b/ComunidadesCore.py
@@ -223,6 +223,45 @@ def anadir_categoria_enfrentamientos_comunidades(
     )
 
 
+def obtener_categorias_comunidades(session: Any, *, torneo_id: int, tipo: str):
+    """Devuelve las categorías configuradas del tipo indicado en orden de alta."""
+    from GestorSQL import (
+        ComunidadesCategoriaEnfrentamiento,
+        ComunidadesCategoriaPartido,
+        ComunidadesTorneo,
+    )
+
+    _validar_entero_positivo(torneo_id, "torneo_id")
+    torneo_existe = (
+        session.query(ComunidadesTorneo.id)
+        .filter(ComunidadesTorneo.id == torneo_id)
+        .first()
+    )
+    if torneo_existe is None:
+        _error_configuracion(
+            "TORNEO_NO_EXISTE",
+            f"No existe un torneo de comunidades con ID {torneo_id}.",
+        )
+
+    modelos = {
+        "enfrentamientos": ComunidadesCategoriaEnfrentamiento,
+        "partidos": ComunidadesCategoriaPartido,
+    }
+    modelo = modelos.get(tipo)
+    if modelo is None:
+        _error_configuracion(
+            "TIPO_CATEGORIA_INVALIDO",
+            "El tipo de categoría debe ser 'enfrentamientos' o 'partidos'.",
+        )
+
+    return (
+        session.query(modelo)
+        .filter(modelo.torneo_id == torneo_id)
+        .order_by(modelo.orden_alta.asc())
+        .all()
+    )
+
+
 def anadir_equipo_comunidades(
     session: Any,
     *,

--- a/ComunidadesDiscord.py
+++ b/ComunidadesDiscord.py
@@ -1,7 +1,208 @@
-"""Parsing de argumentos Discord para los comandos del torneo de comunidades."""
+"""Helpers de Discord para los comandos del torneo de comunidades."""
 
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
+from typing import Any, Optional, Tuple
+
+
+MAX_CANALES_POR_CATEGORIA_COMUNIDADES = 40
+
+
+@dataclass(frozen=True)
+class IncidenciaCategoriaComunidades:
+    """Motivo por el que una categoría configurada no se puede utilizar."""
+
+    categoria_discord_id: int
+    orden_alta: int
+    estado: str
+    canales_existentes: Optional[int] = None
+    detalle: Optional[str] = None
+
+
+class ErrorSeleccionCategoriaComunidades(ValueError):
+    """Error estructurado listo para comunicarse en el canal administrativo."""
+
+    def __init__(
+        self,
+        codigo: str,
+        detalle: str,
+        *,
+        torneo_id: int,
+        tipo: str,
+        incidencias: Tuple[IncidenciaCategoriaComunidades, ...] = (),
+    ):
+        super().__init__(detalle)
+        self.codigo = codigo
+        self.detalle = detalle
+        self.torneo_id = torneo_id
+        self.tipo = tipo
+        self.incidencias = incidencias
+
+    def para_administracion(self) -> dict:
+        """Expone un payload estable para que el llamador componga la publicación."""
+        return {
+            "codigo": self.codigo,
+            "detalle": self.detalle,
+            "torneo_id": self.torneo_id,
+            "tipo": self.tipo,
+            "categorias": [
+                {
+                    "categoria_discord_id": incidencia.categoria_discord_id,
+                    "orden_alta": incidencia.orden_alta,
+                    "estado": incidencia.estado,
+                    "canales_existentes": incidencia.canales_existentes,
+                    "detalle": incidencia.detalle,
+                }
+                for incidencia in self.incidencias
+            ],
+        }
+
+
+def _estado_error_discord(exc: Exception) -> str:
+    """Distingue las respuestas que Discord usa para recurso ausente y prohibido."""
+    status = getattr(exc, "status", None)
+    nombre = type(exc).__name__.lower()
+    if status == 404 or nombre == "notfound":
+        return "INEXISTENTE"
+    return "INACCESIBLE"
+
+
+async def _resolver_canal_configurado(guild: Any, categoria_id: int):
+    categoria = guild.get_channel(categoria_id)
+    if categoria is not None:
+        return categoria, None
+
+    fetch_channel = getattr(guild, "fetch_channel", None)
+    if fetch_channel is None:
+        return None, "INEXISTENTE"
+
+    try:
+        categoria = await fetch_channel(categoria_id)
+    except Exception as exc:
+        return None, _estado_error_discord(exc)
+    if categoria is None:
+        return None, "INEXISTENTE"
+    return categoria, None
+
+
+def _detalle_inaccesible(guild: Any, categoria: Any) -> Optional[str]:
+    """Comprueba los permisos necesarios cuando el objeto Discord los expone."""
+    permissions_for = getattr(categoria, "permissions_for", None)
+    miembro_bot = getattr(guild, "me", None)
+    if not callable(permissions_for) or miembro_bot is None:
+        return None
+
+    try:
+        permisos = permissions_for(miembro_bot)
+    except Exception:
+        return "No se pudieron comprobar los permisos del bot en la categoría."
+
+    if not getattr(permisos, "view_channel", True):
+        return "El bot no puede ver la categoría."
+    if not getattr(permisos, "manage_channels", True):
+        return "El bot no puede administrar canales en la categoría."
+    return None
+
+
+async def seleccionar_categoria_comunidades(
+    session: Any,
+    guild: Any,
+    *,
+    torneo_id: int,
+    tipo: str,
+):
+    """Elige la primera categoría configurada con menos de 40 canales.
+
+    La configuración procede de base de datos y se recorre estrictamente por
+    ``orden_alta``. El recuento usa la colección completa ``channels`` de cada
+    categoría, sin filtrar por torneo ni por tipo de canal.
+    """
+    from ComunidadesCore import obtener_categorias_comunidades
+
+    categorias_configuradas = obtener_categorias_comunidades(
+        session, torneo_id=torneo_id, tipo=tipo
+    )
+    if not categorias_configuradas:
+        raise ErrorSeleccionCategoriaComunidades(
+            "SIN_CATEGORIAS_CONFIGURADAS",
+            f"El torneo {torneo_id} no tiene categorías de {tipo} configuradas.",
+            torneo_id=torneo_id,
+            tipo=tipo,
+        )
+
+    incidencias = []
+    for configuracion in categorias_configuradas:
+        categoria_id = int(configuracion.categoria_discord_id)
+        categoria, estado_error = await _resolver_canal_configurado(guild, categoria_id)
+        if categoria is None:
+            incidencias.append(
+                IncidenciaCategoriaComunidades(
+                    categoria_discord_id=categoria_id,
+                    orden_alta=int(configuracion.orden_alta),
+                    estado=estado_error,
+                )
+            )
+            continue
+
+        detalle_inaccesible = _detalle_inaccesible(guild, categoria)
+        if detalle_inaccesible is not None:
+            incidencias.append(
+                IncidenciaCategoriaComunidades(
+                    categoria_discord_id=categoria_id,
+                    orden_alta=int(configuracion.orden_alta),
+                    estado="INACCESIBLE",
+                    detalle=detalle_inaccesible,
+                )
+            )
+            continue
+
+        try:
+            canales = categoria.channels
+        except (AttributeError, TypeError):
+            incidencias.append(
+                IncidenciaCategoriaComunidades(
+                    categoria_discord_id=categoria_id,
+                    orden_alta=int(configuracion.orden_alta),
+                    estado="INACCESIBLE",
+                    detalle="El recurso configurado no expone canales de categoría.",
+                )
+            )
+            continue
+
+        try:
+            canales_existentes = len(canales)
+        except TypeError:
+            incidencias.append(
+                IncidenciaCategoriaComunidades(
+                    categoria_discord_id=categoria_id,
+                    orden_alta=int(configuracion.orden_alta),
+                    estado="INACCESIBLE",
+                    detalle="No se pudo contar los canales de la categoría.",
+                )
+            )
+            continue
+
+        if canales_existentes >= MAX_CANALES_POR_CATEGORIA_COMUNIDADES:
+            incidencias.append(
+                IncidenciaCategoriaComunidades(
+                    categoria_discord_id=categoria_id,
+                    orden_alta=int(configuracion.orden_alta),
+                    estado="LLENA",
+                    canales_existentes=canales_existentes,
+                )
+            )
+            continue
+
+        return categoria
+
+    raise ErrorSeleccionCategoriaComunidades(
+        "SIN_CATEGORIA_UTILIZABLE",
+        f"Ninguna categoría de {tipo} del torneo {torneo_id} tiene capacidad disponible.",
+        torneo_id=torneo_id,
+        tipo=tipo,
+        incidencias=tuple(incidencias),
+    )
 
 
 def parsear_fecha_limite(fecha: str, hora: str) -> datetime:

--- a/tests/test_comunidades_categorias_discord.py
+++ b/tests/test_comunidades_categorias_discord.py
@@ -1,0 +1,286 @@
+import asyncio
+from datetime import datetime
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from ComunidadesCore import (
+    anadir_categoria_enfrentamientos_comunidades,
+    anadir_categoria_partidos_comunidades,
+    crear_torneo_comunidades,
+    obtener_categorias_comunidades,
+)
+from ComunidadesDiscord import (
+    ErrorSeleccionCategoriaComunidades,
+    seleccionar_categoria_comunidades,
+)
+from GestorSQL import Base
+
+
+class CategoriaDiscordDoble:
+    def __init__(self, categoria_id, numero_canales):
+        self.id = categoria_id
+        self.channels = [object() for _ in range(numero_canales)]
+
+
+class PermisosDoble:
+    def __init__(self, *, view_channel=True, manage_channels=True):
+        self.view_channel = view_channel
+        self.manage_channels = manage_channels
+
+
+class CategoriaConPermisosDoble(CategoriaDiscordDoble):
+    def __init__(self, categoria_id, numero_canales, permisos):
+        super().__init__(categoria_id, numero_canales)
+        self.permisos = permisos
+
+    def permissions_for(self, miembro):
+        return self.permisos
+
+
+class RespuestaDiscordError(Exception):
+    def __init__(self, status):
+        super().__init__(f"Discord respondió {status}")
+        self.status = status
+
+
+class GuildDoble:
+    def __init__(self, categorias=None, errores_fetch=None):
+        self.me = object()
+        self.categorias = categorias or {}
+        self.errores_fetch = errores_fetch or {}
+        self.ids_consultados = []
+        self.ids_recuperados = []
+
+    def get_channel(self, categoria_id):
+        self.ids_consultados.append(categoria_id)
+        return self.categorias.get(categoria_id)
+
+    async def fetch_channel(self, categoria_id):
+        self.ids_recuperados.append(categoria_id)
+        if categoria_id in self.errores_fetch:
+            raise RespuestaDiscordError(self.errores_fetch[categoria_id])
+        return self.categorias.get(categoria_id)
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def _crear_torneo(session):
+    torneo = crear_torneo_comunidades(
+        session,
+        nombre="Copa",
+        rondas_totales=3,
+        fecha_fin_ronda1=datetime(2026, 7, 1, 23, 59),
+        dias_por_ronda=7,
+        canal_hub_id=1497290209505710120,
+        creado_por_discord_id=1497290209505710121,
+    )
+    session.commit()
+    return torneo
+
+
+def _seleccionar(session, guild, torneo_id, tipo):
+    return asyncio.run(
+        seleccionar_categoria_comunidades(
+            session, guild, torneo_id=torneo_id, tipo=tipo
+        )
+    )
+
+
+def test_recupera_categorias_de_cada_tipo_en_orden_de_alta():
+    with _session() as session:
+        torneo = _crear_torneo(session)
+        anadir_categoria_partidos_comunidades(
+            session, torneo_id=torneo.id, categoria_discord_id=103
+        )
+        anadir_categoria_partidos_comunidades(
+            session, torneo_id=torneo.id, categoria_discord_id=101
+        )
+        anadir_categoria_enfrentamientos_comunidades(
+            session, torneo_id=torneo.id, categoria_discord_id=202
+        )
+        anadir_categoria_enfrentamientos_comunidades(
+            session, torneo_id=torneo.id, categoria_discord_id=201
+        )
+        session.commit()
+
+        partidos = obtener_categorias_comunidades(
+            session, torneo_id=torneo.id, tipo="partidos"
+        )
+        enfrentamientos = obtener_categorias_comunidades(
+            session, torneo_id=torneo.id, tipo="enfrentamientos"
+        )
+
+        assert [categoria.categoria_discord_id for categoria in partidos] == [103, 101]
+        assert [categoria.categoria_discord_id for categoria in enfrentamientos] == [202, 201]
+
+
+@pytest.mark.parametrize("tipo", ["partidos", "enfrentamientos"])
+def test_selecciona_primera_categoria_con_capacidad_para_ambos_tipos(tipo):
+    with _session() as session:
+        torneo = _crear_torneo(session)
+        alta = (
+            anadir_categoria_partidos_comunidades
+            if tipo == "partidos"
+            else anadir_categoria_enfrentamientos_comunidades
+        )
+        for categoria_id in (301, 302, 303):
+            alta(session, torneo_id=torneo.id, categoria_discord_id=categoria_id)
+        session.commit()
+
+        guild = GuildDoble(
+            {
+                303: CategoriaDiscordDoble(303, 0),
+                302: CategoriaDiscordDoble(302, 39),
+                301: CategoriaDiscordDoble(301, 40),
+            }
+        )
+
+        seleccionada = _seleccionar(session, guild, torneo.id, tipo)
+
+        assert seleccionada.id == 302
+        assert guild.ids_consultados == [301, 302]
+
+
+def test_cuenta_todos_los_canales_sin_filtrar_su_procedencia():
+    with _session() as session:
+        torneo = _crear_torneo(session)
+        anadir_categoria_partidos_comunidades(
+            session, torneo_id=torneo.id, categoria_discord_id=401
+        )
+        anadir_categoria_partidos_comunidades(
+            session, torneo_id=torneo.id, categoria_discord_id=402
+        )
+        session.commit()
+        primera = CategoriaDiscordDoble(401, 40)
+        primera.channels[-1] = {"pertenece_al_torneo": False}
+        segunda = CategoriaDiscordDoble(402, 0)
+
+        seleccionada = _seleccionar(
+            session, GuildDoble({401: primera, 402: segunda}), torneo.id, "partidos"
+        )
+
+        assert seleccionada is segunda
+
+
+def test_salta_categoria_eliminada_y_usa_la_siguiente():
+    with _session() as session:
+        torneo = _crear_torneo(session)
+        for categoria_id in (501, 502):
+            anadir_categoria_enfrentamientos_comunidades(
+                session, torneo_id=torneo.id, categoria_discord_id=categoria_id
+            )
+        session.commit()
+        guild = GuildDoble(
+            {502: CategoriaDiscordDoble(502, 0)}, errores_fetch={501: 404}
+        )
+
+        seleccionada = _seleccionar(
+            session, guild, torneo.id, "enfrentamientos"
+        )
+
+        assert seleccionada.id == 502
+        assert guild.ids_recuperados == [501]
+
+
+def test_salta_categoria_sin_permisos_para_administrar_canales():
+    with _session() as session:
+        torneo = _crear_torneo(session)
+        for categoria_id in (551, 552):
+            anadir_categoria_enfrentamientos_comunidades(
+                session, torneo_id=torneo.id, categoria_discord_id=categoria_id
+            )
+        session.commit()
+        sin_permisos = CategoriaConPermisosDoble(
+            551, 0, PermisosDoble(manage_channels=False)
+        )
+        disponible = CategoriaDiscordDoble(552, 0)
+
+        seleccionada = _seleccionar(
+            session,
+            GuildDoble({551: sin_permisos, 552: disponible}),
+            torneo.id,
+            "enfrentamientos",
+        )
+
+        assert seleccionada is disponible
+
+
+def test_error_estructurado_diferencia_inexistente_inaccesible_y_llena():
+    with _session() as session:
+        torneo = _crear_torneo(session)
+        for categoria_id in (601, 602, 603):
+            anadir_categoria_partidos_comunidades(
+                session, torneo_id=torneo.id, categoria_discord_id=categoria_id
+            )
+        session.commit()
+        guild = GuildDoble(
+            {603: CategoriaDiscordDoble(603, 40)},
+            errores_fetch={601: 404, 602: 403},
+        )
+
+        with pytest.raises(ErrorSeleccionCategoriaComunidades) as capturado:
+            _seleccionar(session, guild, torneo.id, "partidos")
+
+        error = capturado.value
+        assert error.codigo == "SIN_CATEGORIA_UTILIZABLE"
+        assert [incidencia.estado for incidencia in error.incidencias] == [
+            "INEXISTENTE",
+            "INACCESIBLE",
+            "LLENA",
+        ]
+        assert error.incidencias[-1].canales_existentes == 40
+        assert error.para_administracion() == {
+            "codigo": "SIN_CATEGORIA_UTILIZABLE",
+            "detalle": (
+                f"Ninguna categoría de partidos del torneo {torneo.id} "
+                "tiene capacidad disponible."
+            ),
+            "torneo_id": torneo.id,
+            "tipo": "partidos",
+            "categorias": [
+                {
+                    "categoria_discord_id": 601,
+                    "orden_alta": 1,
+                    "estado": "INEXISTENTE",
+                    "canales_existentes": None,
+                    "detalle": None,
+                },
+                {
+                    "categoria_discord_id": 602,
+                    "orden_alta": 2,
+                    "estado": "INACCESIBLE",
+                    "canales_existentes": None,
+                    "detalle": None,
+                },
+                {
+                    "categoria_discord_id": 603,
+                    "orden_alta": 3,
+                    "estado": "LLENA",
+                    "canales_existentes": 40,
+                    "detalle": None,
+                },
+            ],
+        }
+
+
+def test_torneo_sin_categorias_falla_con_error_especifico():
+    with _session() as session:
+        torneo = _crear_torneo(session)
+
+        with pytest.raises(ErrorSeleccionCategoriaComunidades) as capturado:
+            _seleccionar(session, GuildDoble(), torneo.id, "enfrentamientos")
+
+        error = capturado.value
+        assert error.codigo == "SIN_CATEGORIAS_CONFIGURADAS"
+        assert error.incidencias == ()
+        assert error.para_administracion()["categorias"] == []


### PR DESCRIPTION
### Motivation
- El selector anterior usaba categorías hardcodeadas y no respeta la nueva configuración por torneo ni el límite de 40 canales indicado por la especificación.
- Es necesario elegir la primera categoría disponible según el `orden_alta` almacenado en la base de datos y distinguir claramente categorías inexistentes, inaccesibles o llenas para notificar en el canal administrativo.
- El helper debe ser reutilizable tanto para categorías de enfrentamientos como de partidos y contar todos los canales presentes en la categoría sin filtrar su procedencia.

### Description
- Añadido `obtener_categorias_comunidades(session, torneo_id, tipo)` en `ComunidadesCore.py` para recuperar las categorías configuradas de tipo `enfrentamientos` o `partidos` respetando exactamente `orden_alta` y validando existencia del torneo. 
- Implementado el helper Discord `seleccionar_categoria_comunidades(session, guild, torneo_id, tipo)` en `ComunidadesDiscord.py` que recorre la configuración, resuelve cada categoría en Discord, cuenta `channels` y selecciona la primera con menos de 40 canales; además comprueba accesibilidad y permisos del bot antes de elegirla. 
- Introducidos objetos de error/diagnóstico: `ErrorSeleccionCategoriaComunidades` y `IncidenciaCategoriaComunidades` para diferenciar y reportar estados `INEXISTENTE`, `INACCESIBLE` y `LLENA`, y un método `para_administracion()` que expone un payload estructurado para publicar en el canal administrativo. 
- Añadidos tests con dobles de Discord en `tests/test_comunidades_categorias_discord.py` que cubren ambos tipos de categoría, orden de alta, conteo de canales (0/39/40), categorías eliminadas, permisos insuficientes y el formato del error estructurado.

### Testing
- Ejecutado `pytest -q tests/test_comunidades_categorias_discord.py` y los 8 tests del nuevo módulo pasaron correctamente. 
- Ejecutada la suite completa `pytest -q` y todas las pruebas del repositorio (426 tests) pasaron correctamente. 
- Verificada la compilación de los módulos nuevos con `python -m py_compile` y realizada comprobación de estilo básico (`git diff --check`) sin errores detectados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24a771958c832abfeac08da085cabc)