### PR TITLE
Add attacker-selection command and orchestration + accept Discord attacker id, improve messaging and tests

### DIFF
--- a/ComunidadesCore.py
+++ b/ComunidadesCore.py
@@ -1449,8 +1449,10 @@ class ResultadoSeleccionAtacanteComunidades:
     eleccion: Any
     atacante: Any
     defensor: Any
+    equipo_nombre: str
     ambas_elecciones_completas: bool
     requiere_crear_partidos: bool
+    acaba_de_completar_elecciones: bool
 
 
 def _error_seleccion_atacante(codigo: str, detalle: str) -> None:
@@ -1506,7 +1508,8 @@ def registrar_eleccion_atacante_comunidades(
     session: Any,
     *,
     actor_discord_id: int,
-    atacante_usuario_id: int,
+    atacante_usuario_id: Optional[int] = None,
+    atacante_discord_id: Optional[int] = None,
     enfrentamiento_id: Optional[int] = None,
     canal_general_discord_id: Optional[int] = None,
     elegido_en: Optional[datetime] = None,
@@ -1528,7 +1531,17 @@ def registrar_eleccion_atacante_comunidades(
         _error_seleccion_atacante(
             "ACTOR_INVALIDO", "El ID Discord del actor debe ser un entero mayor que cero."
         )
-    if type(atacante_usuario_id) is not int or atacante_usuario_id <= 0:
+    if (atacante_usuario_id is None) == (atacante_discord_id is None):
+        _error_seleccion_atacante(
+            "ATACANTE_INVALIDO",
+            "Debe indicarse exactamente un ID interno o un ID Discord del atacante.",
+        )
+    atacante_referencia = (
+        atacante_usuario_id
+        if atacante_usuario_id is not None
+        else atacante_discord_id
+    )
+    if type(atacante_referencia) is not int or atacante_referencia <= 0:
         _error_seleccion_atacante(
             "ATACANTE_INVALIDO", "El ID del atacante debe ser un entero mayor que cero."
         )
@@ -1557,6 +1570,12 @@ def registrar_eleccion_atacante_comunidades(
         )
         session.expire_all()
         enfrentamiento = session.get(ComunidadesEnfrentamiento, identificador)
+
+        if enfrentamiento.ronda is None or enfrentamiento.ronda.estado != "ABIERTA":
+            _error_seleccion_atacante(
+                "ENFRENTAMIENTO_NO_ACTIVO",
+                "El enfrentamiento no pertenece a una ronda activa.",
+            )
 
         equipo_ids = (int(enfrentamiento.equipo_a_id), int(enfrentamiento.equipo_b_id))
         miembros = (
@@ -1591,7 +1610,16 @@ def registrar_eleccion_atacante_comunidades(
             (
                 miembro
                 for miembro in miembros_equipo
-                if int(miembro.usuario_id) == atacante_usuario_id
+                if (
+                    atacante_usuario_id is not None
+                    and int(miembro.usuario_id) == atacante_usuario_id
+                )
+                or (
+                    atacante_discord_id is not None
+                    and miembro.usuario is not None
+                    and miembro.usuario.id_discord is not None
+                    and int(miembro.usuario.id_discord) == atacante_discord_id
+                )
             ),
             None,
         )
@@ -1600,10 +1628,11 @@ def registrar_eleccion_atacante_comunidades(
                 "ATACANTE_NO_PERTENECE",
                 "El atacante seleccionado no pertenece al equipo del actor.",
             )
+        atacante_usuario_id_resuelto = int(atacante_miembro.usuario_id)
         defensor_miembro = next(
             miembro
             for miembro in miembros_equipo
-            if int(miembro.usuario_id) != atacante_usuario_id
+            if int(miembro.usuario_id) != atacante_usuario_id_resuelto
         )
 
         eleccion = (
@@ -1615,20 +1644,6 @@ def registrar_eleccion_atacante_comunidades(
             .one_or_none()
         )
         if enfrentamiento.estado != ENFRENTAMIENTO_PENDIENTE_ELECCIONES:
-            if (
-                enfrentamiento.estado == ENFRENTAMIENTO_ELECCIONES_COMPLETAS
-                and eleccion is not None
-                and int(eleccion.atacante_usuario_id) == atacante_usuario_id
-                and bool(eleccion.bloqueada)
-            ):
-                session.commit()
-                return ResultadoSeleccionAtacanteComunidades(
-                    eleccion=eleccion,
-                    atacante=atacante_miembro.usuario,
-                    defensor=defensor_miembro.usuario,
-                    ambas_elecciones_completas=True,
-                    requiere_crear_partidos=True,
-                )
             _error_seleccion_atacante(
                 "ELECCIONES_BLOQUEADAS",
                 "Las elecciones del enfrentamiento ya no se pueden modificar.",
@@ -1640,7 +1655,7 @@ def registrar_eleccion_atacante_comunidades(
                 torneo_id=enfrentamiento.torneo_id,
                 enfrentamiento_id=identificador,
                 equipo_id=equipo_id,
-                atacante_usuario_id=atacante_usuario_id,
+                atacante_usuario_id=atacante_usuario_id_resuelto,
                 defensor_usuario_id=int(defensor_miembro.usuario_id),
                 elegido_por_discord_id=actor_discord_id,
                 elegido_en=ahora,
@@ -1653,7 +1668,7 @@ def registrar_eleccion_atacante_comunidades(
                     "ELECCIONES_BLOQUEADAS",
                     "La elección del equipo ya está bloqueada.",
                 )
-            eleccion.atacante_usuario_id = atacante_usuario_id
+            eleccion.atacante_usuario_id = atacante_usuario_id_resuelto
             eleccion.defensor_usuario_id = int(defensor_miembro.usuario_id)
             eleccion.elegido_por_discord_id = actor_discord_id
             eleccion.elegido_en = ahora
@@ -1676,8 +1691,10 @@ def registrar_eleccion_atacante_comunidades(
             eleccion=eleccion,
             atacante=atacante_miembro.usuario,
             defensor=defensor_miembro.usuario,
+            equipo_nombre=str(atacante_miembro.equipo.nombre),
             ambas_elecciones_completas=completas,
             requiere_crear_partidos=completas,
+            acaba_de_completar_elecciones=completas,
         )
     except Exception:
         session.rollback()

--- a/ComunidadesDiscord.py
+++ b/ComunidadesDiscord.py
@@ -436,8 +436,6 @@ async def materializar_partidos_comunidades(
         cantidad=len(pendientes),
     )
 
-    await canal_general.send("Se van a crear los encuentros")
-
     canales_creados = 0
     for partido, categoria in zip(pendientes, categorias):
         miembros = miembros_por_partido[int(partido.id)]
@@ -500,3 +498,230 @@ async def materializar_partidos_comunidades(
         canal_ids=(int(partidos[0].canal_discord_id), int(partidos[1].canal_discord_id)),
         canales_creados=canales_creados,
     )
+
+
+def texto_discord_seguro_comunidades(valor: object) -> str:
+    """Evita menciones accidentales al presentar nombres configurables."""
+    return str(valor or "").replace("@", "@\u200b")
+
+
+def mencion_usuario_comunidades(usuario: Any) -> str:
+    """Construye una mención desde un usuario persistido por comunidades."""
+    discord_id = getattr(usuario, "id_discord", None)
+    if discord_id is None:
+        return texto_discord_seguro_comunidades(
+            getattr(usuario, "nombre_discord", "Jugador")
+        )
+    return f"<@{int(discord_id)}>"
+
+
+def mensaje_eleccion_ephemeral_comunidades(resultado: Any) -> str:
+    """Presenta únicamente al equipo que eligió sus identidades privadas."""
+    return (
+        f"**Equipo:** {texto_discord_seguro_comunidades(resultado.equipo_nombre)}\n"
+        f"**Atacante:** {mencion_usuario_comunidades(resultado.atacante)}\n"
+        f"**Defensor:** {mencion_usuario_comunidades(resultado.defensor)}"
+    )
+
+
+async def _responder_ephemeral_comunidades(interaction: Any, mensaje: str) -> None:
+    respuesta = interaction.response
+    if respuesta.is_done():
+        await interaction.followup.send(mensaje, ephemeral=True)
+    else:
+        await respuesta.send_message(mensaje, ephemeral=True)
+
+
+_MENSAJES_ERROR_SELECCION_COMUNIDADES = {
+    "ENFRENTAMIENTO_NO_EXISTE": (
+        "Este canal no corresponde al canal general de un enfrentamiento activo."
+    ),
+    "CANAL_ENFRENTAMIENTO_AMBIGUO": (
+        "Este canal no permite identificar un único enfrentamiento activo."
+    ),
+    "ENFRENTAMIENTO_NO_ACTIVO": "El enfrentamiento de este canal no está activo.",
+    "ACTOR_NO_PERTENECE": "No perteneces a ninguno de los equipos de este enfrentamiento.",
+    "ATACANTE_NO_PERTENECE": "Solo puedes elegir a un miembro de tu propio equipo.",
+    "EQUIPO_INCOMPLETO": "Tu equipo no tiene exactamente dos miembros configurados.",
+    "ELECCIONES_BLOQUEADAS": "Las elecciones ya están completas y no se pueden modificar.",
+}
+
+
+def resolver_enfrentamiento_id_por_canal_comunidades(
+    session: Any, canal_general_discord_id: int
+) -> int:
+    """Traduce el contexto Discord a una única referencia de dominio."""
+    from ComunidadesCore import ErrorSeleccionAtacanteComunidades
+    from GestorSQL import ComunidadesEnfrentamiento
+
+    enfrentamientos = (
+        session.query(ComunidadesEnfrentamiento.id)
+        .filter(
+            ComunidadesEnfrentamiento.canal_general_discord_id
+            == canal_general_discord_id
+        )
+        .limit(2)
+        .all()
+    )
+    if not enfrentamientos:
+        raise ErrorSeleccionAtacanteComunidades(
+            "ENFRENTAMIENTO_NO_EXISTE",
+            "No existe un enfrentamiento asociado al canal indicado.",
+        )
+    if len(enfrentamientos) != 1:
+        raise ErrorSeleccionAtacanteComunidades(
+            "CANAL_ENFRENTAMIENTO_AMBIGUO",
+            "El canal está asociado a más de un enfrentamiento.",
+        )
+    return int(enfrentamientos[0][0])
+
+
+async def ejecutar_seleccion_atacante_comunidades(
+    interaction: Any,
+    usuario: Any,
+    *,
+    session_factory: Any,
+    servicio_eleccion: Any = None,
+    servicio_materializacion: Any = None,
+    servicio_resolucion_enfrentamiento: Any = None,
+    notificar_administracion: Any = None,
+    elegido_en: Optional[datetime] = None,
+) -> Optional[Any]:
+    """Orquesta el slash command sin reproducir reglas de dominio.
+
+    Cada servicio recibe una sesión independiente. La elección queda confirmada
+    y su sesión se cierra antes de publicar en Discord o crear canales.
+    """
+    from ComunidadesCore import (
+        ErrorSeleccionAtacanteComunidades,
+        registrar_eleccion_atacante_comunidades,
+    )
+
+    if servicio_eleccion is None:
+        servicio_eleccion = registrar_eleccion_atacante_comunidades
+    if servicio_materializacion is None:
+        servicio_materializacion = materializar_partidos_comunidades
+    if servicio_resolucion_enfrentamiento is None:
+        servicio_resolucion_enfrentamiento = resolver_enfrentamiento_id_por_canal_comunidades
+
+    guild = getattr(interaction, "guild", None)
+    channel = getattr(interaction, "channel", None)
+    actor = getattr(interaction, "user", None)
+    if guild is None or channel is None or actor is None:
+        await _responder_ephemeral_comunidades(
+            interaction, "Este comando solo puede utilizarse en el servidor."
+        )
+        return None
+
+    session = session_factory()
+    try:
+        enfrentamiento_id = servicio_resolucion_enfrentamiento(
+            session, int(channel.id)
+        )
+        resultado = servicio_eleccion(
+            session,
+            enfrentamiento_id=enfrentamiento_id,
+            actor_discord_id=int(actor.id),
+            atacante_discord_id=int(usuario.id),
+            elegido_en=elegido_en,
+        )
+        enfrentamiento_id = int(resultado.eleccion.enfrentamiento_id)
+        mensaje_privado = mensaje_eleccion_ephemeral_comunidades(resultado)
+        mensaje_publico = (
+            "El equipo "
+            f"{texto_discord_seguro_comunidades(resultado.equipo_nombre)} "
+            "ha elegido atacante"
+        )
+        requiere_materializacion = bool(resultado.requiere_crear_partidos)
+    except ErrorSeleccionAtacanteComunidades as exc:
+        await _responder_ephemeral_comunidades(
+            interaction,
+            _MENSAJES_ERROR_SELECCION_COMUNIDADES.get(
+                exc.codigo, "No se pudo registrar la elección indicada."
+            ),
+        )
+        return None
+    except Exception as exc:
+        try:
+            session.rollback()
+        finally:
+            if notificar_administracion is not None:
+                await notificar_administracion(
+                    "Fallo al registrar una elección de comunidades "
+                    f"en el canal `{int(channel.id)}` ({type(exc).__name__}: {exc})."
+                )
+        await _responder_ephemeral_comunidades(
+            interaction, "No se pudo registrar la elección. Inténtalo de nuevo más tarde."
+        )
+        return None
+    finally:
+        session.close()
+
+    try:
+        await _responder_ephemeral_comunidades(interaction, mensaje_privado)
+    except Exception as exc:
+        if notificar_administracion is not None:
+            await notificar_administracion(
+                "La elección quedó persistida, pero falló la respuesta privada "
+                f"del enfrentamiento `{enfrentamiento_id}` ({type(exc).__name__}: {exc})."
+            )
+
+    try:
+        await channel.send(mensaje_publico)
+    except Exception as exc:
+        if notificar_administracion is not None:
+            await notificar_administracion(
+                "La elección quedó persistida, pero falló el aviso público "
+                f"del enfrentamiento `{enfrentamiento_id}` ({type(exc).__name__}: {exc})."
+            )
+
+    if not requiere_materializacion:
+        return resultado
+
+    try:
+        await channel.send("Se van a crear los encuentros")
+    except Exception as exc:
+        if notificar_administracion is not None:
+            await notificar_administracion(
+                "Las elecciones quedaron bloqueadas, pero falló el aviso previo "
+                f"del enfrentamiento `{enfrentamiento_id}` ({type(exc).__name__}: {exc})."
+            )
+
+    session_materializacion = session_factory()
+    try:
+        materializacion = await servicio_materializacion(
+            session_materializacion,
+            guild,
+            enfrentamiento_id=enfrentamiento_id,
+        )
+    except Exception as exc:
+        session_materializacion.rollback()
+        if notificar_administracion is not None:
+            await notificar_administracion(
+                "Las elecciones del enfrentamiento "
+                f"`{enfrentamiento_id}` permanecen bloqueadas, pero la materialización "
+                f"no se completó ({type(exc).__name__}: {exc})."
+            )
+        try:
+            await _responder_ephemeral_comunidades(
+                interaction,
+                "La elección se guardó, pero no se pudieron crear todos los encuentros. "
+                "La administración ha sido avisada.",
+            )
+        except Exception:
+            pass
+        return resultado
+    finally:
+        session_materializacion.close()
+
+    canales = " y ".join(f"<#{int(canal_id)}>" for canal_id in materializacion.canal_ids)
+    try:
+        await channel.send(f"Encuentros creados: {canales}")
+    except Exception as exc:
+        if notificar_administracion is not None:
+            await notificar_administracion(
+                "Los encuentros del enfrentamiento "
+                f"`{enfrentamiento_id}` se materializaron, pero falló su confirmación "
+                f"pública ({type(exc).__name__}: {exc})."
+            )
+    return resultado

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -68,6 +68,7 @@ from ComunidadesCore import (
 )
 from ComunidadesDiscord import (
     ErrorSeleccionCategoriaComunidades,
+    ejecutar_seleccion_atacante_comunidades,
     parsear_decimal,
     parsear_fecha_limite,
     planificar_categorias_comunidades,
@@ -4604,6 +4605,31 @@ async def _publicar_error_administrativo_comunidades(ctx, mensaje: str) -> None:
     except Exception as exc:
         print(f"No se pudo publicar la incidencia de comunidades en administración: {exc}")
     await UtilesDiscord.enviar_mensaje_largo(ctx, texto)
+
+
+@bot.tree.command(
+    name="comunidades_seleccion_atacante",
+    description="Elige secretamente al atacante de tu equipo para este enfrentamiento",
+)
+@app_commands.describe(usuario="Miembro de tu equipo que actuará como atacante")
+async def comunidades_seleccion_atacante(
+    interaction: discord.Interaction,
+    usuario: discord.Member,
+):
+    SessionComunidades = sessionmaker(bind=GestorSQL.conexionEngine())
+
+    async def notificar_administracion(mensaje: str) -> None:
+        await UtilesDiscord.mensaje_administradores(
+            "❌ **Incidencia en selección de atacante de comunidades**\n" + mensaje
+        )
+
+    await ejecutar_seleccion_atacante_comunidades(
+        interaction,
+        usuario,
+        session_factory=SessionComunidades,
+        notificar_administracion=notificar_administracion,
+        elegido_en=datetime.now(ZoneInfo("UTC")).replace(tzinfo=None),
+    )
 
 
 async def _resolver_miembro_guild_comunidades(guild, discord_id: int):

--- a/tests/test_comunidades_materializacion_partidos.py
+++ b/tests/test_comunidades_materializacion_partidos.py
@@ -228,7 +228,7 @@ def test_materializa_dos_canales_con_permisos_mensajes_y_estado():
 
         assert resultado.canales_creados == 2
         assert len(guild.creaciones) == 2
-        assert guild.general.mensajes == ["Se van a crear los encuentros"]
+        assert guild.general.mensajes == []
         assert all(creacion["category"] is guild.categoria for creacion in guild.creaciones)
         assert set(guild.creaciones[0]["overwrites"]) == {
             guild.default_role,

--- a/tests/test_comunidades_seleccion_atacante.py
+++ b/tests/test_comunidades_seleccion_atacante.py
@@ -146,7 +146,7 @@ def test_resuelve_por_canal_registra_actor_y_deriva_defensor():
             session,
             canal_general_discord_id=555,
             actor_discord_id=101,
-            atacante_usuario_id=11,
+            atacante_discord_id=101,
             elegido_en=fecha,
         )
 
@@ -243,7 +243,7 @@ def test_segunda_eleccion_bloquea_ambas_y_marca_materializacion_pendiente():
         assert resultado.defensor.idUsuarios == 21
 
 
-def test_repeticion_identica_es_idempotente_y_cambio_posterior_se_rechaza():
+def test_cualquier_repeticion_posterior_al_bloqueo_se_rechaza():
     engine = _engine()
     enfrentamiento_id = _crear_escenario(engine)
 
@@ -254,32 +254,25 @@ def test_repeticion_identica_es_idempotente_y_cambio_posterior_se_rechaza():
             actor_discord_id=101,
             atacante_usuario_id=11,
         )
-        original = registrar_eleccion_atacante_comunidades(
-            session,
-            enfrentamiento_id=enfrentamiento_id,
-            actor_discord_id=201,
-            atacante_usuario_id=21,
-        )
-        repetida = registrar_eleccion_atacante_comunidades(
+        registrar_eleccion_atacante_comunidades(
             session,
             enfrentamiento_id=enfrentamiento_id,
             actor_discord_id=201,
             atacante_usuario_id=21,
         )
 
-        assert repetida.eleccion.id == original.eleccion.id
-        assert repetida.ambas_elecciones_completas is True
-        assert session.query(ComunidadesEleccionAtacante).count() == 2
+        for actor, atacante in ((201, 21), (202, 22)):
+            with pytest.raises(ErrorSeleccionAtacanteComunidades) as error:
+                registrar_eleccion_atacante_comunidades(
+                    session,
+                    enfrentamiento_id=enfrentamiento_id,
+                    actor_discord_id=actor,
+                    atacante_usuario_id=atacante,
+                )
+            assert error.value.codigo == "ELECCIONES_BLOQUEADAS"
 
-        with pytest.raises(ErrorSeleccionAtacanteComunidades) as error:
-            registrar_eleccion_atacante_comunidades(
-                session,
-                enfrentamiento_id=enfrentamiento_id,
-                actor_discord_id=202,
-                atacante_usuario_id=22,
-            )
-        assert error.value.codigo == "ELECCIONES_BLOQUEADAS"
         elecciones = session.query(ComunidadesEleccionAtacante).all()
+        assert len(elecciones) == 2
         assert {eleccion.atacante_usuario_id for eleccion in elecciones} == {11, 21}
 
 

--- a/tests/test_comunidades_seleccion_atacante_command.py
+++ b/tests/test_comunidades_seleccion_atacante_command.py
@@ -1,0 +1,301 @@
+import asyncio
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ComunidadesCore import ErrorSeleccionAtacanteComunidades
+from ComunidadesDiscord import ejecutar_seleccion_atacante_comunidades
+
+
+class SessionDoble:
+    def __init__(self):
+        self.closed = False
+        self.rollbacks = 0
+
+    def close(self):
+        self.closed = True
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+class ResponseDoble:
+    def __init__(self):
+        self.mensajes = []
+
+    def is_done(self):
+        return bool(self.mensajes)
+
+    async def send_message(self, mensaje, *, ephemeral=False):
+        self.mensajes.append((mensaje, ephemeral))
+
+
+class FollowupDoble:
+    def __init__(self):
+        self.mensajes = []
+
+    async def send(self, mensaje, *, ephemeral=False):
+        self.mensajes.append((mensaje, ephemeral))
+
+
+class CanalDoble:
+    def __init__(self, canal_id=555, fallar_en=None):
+        self.id = canal_id
+        self.mensajes = []
+        self.fallar_en = fallar_en
+        self.intentos = 0
+
+    async def send(self, mensaje):
+        self.intentos += 1
+        if self.fallar_en == self.intentos:
+            raise RuntimeError("fallo Discord")
+        self.mensajes.append(mensaje)
+
+
+class InteraccionDoble:
+    def __init__(self, *, canal=None, actor_id=101):
+        self.guild = SimpleNamespace(id=1)
+        self.channel = canal or CanalDoble()
+        self.user = SimpleNamespace(id=actor_id)
+        self.response = ResponseDoble()
+        self.followup = FollowupDoble()
+
+
+def resultado_eleccion(*, completar=False):
+    return SimpleNamespace(
+        eleccion=SimpleNamespace(enfrentamiento_id=77),
+        atacante=SimpleNamespace(id_discord=101, nombre_discord="Uno"),
+        defensor=SimpleNamespace(id_discord=102, nombre_discord="Dos"),
+        equipo_nombre="Equipo @A",
+        requiere_crear_partidos=completar,
+        acaba_de_completar_elecciones=completar,
+    )
+
+
+def ejecutar(coro):
+    return asyncio.run(coro)
+
+
+def test_primera_eleccion_responde_privado_publica_sin_identidades_y_no_materializa():
+    interaccion = InteraccionDoble()
+    sesiones = []
+    llamadas = []
+
+    def session_factory():
+        sesion = SessionDoble()
+        sesiones.append(sesion)
+        return sesion
+
+    def elegir(session, **kwargs):
+        llamadas.append(kwargs)
+        return resultado_eleccion()
+
+    async def materializar(*args, **kwargs):
+        raise AssertionError("No debe materializar la primera elección")
+
+    ejecutar(
+        ejecutar_seleccion_atacante_comunidades(
+            interaccion,
+            SimpleNamespace(id=101),
+            session_factory=session_factory,
+            servicio_eleccion=elegir,
+            servicio_materializacion=materializar,
+            servicio_resolucion_enfrentamiento=lambda session, canal_id: 77,
+            elegido_en=datetime(2026, 6, 7, 12, 0),
+        )
+    )
+
+    privado, ephemeral = interaccion.response.mensajes[0]
+    assert ephemeral is True
+    assert "**Equipo:** Equipo @\u200bA" in privado
+    assert "**Atacante:** <@101>" in privado
+    assert "**Defensor:** <@102>" in privado
+    assert interaccion.channel.mensajes == ["El equipo Equipo @\u200bA ha elegido atacante"]
+    assert llamadas == [{
+        "enfrentamiento_id": 77,
+        "actor_discord_id": 101,
+        "atacante_discord_id": 101,
+        "elegido_en": datetime(2026, 6, 7, 12, 0),
+    }]
+    assert len(sesiones) == 1 and sesiones[0].closed
+
+
+def test_segunda_eleccion_anuncia_materializa_una_vez_y_confirma_canales():
+    interaccion = InteraccionDoble(actor_id=201)
+    sesiones = []
+    materializaciones = []
+
+    def session_factory():
+        sesion = SessionDoble()
+        sesiones.append(sesion)
+        return sesion
+
+    def elegir(session, **kwargs):
+        return resultado_eleccion(completar=True)
+
+    async def materializar(session, guild, *, enfrentamiento_id):
+        materializaciones.append((session, guild, enfrentamiento_id))
+        return SimpleNamespace(canal_ids=(901, 902))
+
+    ejecutar(
+        ejecutar_seleccion_atacante_comunidades(
+            interaccion,
+            SimpleNamespace(id=202),
+            session_factory=session_factory,
+            servicio_eleccion=elegir,
+            servicio_materializacion=materializar,
+            servicio_resolucion_enfrentamiento=lambda session, canal_id: 77,
+        )
+    )
+
+    assert interaccion.channel.mensajes == [
+        "El equipo Equipo @\u200bA ha elegido atacante",
+        "Se van a crear los encuentros",
+        "Encuentros creados: <#901> y <#902>",
+    ]
+    assert len(materializaciones) == 1
+    assert materializaciones[0][2] == 77
+    assert len(sesiones) == 2 and all(sesion.closed for sesion in sesiones)
+
+
+def test_elecciones_bloqueadas_no_publican_ni_materializan():
+    interaccion = InteraccionDoble()
+    materializaciones = []
+
+    def elegir(session, **kwargs):
+        raise ErrorSeleccionAtacanteComunidades(
+            "ELECCIONES_BLOQUEADAS", "detalle no público"
+        )
+
+    async def materializar(*args, **kwargs):
+        materializaciones.append(True)
+
+    ejecutar(
+        ejecutar_seleccion_atacante_comunidades(
+            interaccion,
+            SimpleNamespace(id=101),
+            session_factory=SessionDoble,
+            servicio_eleccion=elegir,
+            servicio_materializacion=materializar,
+            servicio_resolucion_enfrentamiento=lambda session, canal_id: 77,
+        )
+    )
+
+    assert interaccion.response.mensajes == [
+        ("Las elecciones ya están completas y no se pueden modificar.", True)
+    ]
+    assert interaccion.channel.mensajes == []
+    assert materializaciones == []
+
+
+def test_fallo_materializacion_conserva_eleccion_notifica_y_cierra_sesion():
+    interaccion = InteraccionDoble()
+    sesiones = []
+    avisos = []
+
+    def session_factory():
+        sesion = SessionDoble()
+        sesiones.append(sesion)
+        return sesion
+
+    def elegir(session, **kwargs):
+        return resultado_eleccion(completar=True)
+
+    async def materializar(session, guild, *, enfrentamiento_id):
+        raise RuntimeError("secreto interno")
+
+    async def notificar(mensaje):
+        avisos.append(mensaje)
+
+    ejecutar(
+        ejecutar_seleccion_atacante_comunidades(
+            interaccion,
+            SimpleNamespace(id=101),
+            session_factory=session_factory,
+            servicio_eleccion=elegir,
+            servicio_materializacion=materializar,
+            servicio_resolucion_enfrentamiento=lambda session, canal_id: 77,
+            notificar_administracion=notificar,
+        )
+    )
+
+    assert len(sesiones) == 2
+    assert sesiones[1].rollbacks == 1
+    assert all(sesion.closed for sesion in sesiones)
+    assert "secreto interno" in avisos[0]
+    assert "secreto interno" not in interaccion.followup.mensajes[0][0]
+    assert interaccion.channel.mensajes == [
+        "El equipo Equipo @\u200bA ha elegido atacante",
+        "Se van a crear los encuentros",
+    ]
+
+
+def test_fallo_del_aviso_publico_no_revierte_y_aun_materializa():
+    interaccion = InteraccionDoble(canal=CanalDoble(fallar_en=1))
+    avisos = []
+    materializaciones = []
+
+    def elegir(session, **kwargs):
+        return resultado_eleccion(completar=True)
+
+    async def materializar(session, guild, *, enfrentamiento_id):
+        materializaciones.append(enfrentamiento_id)
+        return SimpleNamespace(canal_ids=(901, 902))
+
+    async def notificar(mensaje):
+        avisos.append(mensaje)
+
+    ejecutar(
+        ejecutar_seleccion_atacante_comunidades(
+            interaccion,
+            SimpleNamespace(id=101),
+            session_factory=SessionDoble,
+            servicio_eleccion=elegir,
+            servicio_materializacion=materializar,
+            servicio_resolucion_enfrentamiento=lambda session, canal_id: 77,
+            notificar_administracion=notificar,
+        )
+    )
+
+    assert materializaciones == [77]
+    assert avisos and "aviso público" in avisos[0]
+    assert interaccion.channel.mensajes == [
+        "Se van a crear los encuentros",
+        "Encuentros creados: <#901> y <#902>",
+    ]
+
+
+def test_canal_sin_enfrentamiento_se_rechaza_sin_llamar_servicios():
+    interaccion = InteraccionDoble(canal=CanalDoble(canal_id=999))
+    llamadas = []
+
+    def resolver(session, canal_id):
+        raise ErrorSeleccionAtacanteComunidades(
+            "ENFRENTAMIENTO_NO_EXISTE", "detalle interno"
+        )
+
+    def elegir(*args, **kwargs):
+        llamadas.append("eleccion")
+
+    async def materializar(*args, **kwargs):
+        llamadas.append("materializacion")
+
+    ejecutar(
+        ejecutar_seleccion_atacante_comunidades(
+            interaccion,
+            SimpleNamespace(id=101),
+            session_factory=SessionDoble,
+            servicio_resolucion_enfrentamiento=resolver,
+            servicio_eleccion=elegir,
+            servicio_materializacion=materializar,
+        )
+    )
+
+    assert interaccion.response.mensajes == [
+        ("Este canal no corresponde al canal general de un enfrentamiento activo.", True)
+    ]
+    assert interaccion.channel.mensajes == []
+    assert llamadas == []


### PR DESCRIPTION
### Motivation
- Provide a Discord slash command to let teams secretly select an attacker and orchestrate post-selection actions (public notice, ephemeral private confirmation, and channel materialization). 
- Allow identifying the selected attacker by Discord ID in addition to the internal user ID to simplify command usage from Discord. 
- Improve user-facing messages to avoid accidental mentions and surface only safe information in ephemeral replies. 

### Description
- Extended the selection result contract `ResultadoSeleccionAtacanteComunidades` with `equipo_nombre` and `acaba_de_completar_elecciones` fields and adjusted code paths to populate them. 
- Modified `registrar_eleccion_atacante_comunidades` to accept either `atacante_usuario_id` or `atacante_discord_id`, resolve the selection to the persisted user, validate the round is active, and consistently persist the resolved internal attacker id. 
- Added orchestration and UI helpers in `ComunidadesDiscord.py`: safe text escaping, user mention helper, ephemeral message builder, error message map, resolver to get enfrentamiento id from a channel, and `ejecutar_seleccion_atacante_comunidades` to implement the slash command flow including session management, notifications to admins on failures, public announcements, and invoking `materializar_partidos_comunidades` when both teams completed. 
- Removed the immediate public pre-message in `materializar_partidos_comunidades` so orchestration is responsible for announcing materialization; added a new bot tree command `comunidades_seleccion_atacante` wired to the orchestration function in `LombardBot.py`. 
- Updated and added tests to cover the new behavior and API: adapted existing selection/materialization tests and added `tests/test_comunidades_seleccion_atacante_command.py` for the command orchestration logic. 

### Testing
- Updated `tests/test_comunidades_seleccion_atacante.py` to reflect use of `atacante_discord_id` and changed post-blocking expectations, and `tests/test_comunidades_materializacion_partidos.py` to adjust message expectations; all assertions updated accordingly. 
- Added `tests/test_comunidades_seleccion_atacante_command.py` to unit-test the interaction orchestration including ephemeral replies, public announcements, admin notifications and materialization flows. 
- Ran the test suite for the modified areas (`pytest tests/test_comunidades_seleccion_atacante.py tests/test_comunidades_materializacion_partidos.py tests/test_comunidades_seleccion_atacante_command.py`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24b37d7928832a9d779e449a1e37e9)