### PR TITLE
Materializar partidos de comunidades de forma idempotente

### DIFF
--- a/ComunidadesCore.py
+++ b/ComunidadesCore.py
@@ -1684,6 +1684,149 @@ def registrar_eleccion_atacante_comunidades(
         raise
 
 
+class ErrorMaterializacionPartidosComunidades(ValueError):
+    """Error de dominio al fijar las identidades de los partidos."""
+
+    def __init__(self, codigo: str, detalle: str):
+        super().__init__(detalle)
+        self.codigo = codigo
+        self.detalle = detalle
+
+
+@dataclass(frozen=True)
+class ResultadoMaterializacionPartidosComunidades:
+    """Identidades estables de los dos partidos de un enfrentamiento."""
+
+    enfrentamiento: Any
+    partidos: tuple[Any, Any]
+    creados: bool
+
+
+def _error_materializacion_partidos(codigo: str, detalle: str) -> None:
+    raise ErrorMaterializacionPartidosComunidades(codigo, detalle)
+
+
+def materializar_identidades_partidos_comunidades(
+    session: Any,
+    *,
+    enfrentamiento_id: int,
+) -> ResultadoMaterializacionPartidosComunidades:
+    """Persiste exactamente los dos cruces derivados de elecciones bloqueadas.
+
+    Esta función no confirma la transacción. El llamador debe hacer ``commit``
+    antes de iniciar efectos externos en Discord, de modo que un reintento
+    conserve la misma identidad de partido aunque falle la creación de canales.
+    """
+    from GestorSQL import (
+        ComunidadesEleccionAtacante,
+        ComunidadesEnfrentamiento,
+        ComunidadesPartido,
+    )
+
+    if type(enfrentamiento_id) is not int or enfrentamiento_id <= 0:
+        _error_materializacion_partidos(
+            "REFERENCIA_INVALIDA",
+            "El ID del enfrentamiento debe ser un entero mayor que cero.",
+        )
+
+    enfrentamiento = (
+        session.query(ComunidadesEnfrentamiento)
+        .filter(ComunidadesEnfrentamiento.id == enfrentamiento_id)
+        .with_for_update()
+        .one_or_none()
+    )
+    if enfrentamiento is None:
+        _error_materializacion_partidos(
+            "ENFRENTAMIENTO_NO_EXISTE",
+            f"No existe el enfrentamiento {enfrentamiento_id}.",
+        )
+
+    partidos_existentes = (
+        session.query(ComunidadesPartido)
+        .filter(ComunidadesPartido.enfrentamiento_id == enfrentamiento_id)
+        .order_by(ComunidadesPartido.indice)
+        .all()
+    )
+    if partidos_existentes:
+        indices = [int(partido.indice) for partido in partidos_existentes]
+        if len(partidos_existentes) != 2 or indices != [1, 2]:
+            _error_materializacion_partidos(
+                "PARTIDOS_INCOMPLETOS",
+                "El enfrentamiento tiene una materialización parcial o inconsistente.",
+            )
+        return ResultadoMaterializacionPartidosComunidades(
+            enfrentamiento=enfrentamiento,
+            partidos=(partidos_existentes[0], partidos_existentes[1]),
+            creados=False,
+        )
+
+    if enfrentamiento.estado != ENFRENTAMIENTO_ELECCIONES_COMPLETAS:
+        _error_materializacion_partidos(
+            "ELECCIONES_NO_COMPLETAS",
+            (
+                "Los partidos solo pueden materializarse cuando ambas "
+                "elecciones están bloqueadas."
+            ),
+        )
+
+    elecciones = (
+        session.query(ComunidadesEleccionAtacante)
+        .filter(ComunidadesEleccionAtacante.enfrentamiento_id == enfrentamiento_id)
+        .all()
+    )
+    por_equipo = {int(eleccion.equipo_id): eleccion for eleccion in elecciones}
+    equipos_esperados = {
+        int(enfrentamiento.equipo_a_id),
+        int(enfrentamiento.equipo_b_id),
+    }
+    if set(por_equipo) != equipos_esperados or not all(
+        bool(eleccion.bloqueada) for eleccion in elecciones
+    ):
+        _error_materializacion_partidos(
+            "ELECCIONES_NO_BLOQUEADAS",
+            "Deben existir dos elecciones bloqueadas, una por cada equipo.",
+        )
+
+    eleccion_a = por_equipo[int(enfrentamiento.equipo_a_id)]
+    eleccion_b = por_equipo[int(enfrentamiento.equipo_b_id)]
+    datos = (
+        {
+            "indice": 1,
+            "equipo_local_id": int(enfrentamiento.equipo_a_id),
+            "equipo_visitante_id": int(enfrentamiento.equipo_b_id),
+            "usuario_local_id": int(eleccion_a.atacante_usuario_id),
+            "usuario_visitante_id": int(eleccion_b.defensor_usuario_id),
+            "atacante_usuario_id": int(eleccion_a.atacante_usuario_id),
+            "defensor_usuario_id": int(eleccion_b.defensor_usuario_id),
+        },
+        {
+            "indice": 2,
+            "equipo_local_id": int(enfrentamiento.equipo_b_id),
+            "equipo_visitante_id": int(enfrentamiento.equipo_a_id),
+            "usuario_local_id": int(eleccion_b.atacante_usuario_id),
+            "usuario_visitante_id": int(eleccion_a.defensor_usuario_id),
+            "atacante_usuario_id": int(eleccion_b.atacante_usuario_id),
+            "defensor_usuario_id": int(eleccion_a.defensor_usuario_id),
+        },
+    )
+    partidos = tuple(
+        ComunidadesPartido(
+            torneo_id=int(enfrentamiento.torneo_id),
+            enfrentamiento_id=int(enfrentamiento.id),
+            estado="PENDIENTE",
+            **cruce,
+        )
+        for cruce in datos
+    )
+    session.add_all(partidos)
+    session.flush()
+    return ResultadoMaterializacionPartidosComunidades(
+        enfrentamiento=enfrentamiento,
+        partidos=(partidos[0], partidos[1]),
+        creados=True,
+    )
+
+
 class ErrorGeneracionRondaComunidades(ValueError):
     """Error funcional que cancela por completo la generación de una ronda."""
 

--- a/ComunidadesDiscord.py
+++ b/ComunidadesDiscord.py
@@ -254,3 +254,249 @@ def parsear_decimal(valor: str, nombre: str) -> Decimal:
         return Decimal(valor)
     except (InvalidOperation, TypeError, ValueError) as exc:
         raise ValueError(f"`{nombre}` debe ser un número decimal válido.") from exc
+
+
+class ErrorMaterializacionDiscordComunidades(RuntimeError):
+    """Incidencia recuperable durante la creación de canales individuales."""
+
+    def __init__(self, codigo: str, detalle: str):
+        super().__init__(detalle)
+        self.codigo = codigo
+        self.detalle = detalle
+
+
+@dataclass(frozen=True)
+class ResultadoMaterializacionDiscordComunidades:
+    """Resultado idempotente de materializar los dos partidos en Discord."""
+
+    enfrentamiento_id: int
+    partido_ids: Tuple[int, int]
+    canal_ids: Tuple[int, int]
+    canales_creados: int
+
+
+def _error_materializacion_discord(codigo: str, detalle: str) -> None:
+    raise ErrorMaterializacionDiscordComunidades(codigo, detalle)
+
+
+def _nombre_canal_partido_comunidades(enfrentamiento: Any, partido: Any) -> str:
+    def normalizar(valor: object) -> str:
+        texto = str(valor or "jugador").lower()
+        resultado = []
+        for caracter in texto:
+            if caracter.isalnum():
+                resultado.append(caracter)
+            elif resultado and resultado[-1] != "-":
+                resultado.append("-")
+        return "".join(resultado).strip("-") or "jugador"
+
+    return (
+        f"r{int(enfrentamiento.ronda.numero)}-m{int(enfrentamiento.mesa_numero)}-"
+        f"p{int(partido.indice)}-{normalizar(partido.usuario_local.nombre_discord)}-vs-"
+        f"{normalizar(partido.usuario_visitante.nombre_discord)}"
+    )[:100]
+
+
+def _mensaje_partido_comunidades(enfrentamiento: Any, partido: Any) -> str:
+    atacante_discord_id = int(partido.atacante_usuario.id_discord)
+    defensor_discord_id = int(partido.defensor_usuario.id_discord)
+    return (
+        f"## Partido {int(partido.indice)} — Mesa {int(enfrentamiento.mesa_numero)}\n"
+        f"**Atacante:** <@{atacante_discord_id}>\n"
+        f"**Defensor:** <@{defensor_discord_id}>\n\n"
+        f"<@{atacante_discord_id}> contra <@{defensor_discord_id}>\n"
+        f"**Fecha límite:** {enfrentamiento.ronda.fecha_fin.strftime('%Y-%m-%d %H:%M')}"
+    )
+
+
+async def _resolver_miembro_comunidades(guild: Any, discord_id: int):
+    miembro = guild.get_member(discord_id)
+    if miembro is not None:
+        return miembro
+    fetch_member = getattr(guild, "fetch_member", None)
+    if not callable(fetch_member):
+        return None
+    try:
+        return await fetch_member(discord_id)
+    except Exception:
+        return None
+
+
+async def _resolver_canal_comunidades(guild: Any, canal_id: int):
+    canal = guild.get_channel(canal_id)
+    if canal is not None:
+        return canal
+    fetch_channel = getattr(guild, "fetch_channel", None)
+    if not callable(fetch_channel):
+        return None
+    try:
+        return await fetch_channel(canal_id)
+    except Exception:
+        return None
+
+
+async def materializar_partidos_comunidades(
+    session: Any,
+    guild: Any,
+    *,
+    enfrentamiento_id: int,
+) -> ResultadoMaterializacionDiscordComunidades:
+    """Crea de forma reintentable los dos registros y sus canales privados.
+
+    Las identidades se confirman primero. Después cada canal se crea, recibe su
+    mensaje y se asocia al partido en una confirmación independiente. Así, un
+    fallo tras el primer canal deja un estado parcial visible y recuperable sin
+    duplicar el canal ya guardado.
+    """
+    import discord
+    from ComunidadesCore import materializar_identidades_partidos_comunidades
+    from GestorSQL import ComunidadesEnfrentamiento, ComunidadesPartido
+
+    try:
+        materializar_identidades_partidos_comunidades(
+            session, enfrentamiento_id=enfrentamiento_id
+        )
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+
+    enfrentamiento = session.get(ComunidadesEnfrentamiento, enfrentamiento_id)
+    partidos = (
+        session.query(ComunidadesPartido)
+        .filter(ComunidadesPartido.enfrentamiento_id == enfrentamiento_id)
+        .order_by(ComunidadesPartido.indice)
+        .all()
+    )
+    if enfrentamiento is None or len(partidos) != 2:
+        _error_materializacion_discord(
+            "IDENTIDADES_NO_DISPONIBLES",
+            "No se pudieron recuperar las dos identidades persistidas.",
+        )
+
+    pendientes = [partido for partido in partidos if partido.canal_discord_id is None]
+    if not pendientes:
+        if enfrentamiento.estado != "PARTIDOS_CREADOS":
+            enfrentamiento.estado = "PARTIDOS_CREADOS"
+            session.commit()
+        return ResultadoMaterializacionDiscordComunidades(
+            enfrentamiento_id=enfrentamiento_id,
+            partido_ids=(int(partidos[0].id), int(partidos[1].id)),
+            canal_ids=(int(partidos[0].canal_discord_id), int(partidos[1].canal_discord_id)),
+            canales_creados=0,
+        )
+
+    canal_general_id = enfrentamiento.canal_general_discord_id
+    if canal_general_id is None:
+        _error_materializacion_discord(
+            "CANAL_GENERAL_NO_ASOCIADO",
+            "El enfrentamiento no tiene un canal general asociado.",
+        )
+    canal_general = await _resolver_canal_comunidades(guild, int(canal_general_id))
+    if canal_general is None:
+        _error_materializacion_discord(
+            "CANAL_GENERAL_INACCESIBLE",
+            f"No se pudo acceder al canal general {int(canal_general_id)}.",
+        )
+
+    comisario_role = next(
+        (rol for rol in getattr(guild, "roles", ()) if getattr(rol, "name", None) == "Comisario"),
+        None,
+    )
+    if comisario_role is None:
+        _error_materializacion_discord(
+            "ROL_COMISARIO_INEXISTENTE",
+            "No existe el rol Comisario necesario para configurar los permisos.",
+        )
+
+    miembros_por_partido = {}
+    for partido in pendientes:
+        miembros = []
+        for usuario in (partido.usuario_local, partido.usuario_visitante):
+            discord_id = getattr(usuario, "id_discord", None)
+            if discord_id is None:
+                _error_materializacion_discord(
+                    "USUARIO_SIN_DISCORD",
+                    f"El usuario BD {int(usuario.idUsuarios)} no tiene ID de Discord.",
+                )
+            miembro = await _resolver_miembro_comunidades(guild, int(discord_id))
+            if miembro is None:
+                _error_materializacion_discord(
+                    "MIEMBRO_NO_ENCONTRADO",
+                    f"No se encontró el usuario Discord {int(discord_id)} en el servidor.",
+                )
+            miembros.append(miembro)
+        miembros_por_partido[int(partido.id)] = tuple(miembros)
+
+    categorias = await planificar_categorias_comunidades(
+        session,
+        guild,
+        torneo_id=int(enfrentamiento.torneo_id),
+        tipo="partidos",
+        cantidad=len(pendientes),
+    )
+
+    await canal_general.send("Se van a crear los encuentros")
+
+    canales_creados = 0
+    for partido, categoria in zip(pendientes, categorias):
+        miembros = miembros_por_partido[int(partido.id)]
+        overwrites = {
+            guild.default_role: discord.PermissionOverwrite(
+                view_channel=False, read_messages=False
+            ),
+            comisario_role: discord.PermissionOverwrite(
+                view_channel=True, read_messages=True, send_messages=True
+            ),
+        }
+        for miembro in miembros:
+            overwrites[miembro] = discord.PermissionOverwrite(
+                view_channel=True, read_messages=True, send_messages=True
+            )
+
+        canal = None
+        try:
+            canal = await guild.create_text_channel(
+                name=_nombre_canal_partido_comunidades(enfrentamiento, partido),
+                category=categoria,
+                overwrites=overwrites,
+                reason=(
+                    f"Torneo de comunidades, enfrentamiento {enfrentamiento_id}, "
+                    f"partido {int(partido.indice)}"
+                ),
+            )
+            await canal.send(_mensaje_partido_comunidades(enfrentamiento, partido))
+            partido.canal_discord_id = int(canal.id)
+            session.commit()
+            canales_creados += 1
+        except Exception as exc:
+            session.rollback()
+            limpieza = ""
+            if canal is not None:
+                try:
+                    await canal.delete(reason="Fallo al materializar partido de comunidades")
+                except Exception as error_limpieza:
+                    limpieza = f"; no se pudo eliminar el canal huérfano ({error_limpieza})"
+            _error_materializacion_discord(
+                "FALLO_CREACION_CANAL",
+                f"Falló el canal del partido {int(partido.indice)} ({exc}){limpieza}.",
+            )
+
+    session.expire_all()
+    enfrentamiento = session.get(ComunidadesEnfrentamiento, enfrentamiento_id)
+    partidos = (
+        session.query(ComunidadesPartido)
+        .filter(ComunidadesPartido.enfrentamiento_id == enfrentamiento_id)
+        .order_by(ComunidadesPartido.indice)
+        .all()
+    )
+    if len(partidos) == 2 and all(partido.canal_discord_id is not None for partido in partidos):
+        enfrentamiento.estado = "PARTIDOS_CREADOS"
+        session.commit()
+
+    return ResultadoMaterializacionDiscordComunidades(
+        enfrentamiento_id=enfrentamiento_id,
+        partido_ids=(int(partidos[0].id), int(partidos[1].id)),
+        canal_ids=(int(partidos[0].canal_discord_id), int(partidos[1].canal_discord_id)),
+        canales_creados=canales_creados,
+    )

--- a/tests/test_comunidades_materializacion_partidos.py
+++ b/tests/test_comunidades_materializacion_partidos.py
@@ -1,0 +1,283 @@
+import asyncio
+from datetime import datetime
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session
+
+from ComunidadesCore import materializar_identidades_partidos_comunidades
+from ComunidadesDiscord import (
+    ErrorMaterializacionDiscordComunidades,
+    materializar_partidos_comunidades,
+)
+from GestorSQL import (
+    Base,
+    ComunidadesCategoriaPartido,
+    ComunidadesComunidad,
+    ComunidadesEleccionAtacante,
+    ComunidadesEnfrentamiento,
+    ComunidadesEquipo,
+    ComunidadesPartido,
+    ComunidadesRonda,
+    ComunidadesTorneo,
+    Usuario,
+)
+
+
+def _engine():
+    engine = create_engine("sqlite://")
+
+    @event.listens_for(engine, "connect")
+    def _foreign_keys(dbapi_connection, _):
+        dbapi_connection.execute("PRAGMA foreign_keys=ON")
+
+    Base.metadata.create_all(engine)
+    return engine
+
+
+def _crear_escenario(session):
+    torneo = ComunidadesTorneo(
+        nombre="Comunidades",
+        rondas_totales=1,
+        fecha_fin_ronda1=datetime(2026, 7, 8, 22, 0),
+        plantilla_mensaje_ronda1="R1",
+        plantilla_mensaje_rondas_siguientes="R2",
+        creado_por_discord_id=999,
+    )
+    session.add(torneo)
+    session.flush()
+    comunidades = [
+        ComunidadesComunidad(torneo_id=torneo.id, nombre="A"),
+        ComunidadesComunidad(torneo_id=torneo.id, nombre="B"),
+    ]
+    session.add_all(comunidades)
+    session.flush()
+    equipos = [
+        ComunidadesEquipo(torneo_id=torneo.id, comunidad_id=comunidades[0].id, nombre="Equipo A"),
+        ComunidadesEquipo(torneo_id=torneo.id, comunidad_id=comunidades[1].id, nombre="Equipo B"),
+    ]
+    session.add_all(equipos)
+    session.flush()
+    usuarios = [
+        Usuario(idUsuarios=11, id_discord=101, nombre_discord="A Uno"),
+        Usuario(idUsuarios=12, id_discord=102, nombre_discord="A Dos"),
+        Usuario(idUsuarios=21, id_discord=201, nombre_discord="B Uno"),
+        Usuario(idUsuarios=22, id_discord=202, nombre_discord="B Dos"),
+    ]
+    session.add_all(usuarios)
+    ronda = ComunidadesRonda(
+        torneo_id=torneo.id,
+        numero=1,
+        estado="ABIERTA",
+        fecha_inicio=datetime(2026, 7, 1),
+        fecha_fin=datetime(2026, 7, 8, 22, 0),
+        generada_por_discord_id=999,
+    )
+    session.add(ronda)
+    session.flush()
+    enfrentamiento = ComunidadesEnfrentamiento(
+        torneo_id=torneo.id,
+        ronda_id=ronda.id,
+        mesa_numero=1,
+        equipo_a_id=equipos[0].id,
+        equipo_b_id=equipos[1].id,
+        canal_general_discord_id=700,
+        estado="ELECCIONES_COMPLETAS",
+    )
+    session.add(enfrentamiento)
+    session.flush()
+    session.add_all(
+        [
+            ComunidadesEleccionAtacante(
+                torneo_id=torneo.id,
+                enfrentamiento_id=enfrentamiento.id,
+                equipo_id=equipos[0].id,
+                atacante_usuario_id=12,
+                defensor_usuario_id=11,
+                elegido_por_discord_id=102,
+                bloqueada=True,
+            ),
+            ComunidadesEleccionAtacante(
+                torneo_id=torneo.id,
+                enfrentamiento_id=enfrentamiento.id,
+                equipo_id=equipos[1].id,
+                atacante_usuario_id=21,
+                defensor_usuario_id=22,
+                elegido_por_discord_id=201,
+                bloqueada=True,
+            ),
+            ComunidadesCategoriaPartido(
+                torneo_id=torneo.id,
+                categoria_discord_id=800,
+                orden_alta=1,
+            ),
+        ]
+    )
+    session.commit()
+    return enfrentamiento.id
+
+
+class ObjetoDiscord:
+    def __init__(self, identificador, nombre=None):
+        self.id = identificador
+        self.name = nombre
+
+
+class CanalDiscord(ObjetoDiscord):
+    def __init__(self, identificador, categoria=None):
+        super().__init__(identificador)
+        self.categoria = categoria
+        self.mensajes = []
+        self.eliminado = False
+
+    async def send(self, mensaje):
+        self.mensajes.append(mensaje)
+
+    async def delete(self, reason=None):
+        self.eliminado = True
+        if self.categoria is not None and self in self.categoria.channels:
+            self.categoria.channels.remove(self)
+
+
+class CategoriaDiscord(ObjetoDiscord):
+    def __init__(self, identificador):
+        super().__init__(identificador)
+        self.channels = []
+
+
+class GuildDiscord:
+    def __init__(self, *, fallar_en_creacion=None):
+        self.default_role = ObjetoDiscord(1, "@everyone")
+        self.comisario = ObjetoDiscord(2, "Comisario")
+        self.roles = [self.default_role, self.comisario]
+        self.miembros = {
+            discord_id: ObjetoDiscord(discord_id, str(discord_id))
+            for discord_id in (101, 102, 201, 202)
+        }
+        self.general = CanalDiscord(700)
+        self.categoria = CategoriaDiscord(800)
+        self.canales = {700: self.general, 800: self.categoria}
+        self.creaciones = []
+        self.fallar_en_creacion = fallar_en_creacion
+        self.intentos_creacion = 0
+
+    @property
+    def me(self):
+        return None
+
+    def get_member(self, identificador):
+        return self.miembros.get(identificador)
+
+    def get_channel(self, identificador):
+        return self.canales.get(identificador)
+
+    async def fetch_channel(self, identificador):
+        return self.canales.get(identificador)
+
+    async def create_text_channel(self, *, name, category, overwrites, reason):
+        self.intentos_creacion += 1
+        if self.fallar_en_creacion == self.intentos_creacion:
+            raise RuntimeError("fallo simulado")
+        canal = CanalDiscord(900 + self.intentos_creacion, category)
+        category.channels.append(canal)
+        self.canales[canal.id] = canal
+        self.creaciones.append(
+            {"canal": canal, "name": name, "category": category, "overwrites": overwrites}
+        )
+        return canal
+
+
+def test_construye_los_dos_cruces_con_indices_estables_e_idempotentes():
+    engine = _engine()
+    with Session(engine) as session:
+        enfrentamiento_id = _crear_escenario(session)
+
+        primero = materializar_identidades_partidos_comunidades(
+            session, enfrentamiento_id=enfrentamiento_id
+        )
+        session.commit()
+        segundo = materializar_identidades_partidos_comunidades(
+            session, enfrentamiento_id=enfrentamiento_id
+        )
+
+        assert primero.creados is True
+        assert segundo.creados is False
+        partidos = session.query(ComunidadesPartido).order_by(ComunidadesPartido.indice).all()
+        assert len(partidos) == 2
+        assert [partido.indice for partido in partidos] == [1, 2]
+        assert (partidos[0].usuario_local_id, partidos[0].usuario_visitante_id) == (12, 22)
+        assert (partidos[1].usuario_local_id, partidos[1].usuario_visitante_id) == (21, 11)
+        assert (partidos[0].atacante_usuario_id, partidos[0].defensor_usuario_id) == (12, 22)
+        assert (partidos[1].atacante_usuario_id, partidos[1].defensor_usuario_id) == (21, 11)
+
+
+def test_materializa_dos_canales_con_permisos_mensajes_y_estado():
+    engine = _engine()
+    guild = GuildDiscord()
+    with Session(engine) as session:
+        enfrentamiento_id = _crear_escenario(session)
+        resultado = asyncio.run(
+            materializar_partidos_comunidades(
+                session, guild, enfrentamiento_id=enfrentamiento_id
+            )
+        )
+
+        assert resultado.canales_creados == 2
+        assert len(guild.creaciones) == 2
+        assert guild.general.mensajes == ["Se van a crear los encuentros"]
+        assert all(creacion["category"] is guild.categoria for creacion in guild.creaciones)
+        assert set(guild.creaciones[0]["overwrites"]) == {
+            guild.default_role,
+            guild.comisario,
+            guild.miembros[102],
+            guild.miembros[202],
+        }
+        assert "**Atacante:** <@102>" in guild.creaciones[0]["canal"].mensajes[0]
+        assert "**Defensor:** <@202>" in guild.creaciones[0]["canal"].mensajes[0]
+        assert "**Fecha límite:** 2026-07-08 22:00" in guild.creaciones[0]["canal"].mensajes[0]
+        enfrentamiento = session.get(ComunidadesEnfrentamiento, enfrentamiento_id)
+        assert enfrentamiento.estado == "PARTIDOS_CREADOS"
+        assert [partido.canal_discord_id for partido in enfrentamiento.partidos] == [901, 902]
+
+        repetido = asyncio.run(
+            materializar_partidos_comunidades(
+                session, guild, enfrentamiento_id=enfrentamiento_id
+            )
+        )
+        assert repetido.canales_creados == 0
+        assert len(guild.creaciones) == 2
+        assert session.query(ComunidadesPartido).count() == 2
+
+
+def test_fallo_tras_primer_canal_es_detectable_y_reintento_no_duplica():
+    engine = _engine()
+    guild = GuildDiscord(fallar_en_creacion=2)
+    with Session(engine) as session:
+        enfrentamiento_id = _crear_escenario(session)
+
+        with pytest.raises(ErrorMaterializacionDiscordComunidades) as error:
+            asyncio.run(
+                materializar_partidos_comunidades(
+                    session, guild, enfrentamiento_id=enfrentamiento_id
+                )
+            )
+        assert error.value.codigo == "FALLO_CREACION_CANAL"
+        partidos = session.query(ComunidadesPartido).order_by(ComunidadesPartido.indice).all()
+        assert len(partidos) == 2
+        assert [partido.canal_discord_id for partido in partidos] == [901, None]
+        assert session.get(ComunidadesEnfrentamiento, enfrentamiento_id).estado == "ELECCIONES_COMPLETAS"
+
+        guild.fallar_en_creacion = None
+        resultado = asyncio.run(
+            materializar_partidos_comunidades(
+                session, guild, enfrentamiento_id=enfrentamiento_id
+            )
+        )
+        assert resultado.canales_creados == 1
+        assert session.query(ComunidadesPartido).count() == 2
+        assert [partido.canal_discord_id for partido in session.query(ComunidadesPartido).order_by(ComunidadesPartido.indice)] == [901, 903]
+        assert session.get(ComunidadesEnfrentamiento, enfrentamiento_id).estado == "PARTIDOS_CREADOS"


### PR DESCRIPTION
### Motivation

- Garantizar que, al quedar ambas `elecciones` bloqueadas, se creen exactamente dos `partidos` individuales con identidades estables antes de tocar Discord. 
- Permitir reintentos seguros sin duplicar registros ni canales y detectar/recover de fallos parciales durante la creación de canales. 
- Cumplir la especificación: partido 1 = atacante A vs defensor B; partido 2 = atacante B vs defensor A; y marcar el enfrentamiento como `PARTIDOS_CREADOS` cuando ambos canales estén asociados.

### Description

- Añadido `materializar_identidades_partidos_comunidades(session, enfrentamiento_id)` en `ComunidadesCore.py` para persistir atómicamente dos `ComunidadesPartido` con índices `1` y `2` y devolver las identidades (idempotente). 
- Añadida la API `materializar_partidos_comunidades(session, guild, enfrentamiento_id)` en `ComunidadesDiscord.py` que: selecciona categorías de `partidos`, publica `Se van a crear los encuentros` en el canal general, crea canales individuales con `PermissionOverwrite` para los dos jugadores y el rol `Comisario`, envía el mensaje específico (atacante/defensor/fecha límite) y persiste cada `canal_discord_id` por separado para permitir reintentos sin duplicación. 
- Introducidas clases de error y tipos de resultado para distinguir fallos de dominio y errores de materialización en Discord (`ErrorMaterializacionPartidosComunidades`, `ErrorMaterializacionDiscordComunidades`, y tipos `Resultado*`). 
- Logica de persistencia: confirmar (commit) las identidades antes de crear canales en Discord; confirmar cada canal individualmente tras creación; si ambos canales quedan asociados, el `enfrentamiento.estado` pasa a `PARTIDOS_CREADOS`. 
- Añadidos tests en `tests/test_comunidades_materializacion_partidos.py` que cubren la construcción de cruces, idempotencia, permisos/mensajes y la recuperación tras un fallo simulado al crear el segundo canal.

### Testing

- Ejecutadas las pruebas específicas: `pytest -q tests/test_comunidades_materializacion_partidos.py tests/test_comunidades_seleccion_atacante.py tests/test_comunidades_categorias_discord.py`, que pasaron (22 tests de materialización y relacionadas OK). 
- Suite completa: `pytest -q` ejecutada y superó todas las pruebas (440 passed). 
- Archivo compilado: `python -m py_compile ComunidadesCore.py ComunidadesDiscord.py` sin errores. 
- Verificación básica de formato: `git diff --check` no reportó problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24b18fe114832a9e78d4915be0f941)