### PR TITLE
Añade consulta y forzado administrativo de elecciones de comunidades

### DIFF
--- a/ComunidadesCore.py
+++ b/ComunidadesCore.py
@@ -1701,6 +1701,283 @@ def registrar_eleccion_atacante_comunidades(
         raise
 
 
+class ErrorAdministracionEleccionesComunidades(ValueError):
+    """Error de dominio para consultar o imponer elecciones administrativas."""
+
+    def __init__(self, codigo: str, detalle: str):
+        super().__init__(detalle)
+        self.codigo = codigo
+        self.detalle = detalle
+
+
+@dataclass(frozen=True)
+class EleccionEquipoAdministrativaComunidades:
+    equipo: Any
+    atacante: Optional[Any]
+    defensor: Optional[Any]
+    pendiente: bool
+    bloqueada: bool
+    actor_discord_id: Optional[int]
+    elegido_en: Optional[datetime]
+
+
+@dataclass(frozen=True)
+class EleccionesEnfrentamientoAdministrativasComunidades:
+    enfrentamiento: Any
+    elecciones: tuple[
+        EleccionEquipoAdministrativaComunidades,
+        EleccionEquipoAdministrativaComunidades,
+    ]
+
+
+def _error_administracion_elecciones(codigo: str, detalle: str) -> None:
+    raise ErrorAdministracionEleccionesComunidades(codigo, detalle)
+
+
+def consultar_elecciones_comunidades(
+    session: Any, *, torneo_id: int, ronda_numero: int
+) -> tuple[EleccionesEnfrentamientoAdministrativasComunidades, ...]:
+    """Devuelve las elecciones de una ronda; el llamador debe validar permisos antes."""
+    from GestorSQL import (
+        ComunidadesEleccionAtacante,
+        ComunidadesEnfrentamiento,
+        ComunidadesRonda,
+        ComunidadesTorneo,
+    )
+
+    for valor, nombre in ((torneo_id, "torneo_id"), (ronda_numero, "ronda")):
+        if type(valor) is not int or valor <= 0:
+            _error_administracion_elecciones(
+                "VALOR_INVALIDO", f"{nombre} debe ser un entero mayor que cero."
+            )
+    torneo = session.get(ComunidadesTorneo, torneo_id)
+    if torneo is None:
+        _error_administracion_elecciones(
+            "TORNEO_NO_EXISTE", f"No existe el torneo de comunidades {torneo_id}."
+        )
+    ronda = (
+        session.query(ComunidadesRonda)
+        .filter(
+            ComunidadesRonda.torneo_id == torneo_id,
+            ComunidadesRonda.numero == ronda_numero,
+        )
+        .one_or_none()
+    )
+    if ronda is None:
+        _error_administracion_elecciones(
+            "RONDA_NO_EXISTE",
+            f"No existe la ronda {ronda_numero} del torneo {torneo_id}.",
+        )
+
+    enfrentamientos = (
+        session.query(ComunidadesEnfrentamiento)
+        .filter(ComunidadesEnfrentamiento.ronda_id == ronda.id)
+        .order_by(ComunidadesEnfrentamiento.mesa_numero)
+        .all()
+    )
+    resultado = []
+    for enfrentamiento in enfrentamientos:
+        elecciones = (
+            session.query(ComunidadesEleccionAtacante)
+            .filter(
+                ComunidadesEleccionAtacante.enfrentamiento_id == enfrentamiento.id
+            )
+            .all()
+        )
+        por_equipo = {int(eleccion.equipo_id): eleccion for eleccion in elecciones}
+        detalles = []
+        for equipo in (enfrentamiento.equipo_a, enfrentamiento.equipo_b):
+            eleccion = por_equipo.get(int(equipo.id))
+            detalles.append(
+                EleccionEquipoAdministrativaComunidades(
+                    equipo=equipo,
+                    atacante=(eleccion.atacante_usuario if eleccion else None),
+                    defensor=(eleccion.defensor_usuario if eleccion else None),
+                    pendiente=eleccion is None,
+                    bloqueada=bool(eleccion.bloqueada) if eleccion else False,
+                    actor_discord_id=(
+                        int(eleccion.elegido_por_discord_id) if eleccion else None
+                    ),
+                    elegido_en=eleccion.elegido_en if eleccion else None,
+                )
+            )
+        resultado.append(
+            EleccionesEnfrentamientoAdministrativasComunidades(
+                enfrentamiento=enfrentamiento,
+                elecciones=(detalles[0], detalles[1]),
+            )
+        )
+    return tuple(resultado)
+
+
+def forzar_elecciones_comunidades(
+    session: Any,
+    *,
+    torneo_id: int,
+    ronda_numero: int,
+    enfrentamiento_id: int,
+    atacante_equipo_a_discord_id: int,
+    atacante_equipo_b_discord_id: int,
+    actor_discord_id: int,
+    elegido_en: Optional[datetime] = None,
+):
+    """Impone y bloquea las dos elecciones sin confirmar la transacción."""
+    from GestorSQL import (
+        ComunidadesEleccionAtacante,
+        ComunidadesEnfrentamiento,
+        ComunidadesMiembro,
+        ComunidadesPartido,
+        ComunidadesRonda,
+        ComunidadesTorneo,
+    )
+
+    for valor, nombre in (
+        (torneo_id, "torneo_id"),
+        (ronda_numero, "ronda"),
+        (enfrentamiento_id, "enfrentamiento"),
+        (atacante_equipo_a_discord_id, "atacante_equipo_a"),
+        (atacante_equipo_b_discord_id, "atacante_equipo_b"),
+        (actor_discord_id, "actor_discord_id"),
+    ):
+        if type(valor) is not int or valor <= 0:
+            _error_administracion_elecciones(
+                "VALOR_INVALIDO", f"{nombre} debe ser un entero mayor que cero."
+            )
+    if elegido_en is not None and not isinstance(elegido_en, datetime):
+        _error_administracion_elecciones(
+            "FECHA_INVALIDA", "elegido_en debe ser datetime o None."
+        )
+    if session.get(ComunidadesTorneo, torneo_id) is None:
+        _error_administracion_elecciones(
+            "TORNEO_NO_EXISTE", f"No existe el torneo de comunidades {torneo_id}."
+        )
+    ronda = (
+        session.query(ComunidadesRonda)
+        .filter(
+            ComunidadesRonda.torneo_id == torneo_id,
+            ComunidadesRonda.numero == ronda_numero,
+        )
+        .one_or_none()
+    )
+    if ronda is None:
+        _error_administracion_elecciones(
+            "RONDA_NO_EXISTE",
+            f"No existe la ronda {ronda_numero} del torneo {torneo_id}.",
+        )
+    enfrentamiento = (
+        session.query(ComunidadesEnfrentamiento)
+        .filter(
+            ComunidadesEnfrentamiento.id == enfrentamiento_id,
+            ComunidadesEnfrentamiento.torneo_id == torneo_id,
+            ComunidadesEnfrentamiento.ronda_id == ronda.id,
+        )
+        .with_for_update()
+        .one_or_none()
+    )
+    if enfrentamiento is None:
+        _error_administracion_elecciones(
+            "ENFRENTAMIENTO_NO_EXISTE",
+            "El enfrentamiento no pertenece al torneo y ronda indicados.",
+        )
+
+    miembros = (
+        session.query(ComunidadesMiembro)
+        .filter(
+            ComunidadesMiembro.torneo_id == torneo_id,
+            ComunidadesMiembro.equipo_id.in_(
+                (enfrentamiento.equipo_a_id, enfrentamiento.equipo_b_id)
+            ),
+        )
+        .all()
+    )
+    por_equipo = {}
+    for equipo_id, discord_id, lado in (
+        (int(enfrentamiento.equipo_a_id), atacante_equipo_a_discord_id, "A"),
+        (int(enfrentamiento.equipo_b_id), atacante_equipo_b_discord_id, "B"),
+    ):
+        miembros_equipo = [m for m in miembros if int(m.equipo_id) == equipo_id]
+        if len(miembros_equipo) != 2:
+            _error_administracion_elecciones(
+                "EQUIPO_INCOMPLETO", f"El equipo del lado {lado} no tiene dos miembros."
+            )
+        atacante = next(
+            (
+                m
+                for m in miembros_equipo
+                if m.usuario is not None
+                and m.usuario.id_discord is not None
+                and int(m.usuario.id_discord) == discord_id
+            ),
+            None,
+        )
+        if atacante is None:
+            _error_administracion_elecciones(
+                "ATACANTE_NO_PERTENECE",
+                f"El atacante indicado para el equipo {lado} no pertenece a ese equipo.",
+            )
+        defensor = next(m for m in miembros_equipo if m is not atacante)
+        por_equipo[equipo_id] = (atacante, defensor)
+
+    partidos = (
+        session.query(ComunidadesPartido)
+        .filter(ComunidadesPartido.enfrentamiento_id == enfrentamiento_id)
+        .order_by(ComunidadesPartido.indice)
+        .all()
+    )
+    elecciones = (
+        session.query(ComunidadesEleccionAtacante)
+        .filter(ComunidadesEleccionAtacante.enfrentamiento_id == enfrentamiento_id)
+        .all()
+    )
+    elecciones_por_equipo = {int(e.equipo_id): e for e in elecciones}
+    if partidos:
+        if len(partidos) != 2 or [int(p.indice) for p in partidos] != [1, 2]:
+            _error_administracion_elecciones(
+                "PARTIDOS_INCOMPLETOS",
+                "El enfrentamiento tiene una materialización parcial o inconsistente.",
+            )
+        coinciden = all(
+            equipo_id in elecciones_por_equipo
+            and int(elecciones_por_equipo[equipo_id].atacante_usuario_id)
+            == int(por_equipo[equipo_id][0].usuario_id)
+            for equipo_id in por_equipo
+        )
+        if not coinciden:
+            _error_administracion_elecciones(
+                "PARTIDOS_YA_CREADOS",
+                "Los partidos ya existen y no pueden sustituirse con otros atacantes.",
+            )
+        return enfrentamiento
+
+    if enfrentamiento.estado not in {
+        ENFRENTAMIENTO_PENDIENTE_ELECCIONES,
+        ENFRENTAMIENTO_ELECCIONES_COMPLETAS,
+    }:
+        _error_administracion_elecciones(
+            "ENFRENTAMIENTO_NO_ADMITE_CREACION",
+            f"El enfrentamiento está en estado {enfrentamiento.estado}.",
+        )
+
+    ahora = elegido_en or datetime.now(timezone.utc).replace(tzinfo=None)
+    for equipo_id, (atacante, defensor) in por_equipo.items():
+        eleccion = elecciones_por_equipo.get(equipo_id)
+        if eleccion is None:
+            eleccion = ComunidadesEleccionAtacante(
+                torneo_id=torneo_id,
+                enfrentamiento_id=enfrentamiento_id,
+                equipo_id=equipo_id,
+            )
+            session.add(eleccion)
+        eleccion.atacante_usuario_id = int(atacante.usuario_id)
+        eleccion.defensor_usuario_id = int(defensor.usuario_id)
+        eleccion.elegido_por_discord_id = actor_discord_id
+        eleccion.elegido_en = ahora
+        eleccion.bloqueada = True
+    enfrentamiento.estado = ENFRENTAMIENTO_ELECCIONES_COMPLETAS
+    session.flush()
+    return enfrentamiento
+
+
 class ErrorMaterializacionPartidosComunidades(ValueError):
     """Error de dominio al fijar las identidades de los partidos."""
 

--- a/ComunidadesDiscord.py
+++ b/ComunidadesDiscord.py
@@ -340,13 +340,14 @@ async def materializar_partidos_comunidades(
     guild: Any,
     *,
     enfrentamiento_id: int,
+    atomico: bool = False,
 ) -> ResultadoMaterializacionDiscordComunidades:
     """Crea de forma reintentable los dos registros y sus canales privados.
 
-    Las identidades se confirman primero. Después cada canal se crea, recibe su
-    mensaje y se asocia al partido en una confirmación independiente. Así, un
-    fallo tras el primer canal deja un estado parcial visible y recuperable sin
-    duplicar el canal ya guardado.
+    Por defecto, las identidades se confirman primero y cada canal se asocia en
+    una confirmación independiente para permitir reintentos sin duplicados. Con
+    ``atomico=True`` identidades, elecciones y canales se confirman juntos; un
+    fallo revierte la base de datos y elimina los canales creados en el intento.
     """
     import discord
     from ComunidadesCore import materializar_identidades_partidos_comunidades
@@ -356,7 +357,10 @@ async def materializar_partidos_comunidades(
         materializar_identidades_partidos_comunidades(
             session, enfrentamiento_id=enfrentamiento_id
         )
-        session.commit()
+        if atomico:
+            session.flush()
+        else:
+            session.commit()
     except Exception:
         session.rollback()
         raise
@@ -437,8 +441,11 @@ async def materializar_partidos_comunidades(
     )
 
     canales_creados = 0
+    canales_creados_en_intento = []
     for partido, categoria in zip(pendientes, categorias):
-        miembros = miembros_por_partido[int(partido.id)]
+        partido_id = int(partido.id)
+        indice_partido = int(partido.indice)
+        miembros = miembros_por_partido[partido_id]
         overwrites = {
             guild.default_role: discord.PermissionOverwrite(
                 view_channel=False, read_messages=False
@@ -463,21 +470,39 @@ async def materializar_partidos_comunidades(
                     f"partido {int(partido.indice)}"
                 ),
             )
+            canales_creados_en_intento.append(canal)
             await canal.send(_mensaje_partido_comunidades(enfrentamiento, partido))
             partido.canal_discord_id = int(canal.id)
-            session.commit()
+            if atomico:
+                session.flush()
+            else:
+                session.commit()
             canales_creados += 1
         except Exception as exc:
             session.rollback()
             limpieza = ""
-            if canal is not None:
+            canales_a_eliminar = (
+                list(reversed(canales_creados_en_intento))
+                if atomico
+                else ([canal] if canal is not None else [])
+            )
+            errores_limpieza = []
+            for canal_creado in canales_a_eliminar:
                 try:
-                    await canal.delete(reason="Fallo al materializar partido de comunidades")
+                    await canal_creado.delete(
+                        reason="Fallo al materializar partido de comunidades"
+                    )
                 except Exception as error_limpieza:
-                    limpieza = f"; no se pudo eliminar el canal huérfano ({error_limpieza})"
+                    errores_limpieza.append(str(error_limpieza))
+            if errores_limpieza:
+                limpieza = (
+                    "; no se pudieron eliminar todos los canales huérfanos ("
+                    + "; ".join(errores_limpieza)
+                    + ")"
+                )
             _error_materializacion_discord(
                 "FALLO_CREACION_CANAL",
-                f"Falló el canal del partido {int(partido.indice)} ({exc}){limpieza}.",
+                f"Falló el canal del partido {indice_partido} ({exc}){limpieza}.",
             )
 
     session.expire_all()

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -54,6 +54,7 @@ from SuizoCore import (
     obtener_raza_suizo_o_usuario,
 )
 from ComunidadesCore import (
+    ErrorAdministracionEleccionesComunidades,
     ErrorConfiguracionComunidades,
     anadir_categoria_enfrentamientos_comunidades,
     anadir_categoria_partidos_comunidades,
@@ -63,12 +64,17 @@ from ComunidadesCore import (
     configurar_puntos_equipo_comunidades,
     configurar_puntos_individuales_comunidades,
     crear_torneo_comunidades,
+    consultar_elecciones_comunidades,
     ErrorGeneracionRondaComunidades,
+    forzar_elecciones_comunidades,
     generar_ronda_comunidades,
 )
 from ComunidadesDiscord import (
+    ErrorMaterializacionDiscordComunidades,
     ErrorSeleccionCategoriaComunidades,
     ejecutar_seleccion_atacante_comunidades,
+    materializar_partidos_comunidades,
+    mencion_usuario_comunidades,
     parsear_decimal,
     parsear_fecha_limite,
     planificar_categorias_comunidades,
@@ -4643,6 +4649,138 @@ async def _resolver_miembro_guild_comunidades(guild, discord_id: int):
         return await fetch_member(discord_id)
     except Exception:
         return None
+
+
+
+def _es_canal_administrativo_comunidades(ctx) -> bool:
+    """Comprueba el canal hardcodeado antes de construir contenido sensible."""
+    canal_id = getattr(getattr(ctx, "channel", None), "id", None)
+    return canal_id is not None and str(canal_id) in canales_permitidos
+
+
+def _formatear_consulta_elecciones_comunidades(torneo_id, ronda_numero, filas):
+    lineas = [
+        f"🔐 **Elecciones del torneo `{torneo_id}`, ronda `{ronda_numero}`**"
+    ]
+    if not filas:
+        lineas.append("No hay enfrentamientos en esta ronda.")
+        return "\n".join(lineas)
+    for fila in filas:
+        enfrentamiento = fila.enfrentamiento
+        lineas.append(
+            f"\n**Mesa {int(enfrentamiento.mesa_numero)} · "
+            f"enfrentamiento `{int(enfrentamiento.id)}`**"
+        )
+        for eleccion in fila.elecciones:
+            equipo = str(eleccion.equipo.nombre).replace("@", "@\u200b")
+            if eleccion.pendiente:
+                lineas.append(f"- **{equipo}** — ⏳ PENDIENTE")
+                continue
+            estado = "🔒 BLOQUEADA" if eleccion.bloqueada else "📝 ABIERTA"
+            fecha = (
+                eleccion.elegido_en.strftime("%Y-%m-%d %H:%M:%S")
+                if eleccion.elegido_en is not None
+                else "sin fecha"
+            )
+            lineas.append(
+                f"- **{equipo}** — {estado}\n"
+                f"  Atacante: {mencion_usuario_comunidades(eleccion.atacante)} · "
+                f"Defensor: {mencion_usuario_comunidades(eleccion.defensor)}\n"
+                f"  Actor: <@{int(eleccion.actor_discord_id)}> · Fecha UTC: `{fecha}`"
+            )
+    return "\n".join(lineas)
+
+
+@bot.command(name="comunidades_consulta_elecciones")
+async def comunidades_consulta_elecciones(ctx, torneo_id: int, ronda_numero: int):
+    if not es_comisario(ctx):
+        await ctx.send("No tienes permiso. Este comando es exclusivo para Comisario.")
+        return
+    if not _es_canal_administrativo_comunidades(ctx):
+        await ctx.send(
+            "🔒 Este comando solo puede utilizarse en el canal administrativo. "
+            "No se ha consultado ni revelado ninguna elección."
+        )
+        return
+
+    session = Session()
+    try:
+        filas = consultar_elecciones_comunidades(
+            session, torneo_id=torneo_id, ronda_numero=ronda_numero
+        )
+        await UtilesDiscord.enviar_mensaje_largo(
+            ctx.channel,
+            _formatear_consulta_elecciones_comunidades(
+                torneo_id, ronda_numero, filas
+            ),
+        )
+    except ErrorAdministracionEleccionesComunidades as exc:
+        await ctx.send(f"❌ [{exc.codigo}] {exc.detalle}")
+    except Exception as exc:
+        await ctx.send(f"❌ No se pudieron consultar las elecciones ({exc}).")
+    finally:
+        session.close()
+
+
+@bot.command(name="comunidades_forzar_crear_partidos")
+async def comunidades_forzar_crear_partidos(
+    ctx,
+    torneo_id: int,
+    ronda_numero: int,
+    enfrentamiento_id: int,
+    atacante_equipo_a: discord.Member,
+    atacante_equipo_b: discord.Member,
+):
+    if not es_comisario(ctx):
+        await ctx.send("No tienes permiso. Este comando es exclusivo para Comisario.")
+        return
+    if ctx.guild is None:
+        await ctx.send("❌ Este comando solo puede utilizarse dentro del servidor.")
+        return
+
+    session = Session()
+    try:
+        forzar_elecciones_comunidades(
+            session,
+            torneo_id=torneo_id,
+            ronda_numero=ronda_numero,
+            enfrentamiento_id=enfrentamiento_id,
+            atacante_equipo_a_discord_id=int(atacante_equipo_a.id),
+            atacante_equipo_b_discord_id=int(atacante_equipo_b.id),
+            actor_discord_id=int(ctx.author.id),
+        )
+        resultado = await materializar_partidos_comunidades(
+            session,
+            ctx.guild,
+            enfrentamiento_id=enfrentamiento_id,
+            atomico=True,
+        )
+        await ctx.send(
+            "✅ Elecciones impuestas, bloqueadas y partidos materializados.\n"
+            f"Torneo `{torneo_id}` · ronda `{ronda_numero}` · "
+            f"enfrentamiento `{enfrentamiento_id}`\n"
+            f"Equipo A: {atacante_equipo_a.mention} · "
+            f"Equipo B: {atacante_equipo_b.mention}\n"
+            f"Partidos: `{resultado.partido_ids[0]}`, `{resultado.partido_ids[1]}` · "
+            f"Canales: <#{resultado.canal_ids[0]}>, <#{resultado.canal_ids[1]}>\n"
+            f"Actuación administrativa registrada para <@{int(ctx.author.id)}>; "
+            f"canales creados en este intento: `{resultado.canales_creados}`."
+        )
+    except (
+        ErrorAdministracionEleccionesComunidades,
+        ErrorMaterializacionDiscordComunidades,
+        ErrorSeleccionCategoriaComunidades,
+    ) as exc:
+        session.rollback()
+        await ctx.send(f"❌ [{exc.codigo}] {exc.detalle}")
+    except Exception as exc:
+        session.rollback()
+        await ctx.send(
+            "❌ No se pudo completar el forzado; la transacción se revirtió "
+            f"({exc})."
+        )
+    finally:
+        session.close()
 
 
 @bot.command(name="comunidades_generar_ronda")

--- a/tests/test_comunidades_administracion_elecciones.py
+++ b/tests/test_comunidades_administracion_elecciones.py
@@ -1,0 +1,248 @@
+from datetime import datetime
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session
+
+from ComunidadesCore import (
+    ErrorAdministracionEleccionesComunidades,
+    consultar_elecciones_comunidades,
+    forzar_elecciones_comunidades,
+)
+from GestorSQL import (
+    Base,
+    ComunidadesComunidad,
+    ComunidadesEleccionAtacante,
+    ComunidadesEnfrentamiento,
+    ComunidadesEquipo,
+    ComunidadesMiembro,
+    ComunidadesPartido,
+    ComunidadesRonda,
+    ComunidadesTorneo,
+    Usuario,
+)
+
+
+def _engine():
+    engine = create_engine("sqlite://")
+
+    @event.listens_for(engine, "connect")
+    def _foreign_keys(dbapi_connection, _):
+        dbapi_connection.execute("PRAGMA foreign_keys=ON")
+
+    Base.metadata.create_all(engine)
+    return engine
+
+
+def _escenario(session):
+    torneo = ComunidadesTorneo(
+        nombre="Comunidades",
+        rondas_totales=1,
+        fecha_fin_ronda1=datetime(2026, 7, 8, 22, 0),
+        plantilla_mensaje_ronda1="R1",
+        plantilla_mensaje_rondas_siguientes="R2",
+        creado_por_discord_id=999,
+    )
+    session.add(torneo)
+    session.flush()
+    comunidades = [
+        ComunidadesComunidad(torneo_id=torneo.id, nombre="A"),
+        ComunidadesComunidad(torneo_id=torneo.id, nombre="B"),
+    ]
+    session.add_all(comunidades)
+    session.flush()
+    equipos = [
+        ComunidadesEquipo(torneo_id=torneo.id, comunidad_id=comunidades[0].id, nombre="Equipo A"),
+        ComunidadesEquipo(torneo_id=torneo.id, comunidad_id=comunidades[1].id, nombre="Equipo B"),
+    ]
+    session.add_all(equipos)
+    session.flush()
+    usuarios = [
+        Usuario(idUsuarios=11, id_discord=101, nombre_discord="A Uno"),
+        Usuario(idUsuarios=12, id_discord=102, nombre_discord="A Dos"),
+        Usuario(idUsuarios=21, id_discord=201, nombre_discord="B Uno"),
+        Usuario(idUsuarios=22, id_discord=202, nombre_discord="B Dos"),
+    ]
+    session.add_all(usuarios)
+    session.add_all([
+        ComunidadesMiembro(torneo_id=torneo.id, equipo_id=equipos[0].id, usuario_id=11, posicion=1, raza="Orcos"),
+        ComunidadesMiembro(torneo_id=torneo.id, equipo_id=equipos[0].id, usuario_id=12, posicion=2, raza="Enanos"),
+        ComunidadesMiembro(torneo_id=torneo.id, equipo_id=equipos[1].id, usuario_id=21, posicion=1, raza="Skaven"),
+        ComunidadesMiembro(torneo_id=torneo.id, equipo_id=equipos[1].id, usuario_id=22, posicion=2, raza="Humanos"),
+    ])
+    ronda = ComunidadesRonda(
+        torneo_id=torneo.id,
+        numero=1,
+        estado="ABIERTA",
+        fecha_inicio=datetime(2026, 7, 1),
+        fecha_fin=datetime(2026, 7, 8),
+        generada_por_discord_id=999,
+    )
+    session.add(ronda)
+    session.flush()
+    enfrentamiento = ComunidadesEnfrentamiento(
+        torneo_id=torneo.id,
+        ronda_id=ronda.id,
+        mesa_numero=1,
+        equipo_a_id=equipos[0].id,
+        equipo_b_id=equipos[1].id,
+        estado="PENDIENTE_ELECCIONES",
+        canal_general_discord_id=555,
+    )
+    session.add(enfrentamiento)
+    session.commit()
+    return torneo.id, enfrentamiento.id
+
+
+def test_consulta_diferencia_pendiente_abierta_y_bloqueada():
+    engine = _engine()
+    with Session(engine) as session:
+        torneo_id, enfrentamiento_id = _escenario(session)
+        filas = consultar_elecciones_comunidades(session, torneo_id=torneo_id, ronda_numero=1)
+        assert [e.pendiente for e in filas[0].elecciones] == [True, True]
+
+        enfrentamiento = session.get(ComunidadesEnfrentamiento, enfrentamiento_id)
+        session.add(
+            ComunidadesEleccionAtacante(
+                torneo_id=torneo_id,
+                enfrentamiento_id=enfrentamiento_id,
+                equipo_id=enfrentamiento.equipo_a_id,
+                atacante_usuario_id=11,
+                defensor_usuario_id=12,
+                elegido_por_discord_id=101,
+                elegido_en=datetime(2026, 7, 2, 10, 0),
+                bloqueada=False,
+            )
+        )
+        session.flush()
+        filas = consultar_elecciones_comunidades(session, torneo_id=torneo_id, ronda_numero=1)
+        assert [e.pendiente for e in filas[0].elecciones] == [False, True]
+        assert filas[0].elecciones[0].bloqueada is False
+
+        forzar_elecciones_comunidades(
+            session,
+            torneo_id=torneo_id,
+            ronda_numero=1,
+            enfrentamiento_id=enfrentamiento_id,
+            atacante_equipo_a_discord_id=102,
+            atacante_equipo_b_discord_id=201,
+            actor_discord_id=999,
+            elegido_en=datetime(2026, 7, 2, 12, 0),
+        )
+        filas = consultar_elecciones_comunidades(session, torneo_id=torneo_id, ronda_numero=1)
+        assert [e.pendiente for e in filas[0].elecciones] == [False, False]
+        assert [e.bloqueada for e in filas[0].elecciones] == [True, True]
+        assert [e.atacante.idUsuarios for e in filas[0].elecciones] == [12, 21]
+        assert [e.defensor.idUsuarios for e in filas[0].elecciones] == [11, 22]
+        assert all(e.actor_discord_id == 999 for e in filas[0].elecciones)
+
+
+def test_forzado_reemplaza_una_eleccion_y_audita_al_comisario():
+    engine = _engine()
+    with Session(engine) as session:
+        torneo_id, enfrentamiento_id = _escenario(session)
+        session.add(
+            ComunidadesEleccionAtacante(
+                torneo_id=torneo_id,
+                enfrentamiento_id=enfrentamiento_id,
+                equipo_id=session.get(ComunidadesEnfrentamiento, enfrentamiento_id).equipo_a_id,
+                atacante_usuario_id=11,
+                defensor_usuario_id=12,
+                elegido_por_discord_id=101,
+                elegido_en=datetime(2026, 7, 2, 10, 0),
+                bloqueada=False,
+            )
+        )
+        session.commit()
+
+        forzar_elecciones_comunidades(
+            session,
+            torneo_id=torneo_id,
+            ronda_numero=1,
+            enfrentamiento_id=enfrentamiento_id,
+            atacante_equipo_a_discord_id=102,
+            atacante_equipo_b_discord_id=202,
+            actor_discord_id=999,
+            elegido_en=datetime(2026, 7, 2, 12, 0),
+        )
+        elecciones = session.query(ComunidadesEleccionAtacante).order_by(ComunidadesEleccionAtacante.equipo_id).all()
+        assert len(elecciones) == 2
+        assert [e.atacante_usuario_id for e in elecciones] == [12, 22]
+        assert all(e.bloqueada and e.elegido_por_discord_id == 999 for e in elecciones)
+        assert session.get(ComunidadesEnfrentamiento, enfrentamiento_id).estado == "ELECCIONES_COMPLETAS"
+
+
+@pytest.mark.parametrize("atacante_a,atacante_b", [(201, 202), (101, 102)])
+def test_forzado_rechaza_atacante_del_lado_incorrecto(atacante_a, atacante_b):
+    engine = _engine()
+    with Session(engine) as session:
+        torneo_id, enfrentamiento_id = _escenario(session)
+        with pytest.raises(ErrorAdministracionEleccionesComunidades) as error:
+            forzar_elecciones_comunidades(
+                session,
+                torneo_id=torneo_id,
+                ronda_numero=1,
+                enfrentamiento_id=enfrentamiento_id,
+                atacante_equipo_a_discord_id=atacante_a,
+                atacante_equipo_b_discord_id=atacante_b,
+                actor_discord_id=999,
+            )
+        assert error.value.codigo == "ATACANTE_NO_PERTENECE"
+        session.rollback()
+        assert session.query(ComunidadesEleccionAtacante).count() == 0
+
+
+def test_reintento_con_partidos_existentes_es_idempotente_y_no_admite_cambiar_atacantes():
+    engine = _engine()
+    with Session(engine) as session:
+        torneo_id, enfrentamiento_id = _escenario(session)
+        forzar_elecciones_comunidades(
+            session,
+            torneo_id=torneo_id,
+            ronda_numero=1,
+            enfrentamiento_id=enfrentamiento_id,
+            atacante_equipo_a_discord_id=101,
+            atacante_equipo_b_discord_id=201,
+            actor_discord_id=999,
+        )
+        enfrentamiento = session.get(ComunidadesEnfrentamiento, enfrentamiento_id)
+        session.add_all([
+            ComunidadesPartido(
+                torneo_id=torneo_id, enfrentamiento_id=enfrentamiento_id, indice=1,
+                equipo_local_id=enfrentamiento.equipo_a_id, equipo_visitante_id=enfrentamiento.equipo_b_id,
+                usuario_local_id=11, usuario_visitante_id=22, atacante_usuario_id=11, defensor_usuario_id=22,
+            ),
+            ComunidadesPartido(
+                torneo_id=torneo_id, enfrentamiento_id=enfrentamiento_id, indice=2,
+                equipo_local_id=enfrentamiento.equipo_b_id, equipo_visitante_id=enfrentamiento.equipo_a_id,
+                usuario_local_id=21, usuario_visitante_id=12, atacante_usuario_id=21, defensor_usuario_id=12,
+            ),
+        ])
+        session.commit()
+
+        forzar_elecciones_comunidades(
+            session,
+            torneo_id=torneo_id,
+            ronda_numero=1,
+            enfrentamiento_id=enfrentamiento_id,
+            atacante_equipo_a_discord_id=101,
+            atacante_equipo_b_discord_id=201,
+            actor_discord_id=999,
+        )
+        assert session.query(ComunidadesPartido).count() == 2
+
+        with pytest.raises(ErrorAdministracionEleccionesComunidades) as error:
+            forzar_elecciones_comunidades(
+                session,
+                torneo_id=torneo_id,
+                ronda_numero=1,
+                enfrentamiento_id=enfrentamiento_id,
+                atacante_equipo_a_discord_id=102,
+                atacante_equipo_b_discord_id=201,
+                actor_discord_id=999,
+            )
+        assert error.value.codigo == "PARTIDOS_YA_CREADOS"

--- a/tests/test_comunidades_administracion_elecciones_command.py
+++ b/tests/test_comunidades_administracion_elecciones_command.py
@@ -1,0 +1,70 @@
+import ast
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+
+FUENTE = Path(__file__).resolve().parents[1] / "LombardBot.py"
+
+
+class Contexto:
+    def __init__(self, *, comisario, canal_id):
+        roles = [SimpleNamespace(name="Comisario")] if comisario else []
+        self.author = SimpleNamespace(id=999, roles=roles)
+        self.channel = SimpleNamespace(id=canal_id)
+        self.mensajes = []
+
+    async def send(self, mensaje):
+        self.mensajes.append(mensaje)
+
+
+def _cargar_consulta(*, consulta):
+    arbol = ast.parse(FUENTE.read_text(encoding="utf-8-sig"))
+    nombres = {
+        "es_comisario",
+        "_es_canal_administrativo_comunidades",
+        "comunidades_consulta_elecciones",
+    }
+    nodos = []
+    for nodo in arbol.body:
+        if isinstance(nodo, (ast.FunctionDef, ast.AsyncFunctionDef)) and nodo.name in nombres:
+            nodo.decorator_list = []
+            nodos.append(nodo)
+    modulo = ast.Module(body=nodos, type_ignores=[])
+
+    class SessionProhibida:
+        def __init__(self):
+            raise AssertionError("No se debe abrir sesión antes de validar rol y canal")
+
+    entorno = {
+        "canales_permitidos": ["457740100097540106"],
+        "Session": SessionProhibida,
+        "consultar_elecciones_comunidades": consulta,
+        "UtilesDiscord": SimpleNamespace(enviar_mensaje_largo=None),
+        "ErrorAdministracionEleccionesComunidades": RuntimeError,
+    }
+    exec(compile(modulo, str(FUENTE), "exec"), entorno)
+    return entorno["comunidades_consulta_elecciones"]
+
+
+def test_no_comisario_no_abre_sesion_ni_revela_informacion():
+    llamadas = []
+    comando = _cargar_consulta(consulta=lambda *args, **kwargs: llamadas.append(kwargs))
+    ctx = Contexto(comisario=False, canal_id=457740100097540106)
+
+    asyncio.run(comando(ctx, 1, 1))
+
+    assert llamadas == []
+    assert ctx.mensajes == ["No tienes permiso. Este comando es exclusivo para Comisario."]
+
+
+def test_canal_incorrecto_se_valida_antes_de_leer_elecciones():
+    llamadas = []
+    comando = _cargar_consulta(consulta=lambda *args, **kwargs: llamadas.append(kwargs))
+    ctx = Contexto(comisario=True, canal_id=123)
+
+    asyncio.run(comando(ctx, 1, 1))
+
+    assert llamadas == []
+    assert len(ctx.mensajes) == 1
+    assert "No se ha consultado ni revelado ninguna elección" in ctx.mensajes[0]

--- a/tests/test_comunidades_materializacion_partidos.py
+++ b/tests/test_comunidades_materializacion_partidos.py
@@ -281,3 +281,23 @@ def test_fallo_tras_primer_canal_es_detectable_y_reintento_no_duplica():
         assert session.query(ComunidadesPartido).count() == 2
         assert [partido.canal_discord_id for partido in session.query(ComunidadesPartido).order_by(ComunidadesPartido.indice)] == [901, 903]
         assert session.get(ComunidadesEnfrentamiento, enfrentamiento_id).estado == "PARTIDOS_CREADOS"
+
+
+def test_materializacion_atomica_elimina_primer_canal_y_revierte_partidos_si_falla_el_segundo():
+    engine = _engine()
+    guild = GuildDiscord(fallar_en_creacion=2)
+    with Session(engine) as session:
+        enfrentamiento_id = _crear_escenario(session)
+
+        with pytest.raises(ErrorMaterializacionDiscordComunidades) as error:
+            asyncio.run(
+                materializar_partidos_comunidades(
+                    session, guild, enfrentamiento_id=enfrentamiento_id, atomico=True
+                )
+            )
+
+        assert error.value.codigo == "FALLO_CREACION_CANAL"
+        assert guild.creaciones[0]["canal"].eliminado is True
+        assert guild.categoria.channels == []
+        assert session.query(ComunidadesPartido).count() == 0
+        assert session.get(ComunidadesEnfrentamiento, enfrentamiento_id).estado == "ELECCIONES_COMPLETAS"


### PR DESCRIPTION
### Motivation
- Proveer a los comisarios herramientas para inspeccionar elecciones y forzar la creación de los dos partidos cuando proceda, sin filtrar identidades fuera del canal administrativo.
- Garantizar que el forzado sustituya elecciones previas solo tras validaciones estrictas (torneo, ronda, enfrentamiento, pertenencia a lado A/B) y que la operación sea atómica e idempotente.
- Evitar la construcción de contenido sensible antes de comprobar rol y canal administrativo para reducir el riesgo de divulgación accidental.

### Description
- Añade en `ComunidadesCore.py` los servicios administrativos `consultar_elecciones_comunidades` y `forzar_elecciones_comunidades`, junto con el tipo de error `ErrorAdministracionEleccionesComunidades` y dataclasses de salida para exponer atacante/defensor, pendiente, actor y fecha.
- Implementa validaciones completas en el forzado: existencia de torneo/ronda/enfrentamiento, comprobación de miembros por lado, derivación de defensores, reemplazo/registro del actor y bloqueo de las elecciones, y rechazo si ya existen partidos incompatibles.
- Extiende `materializar_partidos_comunidades` en `ComunidadesDiscord.py` con un modo `atomico=True` que coordina la confirmación en BD y la creación de canales, eliminando canales creados en el intento si ocurre un fallo y preservando el comportamiento idempotente para reintentos.
- Añade comandos en `LombardBot.py`: `!comunidades_consulta_elecciones` (valida rol Comisario y canal administrativo hardcodeado antes de abrir sesión o construir contenido) y `!comunidades_forzar_crear_partidos` (valida, impone elecciones, bloquea, materializa de forma atómica y audita la actuación administrativa).
- Mejora la presentación segura de nombres y menciones al formatear la consulta y reutiliza los helpers existentes para materialización y planificación de categorías.
- Incluye pruebas nuevas y actualizadas que cubren cero/una/dos elecciones, reemplazo administrativo, rechazo de atacantes del lado incorrecto, idempotencia de reintentos y la reversión atómica al fallar la creación del segundo canal (`tests/test_comunidades_administracion_elecciones.py`, `tests/test_comunidades_administracion_elecciones_command.py`, y ajustes en `tests/test_comunidades_materializacion_partidos.py`).

### Testing
- Se ejecutaron pruebas específicas: `pytest -q tests/test_comunidades_administracion_elecciones.py tests/test_comunidades_administracion_elecciones_command.py tests/test_comunidades_materializacion_partidos.py` y todas pasaron (11 tests).
- Se ejecutó la suite completa con `pytest -q` y resultó en éxito total (454 tests passed, 71 warnings).
- Se compiló el código objetivo con `python -m py_compile ComunidadesCore.py ComunidadesDiscord.py LombardBot.py` y se comprobó `git diff --check` sin errores.
- Las pruebas verifican permisos y canalidad (no se abre sesión ni se revela información si no hay rol o canal adecuados), estados pendientes/bloqueados, creación idempotente de partidos y eliminación/rollback atómico de canales en fallo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24b6d87800832a8964b82172b001f8)