### PR TITLE
Add public query endpoints and Discord commands for Comunidades

### DIFF
--- a/ComunidadesCore.py
+++ b/ComunidadesCore.py
@@ -3668,3 +3668,211 @@ def calcular_clasificacion_comunidades(
             criterio_anterior = criterio
         fila["posicion"] = posicion
     return ordenada
+
+
+# ---------------------------------------------------------------------------
+# Consultas públicas
+# ---------------------------------------------------------------------------
+
+class ErrorConsultaComunidades(ValueError):
+    """Error de dominio legible para las consultas públicas."""
+
+    def __init__(self, codigo: str, detalle: str):
+        super().__init__(detalle)
+        self.codigo = codigo
+        self.detalle = detalle
+
+
+def _error_consulta(codigo: str, detalle: str) -> None:
+    raise ErrorConsultaComunidades(codigo, detalle)
+
+
+def _obtener_torneo_consulta(session: Any, torneo_id: int):
+    from GestorSQL import ComunidadesTorneo
+
+    torneo = session.query(ComunidadesTorneo).filter_by(id=torneo_id).one_or_none()
+    if torneo is None:
+        _error_consulta("TORNEO_INEXISTENTE", f"No existe el torneo de comunidades con ID {torneo_id}.")
+    return torneo
+
+
+def _obtener_ronda_consulta(session: Any, torneo_id: int, numero: Optional[int]):
+    from GestorSQL import ComunidadesRonda
+
+    consulta = session.query(ComunidadesRonda).filter_by(torneo_id=torneo_id)
+    if numero is None:
+        ronda = consulta.order_by(ComunidadesRonda.numero.desc()).first()
+    else:
+        if type(numero) is not int or numero <= 0:
+            _error_consulta("RONDA_INVALIDA", "La ronda debe ser un entero positivo.")
+        ronda = consulta.filter_by(numero=numero).one_or_none()
+    if ronda is None:
+        texto = "última generada" if numero is None else str(numero)
+        _error_consulta("RONDA_INEXISTENTE", f"El torneo {torneo_id} no tiene la ronda {texto}.")
+    return ronda
+
+
+def consultar_clasificacion_equipos_comunidades(
+    session: Any, *, torneo_id: int, ronda: Optional[int] = None
+) -> dict[str, Any]:
+    """Obtiene la clasificación actual del core o un snapshot cerrado."""
+    from GestorSQL import ComunidadesSnapshotClasificacionEquipo
+
+    torneo = _obtener_torneo_consulta(session, torneo_id)
+    if ronda is None:
+        filas = calcular_clasificacion_equipos(session, torneo_id)
+        equipos = {int(e.id): e for e in torneo.equipos}
+        for fila in filas:
+            equipo = equipos[int(fila["equipo_id"])]
+            fila.update(
+                comunidad_nombre=equipo.comunidad.nombre,
+                es_zombie=bool(equipo.es_zombie),
+                estado_temporal=equipo.estado_temporal,
+            )
+        return {"torneo": torneo, "ronda": None, "fuente": "ACTUAL", "filas": filas}
+
+    ronda_db = _obtener_ronda_consulta(session, torneo_id, ronda)
+    snapshots = (
+        session.query(ComunidadesSnapshotClasificacionEquipo)
+        .filter_by(torneo_id=torneo_id, ronda_id=ronda_db.id)
+        .order_by(
+            ComunidadesSnapshotClasificacionEquipo.posicion.asc(),
+            ComunidadesSnapshotClasificacionEquipo.equipo_id.asc(),
+        )
+        .all()
+    )
+    if not snapshots:
+        _error_consulta("SNAPSHOT_INEXISTENTE", f"La ronda {ronda} todavía no tiene snapshot de equipos.")
+    filas = []
+    for snap in snapshots:
+        equipo = snap.equipo
+        filas.append({
+            "posicion": int(snap.posicion), "equipo_id": int(snap.equipo_id),
+            "nombre": equipo.nombre, "comunidad_nombre": equipo.comunidad.nombre,
+            "es_zombie": bool(equipo.es_zombie), "estado_temporal": equipo.estado_temporal,
+            "pj": int(snap.partidos_jugados), "pg": int(snap.victorias),
+            "pe": int(snap.empates), "pp": int(snap.derrotas),
+            "cantidad_byes": int(snap.cantidad_byes), "puntos": _decimal(snap.puntos_clasificacion),
+            "buchholz_cut": _decimal(snap.buchholz_cut),
+            "h2h_valor": None if snap.puntos_enfrentamiento_directo is None else _decimal(snap.puntos_enfrentamiento_directo),
+            "td_favor": int(snap.td_favor), "td_contra": int(snap.td_contra),
+            "diferencia_td": int(snap.td_favor) - int(snap.td_contra),
+        })
+    return {"torneo": torneo, "ronda": ronda_db, "fuente": "SNAPSHOT", "filas": filas}
+
+
+def consultar_clasificacion_comunidades_comunidades(
+    session: Any, *, torneo_id: int, ronda: Optional[int] = None
+) -> dict[str, Any]:
+    """Obtiene la clasificación comunitaria actual o un snapshot cerrado."""
+    from GestorSQL import ComunidadesSnapshotClasificacionComunidad
+
+    torneo = _obtener_torneo_consulta(session, torneo_id)
+    if ronda is None:
+        equipos = calcular_clasificacion_equipos(session, torneo_id)
+        filas = calcular_clasificacion_comunidades(session, torneo_id, clasificacion_equipos=equipos)
+        return {"torneo": torneo, "ronda": None, "fuente": "ACTUAL", "filas": filas}
+
+    ronda_db = _obtener_ronda_consulta(session, torneo_id, ronda)
+    snapshots = (
+        session.query(ComunidadesSnapshotClasificacionComunidad)
+        .filter_by(torneo_id=torneo_id, ronda_id=ronda_db.id)
+        .order_by(
+            ComunidadesSnapshotClasificacionComunidad.posicion.asc(),
+            ComunidadesSnapshotClasificacionComunidad.comunidad_id.asc(),
+        ).all()
+    )
+    if not snapshots:
+        _error_consulta("SNAPSHOT_INEXISTENTE", f"La ronda {ronda} todavía no tiene snapshot de comunidades.")
+    filas = [{
+        "posicion": int(s.posicion), "nombre": s.comunidad.nombre,
+        "puntos_zombificaciones": _decimal(s.puntos_zombificaciones),
+        "zombies_matados": int(s.zombies_matados),
+        "suma_puntos_equipos": _decimal(s.suma_puntos_equipos),
+    } for s in snapshots]
+    return {"torneo": torneo, "ronda": ronda_db, "fuente": "SNAPSHOT", "filas": filas}
+
+
+def consultar_ronda_comunidades(
+    session: Any, *, torneo_id: int, ronda: Optional[int] = None
+) -> dict[str, Any]:
+    """Expone una ronda sin leer elecciones de atacante."""
+    from GestorSQL import ComunidadesEnfrentamiento, ComunidadesFotografiaEstado, ComunidadesHistorialTransicion
+
+    torneo = _obtener_torneo_consulta(session, torneo_id)
+    ronda_db = _obtener_ronda_consulta(session, torneo_id, ronda)
+    enfrentamientos = (
+        session.query(ComunidadesEnfrentamiento)
+        .filter_by(torneo_id=torneo_id, ronda_id=ronda_db.id)
+        .order_by(ComunidadesEnfrentamiento.mesa_numero.asc()).all()
+    )
+    fotos = session.query(ComunidadesFotografiaEstado).filter_by(
+        torneo_id=torneo_id, ronda_id=ronda_db.id
+    ).all()
+    estados = {(int(f.enfrentamiento_id), int(f.equipo_id)): {
+        "es_zombie": bool(f.es_zombie), "estado_temporal": f.estado_temporal
+    } for f in fotos}
+    filas = []
+    for e in enfrentamientos:
+        filas.append({
+            "mesa": int(e.mesa_numero), "equipo_a": e.equipo_a, "equipo_b": e.equipo_b,
+            "estado_a": estados.get((int(e.id), int(e.equipo_a_id)), {"es_zombie": bool(e.equipo_a.es_zombie), "estado_temporal": e.equipo_a.estado_temporal}),
+            "estado_b": estados.get((int(e.id), int(e.equipo_b_id)), {"es_zombie": bool(e.equipo_b.es_zombie), "estado_temporal": e.equipo_b.estado_temporal}),
+            "estado": e.estado, "canal_general_discord_id": e.canal_general_discord_id,
+            "puntos_internos_a": _decimal(e.puntos_internos_a), "puntos_internos_b": _decimal(e.puntos_internos_b),
+            "puntos_clasificacion_a": _decimal(e.puntos_clasificacion_a), "puntos_clasificacion_b": _decimal(e.puntos_clasificacion_b),
+        })
+    bye = session.query(ComunidadesHistorialTransicion).filter_by(
+        torneo_id=torneo_id, ronda_id=ronda_db.id, motivo="BYE"
+    ).one_or_none()
+    return {"torneo": torneo, "ronda": ronda_db, "enfrentamientos": filas,
+            "bye_equipo": None if bye is None else bye.equipo}
+
+
+def consultar_equipo_comunidades(session: Any, *, torneo_id: int, equipo_nombre: str) -> dict[str, Any]:
+    """Obtiene identidad pública, estado y clasificación actual de un equipo."""
+    from GestorSQL import ComunidadesEquipo
+
+    torneo = _obtener_torneo_consulta(session, torneo_id)
+    nombre = str(equipo_nombre or "").strip()
+    equipo = session.query(ComunidadesEquipo).filter_by(torneo_id=torneo_id, nombre=nombre).one_or_none()
+    if equipo is None:
+        _error_consulta("EQUIPO_INEXISTENTE", f"No existe el equipo '{nombre}' en el torneo {torneo_id}.")
+    fila = next((f for f in calcular_clasificacion_equipos(session, torneo_id)
+                 if int(f["equipo_id"]) == int(equipo.id)), None)
+    return {"torneo": torneo, "equipo": equipo,
+            "miembros": sorted(equipo.miembros, key=lambda m: int(m.posicion)),
+            "clasificacion": fila}
+
+
+def consultar_estados_comunidades(session: Any, *, torneo_id: int) -> dict[str, Any]:
+    """Lista estados actuales en el orden exacto del clasificador del core."""
+    from GestorSQL import ComunidadesEquipo
+
+    torneo = _obtener_torneo_consulta(session, torneo_id)
+    equipos = {int(e.id): e for e in session.query(ComunidadesEquipo).filter_by(torneo_id=torneo_id).all()}
+    filas = [{"clasificacion": f, "equipo": equipos[int(f["equipo_id"])]}
+             for f in calcular_clasificacion_equipos(session, torneo_id)]
+    return {"torneo": torneo, "filas": filas}
+
+
+def consultar_estado_canales_comunidades(
+    session: Any, *, torneo_id: int, ronda: Optional[int] = None
+) -> dict[str, Any]:
+    """Expone canales y progreso sin identidades ni roles secretos."""
+    from GestorSQL import ComunidadesEnfrentamiento
+
+    torneo = _obtener_torneo_consulta(session, torneo_id)
+    ronda_db = _obtener_ronda_consulta(session, torneo_id, ronda)
+    enfrentamientos = session.query(ComunidadesEnfrentamiento).filter_by(
+        torneo_id=torneo_id, ronda_id=ronda_db.id
+    ).order_by(ComunidadesEnfrentamiento.mesa_numero.asc()).all()
+    filas = []
+    for e in enfrentamientos:
+        filas.append({
+            "mesa": int(e.mesa_numero), "equipo_a": e.equipo_a, "equipo_b": e.equipo_b,
+            "estado": e.estado, "canal_general_discord_id": e.canal_general_discord_id,
+            "partidos": [{"indice": int(p.indice), "estado": p.estado, "canal_discord_id": p.canal_discord_id}
+                         for p in sorted(e.partidos, key=lambda p: int(p.indice))],
+        })
+    return {"torneo": torneo, "ronda": ronda_db, "filas": filas}

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -55,6 +55,7 @@ from SuizoCore import (
 )
 from ComunidadesCore import (
     ErrorAdministracionEleccionesComunidades,
+    ErrorConsultaComunidades,
     ErrorConfiguracionComunidades,
     anadir_categoria_enfrentamientos_comunidades,
     anadir_categoria_partidos_comunidades,
@@ -66,6 +67,12 @@ from ComunidadesCore import (
     configurar_puntos_individuales_comunidades,
     crear_torneo_comunidades,
     consultar_elecciones_comunidades,
+    consultar_clasificacion_comunidades_comunidades,
+    consultar_clasificacion_equipos_comunidades,
+    consultar_equipo_comunidades,
+    consultar_estado_canales_comunidades,
+    consultar_estados_comunidades,
+    consultar_ronda_comunidades,
     ErrorGeneracionRondaComunidades,
     ErrorRegistroResultadoComunidades,
     ErrorTransferenciaComunidades,
@@ -5203,6 +5210,179 @@ def _estado_con_emojis_comunidades(estado_temporal: str, es_zombie: bool) -> str
     if emoji_temporal:
         emojis.append(emoji_temporal)
     return " ".join(emojis) or "⚪"
+
+
+ESTADOS_PUBLICOS_COMUNIDADES = {
+    "CREADO": "🆕", "EN_CURSO": "🟢", "FINALIZADO": "🏁",
+    "ABIERTA": "🟢", "BLOQUEADA": "🔒", "CERRADA": "✅",
+    "PENDIENTE_ELECCIONES": "⏳", "ELECCIONES_COMPLETAS": "🔒",
+    "PARTIDOS_CREADOS": "🧩", "PENDIENTE": "⏳", "ADMINISTRADO": "🛠️",
+}
+
+
+def _estado_publico_comunidades(estado: object) -> str:
+    texto = str(estado or "DESCONOCIDO")
+    return f"{ESTADOS_PUBLICOS_COMUNIDADES.get(texto, 'ℹ️')} `{texto}`"
+
+
+def _decimal_publico_comunidades(valor: object) -> str:
+    texto = format(Decimal(str(valor or 0)), "f")
+    return texto.rstrip("0").rstrip(".") if "." in texto else texto
+
+
+def _mencion_publica_comunidades(usuario) -> str:
+    discord_id = getattr(usuario, "id_discord", None)
+    return f"<@{int(discord_id)}>" if discord_id is not None else _texto_discord_seguro(_nombre_usuario_comunidades(usuario))
+
+
+def _cabecera_publica_comunidades(torneo, titulo: str) -> list[str]:
+    return [f"## {titulo}",
+            f"Torneo: **{_texto_discord_seguro(torneo.nombre)}** (`{int(torneo.id)}`)",
+            f"Estado: {_estado_publico_comunidades(torneo.estado)}"]
+
+
+async def _ejecutar_consulta_publica_comunidades(interaction, consulta, formatear):
+    await interaction.response.defer()
+    SessionComunidades = sessionmaker(bind=GestorSQL.conexionEngine())
+    session = SessionComunidades()
+    try:
+        try:
+            mensaje = formatear(consulta(session))
+        except ErrorConsultaComunidades as exc:
+            await interaction.followup.send(f"❌ {exc.detalle}", ephemeral=True)
+            return
+        except Exception as exc:
+            await interaction.followup.send(f"❌ No se pudo completar la consulta: {exc}", ephemeral=True)
+            return
+        await UtilesDiscord.responder_interaction_largo(interaction, mensaje)
+    finally:
+        session.close()
+
+
+def _formatear_ronda_publica(resultado: dict) -> str:
+    torneo, ronda = resultado["torneo"], resultado["ronda"]
+    lineas = _cabecera_publica_comunidades(torneo, f"Ronda {int(ronda.numero)} de comunidades")
+    lineas += [f"Ronda: {_estado_publico_comunidades(ronda.estado)} · 📅 {ronda.fecha_inicio:%Y-%m-%d %H:%M}—{ronda.fecha_fin:%Y-%m-%d %H:%M} UTC", ""]
+    if not resultado["enfrentamientos"]:
+        lineas.append("ℹ️ No hay enfrentamientos en esta ronda.")
+    for fila in resultado["enfrentamientos"]:
+        ea = _estado_con_emojis_comunidades(fila["estado_a"]["estado_temporal"], fila["estado_a"]["es_zombie"])
+        eb = _estado_con_emojis_comunidades(fila["estado_b"]["estado_temporal"], fila["estado_b"]["es_zombie"])
+        canal = f"<#{int(fila['canal_general_discord_id'])}>" if fila["canal_general_discord_id"] else "⚠️ sin canal"
+        lineas += [f"### Mesa {fila['mesa']} · {_estado_publico_comunidades(fila['estado'])}",
+                   f"{ea} **{_texto_discord_seguro(fila['equipo_a'].nombre)}** vs {eb} **{_texto_discord_seguro(fila['equipo_b'].nombre)}**",
+                   f"📺 Canal general: {canal}"]
+        if fila["estado"] in (ENFRENTAMIENTO_CERRADO, ENFRENTAMIENTO_ADMINISTRADO):
+            lineas.append(f"🏁 Internos **{_decimal_publico_comunidades(fila['puntos_internos_a'])}-{_decimal_publico_comunidades(fila['puntos_internos_b'])}** · Clasificación **{_decimal_publico_comunidades(fila['puntos_clasificacion_a'])}-{_decimal_publico_comunidades(fila['puntos_clasificacion_b'])}**")
+        lineas.append("")
+    if resultado["bye_equipo"] is not None:
+        lineas.append(f"🛌 **BYE:** {_texto_discord_seguro(resultado['bye_equipo'].nombre)}")
+    lineas.append("🔐 Las elecciones de atacante no se muestran en esta consulta pública.")
+    return "\n".join(lineas)
+
+
+def _formatear_equipos_publico(resultado: dict) -> str:
+    fuente = f"snapshot de ronda {resultado['ronda'].numero}" if resultado["fuente"] == "SNAPSHOT" else "clasificación actual"
+    lineas = _cabecera_publica_comunidades(resultado["torneo"], "Clasificación de equipos") + [f"📸 Fuente: **{fuente}**", ""]
+    if not resultado["filas"]:
+        lineas.append("ℹ️ Todavía no hay equipos inscritos.")
+    for f in resultado["filas"]:
+        estado = _estado_con_emojis_comunidades(f["estado_temporal"], f["es_zombie"])
+        h2h = "-" if f["h2h_valor"] is None else _decimal_publico_comunidades(f["h2h_valor"])
+        lineas += [f"**{f['posicion']}.** {estado} **{_texto_discord_seguro(f['nombre'])}** · 🏘️ {_texto_discord_seguro(f['comunidad_nombre'])}",
+                   f"🏆 PTS **{_decimal_publico_comunidades(f['puntos'])}** · PJ {f['pj']} ({f['pg']}/{f['pe']}/{f['pp']}) · 🛌 {f['cantidad_byes']} · BH {_decimal_publico_comunidades(f['buchholz_cut'])} · H2H {h2h} · TD {f['td_favor']}-{f['td_contra']} ({f['diferencia_td']:+d})"]
+    if resultado["fuente"] == "SNAPSHOT":
+        lineas.append("\nℹ️ Los puntos son históricos; los emojis muestran el estado actual.")
+    return "\n".join(lineas)
+
+
+def _formatear_comunidades_publico(resultado: dict) -> str:
+    fuente = f"snapshot de ronda {resultado['ronda'].numero}" if resultado["fuente"] == "SNAPSHOT" else "clasificación actual"
+    lineas = _cabecera_publica_comunidades(resultado["torneo"], "Clasificación de comunidades") + [f"📸 Fuente: **{fuente}**", ""]
+    if not resultado["filas"]:
+        lineas.append("ℹ️ Todavía no hay comunidades configuradas.")
+    for f in resultado["filas"]:
+        lineas.append(f"**{f['posicion']}.** 🏘️ **{_texto_discord_seguro(f['nombre'])}** · 🧟 PZ **{_decimal_publico_comunidades(f['puntos_zombificaciones'])}** · ☠️ kills **{f['zombies_matados']}** · 🏆 PTS equipos **{_decimal_publico_comunidades(f['suma_puntos_equipos'])}**")
+    lineas.append("\n🤝 Los criterios idénticos conservan una posición compartida.")
+    return "\n".join(lineas)
+
+
+def _formatear_equipo_publico(resultado: dict) -> str:
+    equipo, fila = resultado["equipo"], resultado["clasificacion"]
+    estado = _estado_con_emojis_comunidades(equipo.estado_temporal, equipo.es_zombie)
+    lineas = _cabecera_publica_comunidades(resultado["torneo"], "Consulta de equipo")
+    lineas += [f"Equipo: {estado} **{_texto_discord_seguro(equipo.nombre)}**", f"🏘️ Comunidad: **{_texto_discord_seguro(equipo.comunidad.nombre)}**", "", "### Integrantes"]
+    for m in resultado["miembros"]:
+        lineas.append(f"{m.posicion}. {_mencion_publica_comunidades(m.usuario)} · 🧬 **{_texto_discord_seguro(m.raza)}**")
+    if fila:
+        h2h = "-" if fila["h2h_valor"] is None else _decimal_publico_comunidades(fila["h2h_valor"])
+        lineas += ["", "### Clasificación actual", f"📊 Posición **{fila['posicion']}** · 🏆 PTS **{_decimal_publico_comunidades(fila['puntos'])}** · PJ {fila['pj']} ({fila['pg']}/{fila['pe']}/{fila['pp']}) · 🛌 {fila['cantidad_byes']}", f"BH {_decimal_publico_comunidades(fila['buchholz_cut'])} · H2H {h2h} · TD {fila['td_favor']}-{fila['td_contra']} ({fila['diferencia_td']:+d})"]
+    return "\n".join(lineas)
+
+
+def _formatear_estados_publico(resultado: dict) -> str:
+    lineas = _cabecera_publica_comunidades(resultado["torneo"], "Estados de equipos") + ["📊 Orden de la clasificación actual del core.", ""]
+    if not resultado["filas"]:
+        lineas.append("ℹ️ Todavía no hay equipos inscritos.")
+    for dato in resultado["filas"]:
+        e, f = dato["equipo"], dato["clasificacion"]
+        lineas.append(f"**{f['posicion']}.** {_estado_con_emojis_comunidades(e.estado_temporal, e.es_zombie)} **{_texto_discord_seguro(e.nombre)}** · 🏘️ {_texto_discord_seguro(e.comunidad.nombre)}")
+    lineas.append("\nLeyenda: ⚪ neutro · 🏹 cazador · 🩸 herido · 🧟 zombie · 🏹🧟 cazador Z.")
+    return "\n".join(lineas)
+
+
+def _formatear_canales_publico(resultado: dict) -> str:
+    ronda = resultado["ronda"]
+    lineas = _cabecera_publica_comunidades(resultado["torneo"], f"Estado de canales · ronda {ronda.numero}") + [f"Ronda: {_estado_publico_comunidades(ronda.estado)}", ""]
+    if not resultado["filas"]:
+        lineas.append("ℹ️ No hay enfrentamientos ni canales en esta ronda.")
+    for f in resultado["filas"]:
+        general = f"<#{int(f['canal_general_discord_id'])}>" if f["canal_general_discord_id"] else "⚠️ sin canal"
+        lineas += [f"### Mesa {f['mesa']} · {_estado_publico_comunidades(f['estado'])}", f"**{_texto_discord_seguro(f['equipo_a'].nombre)}** vs **{_texto_discord_seguro(f['equipo_b'].nombre)}**", f"📺 General: {general}"]
+        if not f["partidos"]:
+            lineas.append("🔐 Individuales: aún no materializados.")
+        for p in f["partidos"]:
+            canal = f"<#{int(p['canal_discord_id'])}>" if p["canal_discord_id"] else "⚠️ sin canal"
+            lineas.append(f"🏟️ Partido {p['indice']}: {_estado_publico_comunidades(p['estado'])} · {canal}")
+        lineas.append("")
+    lineas.append("🔐 No se muestran atacantes, defensores ni elecciones.")
+    return "\n".join(lineas)
+
+
+@bot.tree.command(name="comunidades_consulta_ronda", description="Consulta una ronda de comunidades")
+@app_commands.describe(torneo_id="Identificador del torneo", ronda="Ronda; omitir para la última generada")
+async def comunidades_consulta_ronda(interaction: discord.Interaction, torneo_id: int, ronda: Optional[int] = None):
+    await _ejecutar_consulta_publica_comunidades(interaction, lambda s: consultar_ronda_comunidades(s, torneo_id=torneo_id, ronda=ronda), _formatear_ronda_publica)
+
+
+@bot.tree.command(name="comunidades_clasif_equipos", description="Consulta la clasificación de equipos")
+@app_commands.describe(torneo_id="Identificador del torneo", ronda="Ronda cerrada cuyo snapshot se consulta")
+async def comunidades_clasif_equipos(interaction: discord.Interaction, torneo_id: int, ronda: Optional[int] = None):
+    await _ejecutar_consulta_publica_comunidades(interaction, lambda s: consultar_clasificacion_equipos_comunidades(s, torneo_id=torneo_id, ronda=ronda), _formatear_equipos_publico)
+
+
+@bot.tree.command(name="comunidades_clasif_comunidades", description="Consulta la clasificación de comunidades")
+@app_commands.describe(torneo_id="Identificador del torneo", ronda="Ronda cerrada cuyo snapshot se consulta")
+async def comunidades_clasif_comunidades(interaction: discord.Interaction, torneo_id: int, ronda: Optional[int] = None):
+    await _ejecutar_consulta_publica_comunidades(interaction, lambda s: consultar_clasificacion_comunidades_comunidades(s, torneo_id=torneo_id, ronda=ronda), _formatear_comunidades_publico)
+
+
+@bot.tree.command(name="comunidades_consulta_equipo", description="Consulta un equipo de comunidades")
+@app_commands.describe(torneo_id="Identificador del torneo", equipo="Nombre exacto del equipo")
+async def comunidades_consulta_equipo(interaction: discord.Interaction, torneo_id: int, equipo: str):
+    await _ejecutar_consulta_publica_comunidades(interaction, lambda s: consultar_equipo_comunidades(s, torneo_id=torneo_id, equipo_nombre=equipo), _formatear_equipo_publico)
+
+
+@bot.tree.command(name="comunidades_consulta_estados", description="Consulta los estados de los equipos")
+@app_commands.describe(torneo_id="Identificador del torneo")
+async def comunidades_consulta_estados(interaction: discord.Interaction, torneo_id: int):
+    await _ejecutar_consulta_publica_comunidades(interaction, lambda s: consultar_estados_comunidades(s, torneo_id=torneo_id), _formatear_estados_publico)
+
+
+@bot.tree.command(name="comunidades_estado_canales", description="Consulta canales de una ronda de comunidades")
+@app_commands.describe(torneo_id="Identificador del torneo", ronda="Ronda; omitir para la última generada")
+async def comunidades_estado_canales(interaction: discord.Interaction, torneo_id: int, ronda: Optional[int] = None):
+    await _ejecutar_consulta_publica_comunidades(interaction, lambda s: consultar_estado_canales_comunidades(s, torneo_id=torneo_id, ronda=ronda), _formatear_canales_publico)
 
 
 def _texto_partido_comunidades(partido) -> str:


### PR DESCRIPTION
### Motivation
- Expose read-only, human-readable queries for comunidades tournaments and rounds without leaking secret attacker choices.
- Allow retrieval of current core state or closed-round snapshots for team and community classifications, round details, channel progress, team identity and states.
- Provide Discord slash commands to let users call those public queries and receive nicely formatted summaries.

### Description
- Added a domain error `ErrorConsultaComunidades` and helpers `_obtener_torneo_consulta` and `_obtener_ronda_consulta` to validate tournament and round input.  
- Implemented public query functions `consultar_clasificacion_equipos_comunidades`, `consultar_clasificacion_comunidades_comunidades`, `consultar_ronda_comunidades`, `consultar_equipo_comunidades`, `consultar_estados_comunidades`, and `consultar_estado_canales_comunidades` that return sanitized structures or snapshots.  
- Extended `LombardBot.py` with presentation utilities (`ESTADOS_PUBLICOS_COMUNIDADES`, `_estado_publico_comunidades`, `_decimal_publico_comunidades`, `_mencion_publica_comunidades`, `_cabecera_publica_comunidades`), formatters (`_formatear_*`), a generic executor `_ejecutar_consulta_publica_comunidades`, and registered slash commands (`/comunidades_consulta_ronda`, `/comunidades_clasif_equipos`, `/comunidades_clasif_comunidades`, `/comunidades_consulta_equipo`, `/comunidades_consulta_estados`, `/comunidades_estado_canales`).  
- Imported `ErrorConsultaComunidades` into the bot and wired exception handling so domain errors return user-facing messages while unexpected errors produce a generic failure response.  

### Testing
- No automated unit tests were added for these changes.  
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a253d4a80b8832a80b691945b3813f5)