### PR TITLE
Implementa cierre administrativo de partido de comunidades y delega lógica en Core

### DIFF
--- a/ComunidadesCore.py
+++ b/ComunidadesCore.py
@@ -33,7 +33,9 @@ from ComunidadesConstantes import (
     PLANTILLA_RONDA1_PENDIENTE,
     PLANTILLA_RONDAS_SIGUIENTES_PENDIENTE,
     RAZAS_VALIDAS,
+    RONDA_ABIERTA,
     TORNEO_CREADO,
+    TORNEO_EN_CURSO,
     validar_puntuacion,
 )
 
@@ -2640,6 +2642,133 @@ def registrar_resultado_partido_comunidades(
         return ResultadoRegistroPartidoComunidades(
             partido, enfrentamiento, True, False, resultado_global
         )
+
+
+def administrar_partido_comunidades(
+    session: Any,
+    *,
+    torneo_id: int,
+    ronda_numero: int,
+    enfrentamiento_id: int,
+    partido_indice: int,
+    td_local: int,
+    td_visitante: int,
+    tipo_forfait: Optional[str] = None,
+) -> ResultadoRegistroPartidoComunidades:
+    """Resuelve un partido administrativo y usa el cierre común de resultados.
+
+    Este servicio valida que los cuatro identificadores pertenezcan al mismo
+    contexto operativo. La persistencia del marcador y, al cerrar el segundo
+    partido, la resolución global se delegan sin duplicación en
+    :func:`registrar_resultado_partido_comunidades`, la misma frontera usada
+    por la actualización desde la API.
+    """
+    from GestorSQL import (
+        ComunidadesEnfrentamiento,
+        ComunidadesPartido,
+        ComunidadesRonda,
+        ComunidadesTorneo,
+    )
+
+    for valor, nombre in (
+        (torneo_id, "torneo_id"),
+        (ronda_numero, "ronda_numero"),
+        (enfrentamiento_id, "enfrentamiento_id"),
+    ):
+        if type(valor) is not int or valor <= 0:
+            _error_registro_resultado(
+                "IDENTIFICADOR_INVALIDO",
+                f"{nombre} debe ser un entero mayor que cero.",
+            )
+    if type(partido_indice) is not int or partido_indice not in {1, 2}:
+        _error_registro_resultado(
+            "INDICE_PARTIDO_INVALIDO",
+            "El índice de partido debe ser 1 o 2.",
+        )
+
+    torneo = (
+        session.query(ComunidadesTorneo)
+        .filter(ComunidadesTorneo.id == torneo_id)
+        .one_or_none()
+    )
+    if torneo is None:
+        _error_registro_resultado(
+            "TORNEO_NO_EXISTE",
+            f"No existe un torneo de comunidades con ID {torneo_id}.",
+        )
+    if torneo.estado != TORNEO_EN_CURSO:
+        _error_registro_resultado(
+            "TORNEO_NO_EN_CURSO",
+            f"El torneo {torneo_id} está en estado {torneo.estado}; "
+            "solo se administran partidos de torneos EN_CURSO.",
+        )
+
+    ronda = (
+        session.query(ComunidadesRonda)
+        .filter(
+            ComunidadesRonda.torneo_id == torneo_id,
+            ComunidadesRonda.numero == ronda_numero,
+        )
+        .one_or_none()
+    )
+    if ronda is None:
+        _error_registro_resultado(
+            "RONDA_NO_EXISTE",
+            f"No existe la ronda {ronda_numero} en el torneo {torneo_id}.",
+        )
+    if ronda.estado != RONDA_ABIERTA:
+        _error_registro_resultado(
+            "RONDA_NO_ABIERTA",
+            f"La ronda {ronda_numero} está en estado {ronda.estado}; "
+            "solo se administran partidos de rondas ABIERTAS.",
+        )
+
+    enfrentamiento = (
+        session.query(ComunidadesEnfrentamiento)
+        .filter(
+            ComunidadesEnfrentamiento.id == enfrentamiento_id,
+            ComunidadesEnfrentamiento.torneo_id == torneo_id,
+            ComunidadesEnfrentamiento.ronda_id == ronda.id,
+        )
+        .one_or_none()
+    )
+    if enfrentamiento is None:
+        _error_registro_resultado(
+            "ENFRENTAMIENTO_NO_EXISTE",
+            f"No existe el enfrentamiento {enfrentamiento_id} en la ronda "
+            f"{ronda_numero} del torneo {torneo_id}.",
+        )
+
+    partido = (
+        session.query(ComunidadesPartido)
+        .filter(
+            ComunidadesPartido.torneo_id == torneo_id,
+            ComunidadesPartido.enfrentamiento_id == enfrentamiento_id,
+            ComunidadesPartido.indice == partido_indice,
+        )
+        .one_or_none()
+    )
+    if partido is None:
+        _error_registro_resultado(
+            "PARTIDO_NO_EXISTE",
+            f"El enfrentamiento {enfrentamiento_id} no tiene creado el partido "
+            f"{partido_indice}.",
+        )
+    if partido.estado in {PARTIDO_FINALIZADO, PARTIDO_ADMINISTRADO}:
+        _error_registro_resultado(
+            "PARTIDO_YA_CERRADO",
+            f"El partido {partido_indice} ya está cerrado con estado "
+            f"{partido.estado} y no puede administrarse de nuevo.",
+        )
+
+    return registrar_resultado_partido_comunidades(
+        session,
+        partido_id=int(partido.id),
+        td_local=td_local,
+        td_visitante=td_visitante,
+        origen=RESULTADO_ORIGEN_ADMIN,
+        tipo_forfait=tipo_forfait,
+    )
 
 
 class ErrorGeneracionRondaComunidades(ValueError):

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -60,6 +60,7 @@ from ComunidadesCore import (
     anadir_categoria_partidos_comunidades,
     anadir_comunidad_comunidades,
     anadir_equipo_comunidades,
+    administrar_partido_comunidades,
     configurar_competicion_comunidades,
     configurar_puntos_equipo_comunidades,
     configurar_puntos_individuales_comunidades,
@@ -74,11 +75,8 @@ from ComunidadesCore import (
 from ComunidadesConstantes import (
     ENFRENTAMIENTO_EN_CURSO,
     ENFRENTAMIENTO_PARTIDOS_CREADOS,
-    PARTIDO_ADMINISTRADO,
     PARTIDO_EN_CURSO,
-    PARTIDO_FINALIZADO,
     PARTIDO_PENDIENTE,
-    RESULTADO_ORIGEN_ADMIN,
     RESULTADO_ORIGEN_API,
     RONDA_ABIERTA,
     TIPO_ADMIN_DOBLE_FORFEIT,
@@ -5140,96 +5138,29 @@ async def comunidades_admin_partido(
     SessionComunidades = sessionmaker(bind=GestorSQL.conexionEngine())
     session = SessionComunidades()
     try:
-        torneo = (
-            session.query(GestorSQL.ComunidadesTorneo)
-            .filter(GestorSQL.ComunidadesTorneo.id == torneo_id)
-            .one_or_none()
-        )
-        if torneo is None:
-            await ctx.send(f"❌ No existe un torneo de comunidades con ID `{torneo_id}`.")
-            return
-        if torneo.estado != TORNEO_EN_CURSO:
-            await ctx.send(
-                f"❌ El torneo `{torneo_id}` está en estado `{torneo.estado}`; "
-                "solo se administran partidos de torneos EN_CURSO."
-            )
-            return
-
-        ronda = (
-            session.query(GestorSQL.ComunidadesRonda)
-            .filter(
-                GestorSQL.ComunidadesRonda.torneo_id == torneo_id,
-                GestorSQL.ComunidadesRonda.numero == ronda_numero,
-            )
-            .one_or_none()
-        )
-        if ronda is None:
-            await ctx.send(
-                f"❌ No existe la ronda `{ronda_numero}` en el torneo `{torneo_id}`."
-            )
-            return
-        if ronda.estado != RONDA_ABIERTA:
-            await ctx.send(
-                f"❌ La ronda `{ronda_numero}` está en estado `{ronda.estado}`; "
-                "solo se administran partidos de rondas ABIERTAS."
-            )
-            return
-
-        enfrentamiento = (
-            session.query(GestorSQL.ComunidadesEnfrentamiento)
-            .filter(
-                GestorSQL.ComunidadesEnfrentamiento.id == enfrentamiento_id,
-                GestorSQL.ComunidadesEnfrentamiento.torneo_id == torneo_id,
-                GestorSQL.ComunidadesEnfrentamiento.ronda_id == ronda.id,
-            )
-            .one_or_none()
-        )
-        if enfrentamiento is None:
-            await ctx.send(
-                f"❌ No existe el enfrentamiento `{enfrentamiento_id}` en la ronda "
-                f"`{ronda_numero}` del torneo `{torneo_id}`."
-            )
-            return
-
-        partido = (
-            session.query(GestorSQL.ComunidadesPartido)
-            .filter(
-                GestorSQL.ComunidadesPartido.torneo_id == torneo_id,
-                GestorSQL.ComunidadesPartido.enfrentamiento_id == enfrentamiento.id,
-                GestorSQL.ComunidadesPartido.indice == partido_indice,
-            )
-            .one_or_none()
-        )
-        if partido is None:
-            await ctx.send(
-                f"❌ El enfrentamiento `{enfrentamiento_id}` no tiene creado el partido "
-                f"`{partido_indice}`."
-            )
-            return
-        if partido.estado in {PARTIDO_FINALIZADO, PARTIDO_ADMINISTRADO}:
-            await ctx.send(
-                f"❌ El partido `{partido_indice}` ya está cerrado con estado "
-                f"`{partido.estado}` y no puede administrarse de nuevo."
-            )
-            return
-
         try:
-            resultado = registrar_resultado_partido_comunidades(
+            resultado = administrar_partido_comunidades(
                 session,
-                partido_id=int(partido.id),
+                torneo_id=torneo_id,
+                ronda_numero=ronda_numero,
+                enfrentamiento_id=enfrentamiento_id,
+                partido_indice=partido_indice,
                 td_local=marcador_local,
                 td_visitante=marcador_visitante,
-                origen=RESULTADO_ORIGEN_ADMIN,
                 tipo_forfait=tipo_forfait,
             )
             if resultado.idempotente:
                 session.rollback()
-                await ctx.send("❌ El partido ya había sido cerrado y no puede administrarse de nuevo.")
+                await ctx.send(
+                    "❌ El partido ya había sido cerrado y no puede administrarse de nuevo."
+                )
                 return
             session.commit()
         except ErrorRegistroResultadoComunidades as exc:
             session.rollback()
-            await ctx.send(f"❌ No se pudo administrar el partido: [{exc.codigo}] {exc.detalle}")
+            await ctx.send(
+                f"❌ No se pudo administrar el partido: [{exc.codigo}] {exc.detalle}"
+            )
             return
 
         mensaje = _mensaje_resultado_admin_comunidades(resultado, tipo.strip().lower())
@@ -5240,8 +5171,10 @@ async def comunidades_admin_partido(
         avisos = []
         enviados = set()
         for nombre, canal_id in destinos:
-            if canal_id is None or int(canal_id) in enviados:
+            if canal_id is None:
                 avisos.append(f"canal {nombre} no disponible")
+                continue
+            if int(canal_id) in enviados:
                 continue
             canal = await _resolver_canal_notificacion_comunidades(ctx, canal_id)
             if canal is None:


### PR DESCRIPTION
### Motivation
- Permitir a los comisarios cerrar un partido individual con los cinco tipos administrativos documentados reutilizando exactamente el mismo servicio transaccional que usa la API. 
- Evitar duplicar la lógica de resolución global del enfrentamiento en el handler del bot, manteniendo la coherencia con el flujo de la tarea de actualización (API).

### Description
- Añade `administrar_partido_comunidades` en `ComunidadesCore.py` que valida `torneo_id`, `ronda_numero`, `enfrentamiento_id` y `partido_indice`, rechaza casos inexistentes o ya cerrados y delega en `registrar_resultado_partido_comunidades` con `origen=RESULTADO_ORIGEN_ADMIN` y `tipo_forfait` cuando corresponde.
- Actualiza el handler `!comunidades_admin_partido` en `LombardBot.py` para interpretar argumentos, traducir los cinco tipos administrativos con `_datos_resultado_admin_comunidades`, abrir la sesión, delegar en `administrar_partido_comunidades`, manejar idempotencia/errores y publicar el mensaje en canales individual y general usando `_mensaje_resultado_admin_comunidades`.
- Conserva el comportamiento especial de `doble_forfeit` (puntos internos `0-0`), la validación de TD en el tipo `manual`, la marca de origen `ADMIN` y la imposibilidad de cerrar dos veces el mismo partido.
- El servicio administrativo queda como frontera de validación; la persistencia y la resolución global siguen ocurriendo exclusivamente vía `registrar_resultado_partido_comunidades` compartida con la actualización desde la API.

### Testing
- Compilación estática: `python -m py_compile ComunidadesCore.py LombardBot.py ComunidadesConstantes.py` (éxito).
- Comprobación AST que verifica que el handler delega en `administrar_partido_comunidades` y que `administrar_partido_comunidades` llama a `registrar_resultado_partido_comunidades` (éxito).
- Prueba aislada de traducción de tipos administrativos ejecutando la función `_datos_resultado_admin_comunidades` para los cinco tipos (`forfeit_local`, `forfeit_visitante`, `empate_admin`, `doble_forfeit`, `manual`) (éxito).
- `git diff --check` y revisión del diff (sin errores) y commit local realizado; no se ejecutaron tests de la carpeta `test/` por indicación explícita.
- Nota: la importación de `LombardBot` en este entorno falló por ausencia del paquete `discord`, por lo que las comprobaciones de comportamiento en tiempo de ejecución se realizaron con análisis estático/AST en lugar de importar el módulo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25353b86ac832a9ee8ebf580c64517)