### PR TITLE
Cerrar rondas de comunidades: snapshots, publicaciones idempotentes y limpieza reintentable

### DIFF
--- a/ComunidadesCore.py
+++ b/ComunidadesCore.py
@@ -3671,6 +3671,225 @@ def calcular_clasificacion_comunidades(
 
 
 # ---------------------------------------------------------------------------
+# Cierre de ronda
+# ---------------------------------------------------------------------------
+
+def _guardar_snapshots_cierre_comunidades(
+    session: Any,
+    *,
+    torneo_id: int,
+    ronda: Any,
+    clasificacion_equipos: list[FilaClasificacion],
+    clasificacion_comunidades: list[FilaClasificacion],
+) -> tuple[int, int]:
+    """Guarda una única fotografía de cada clasificación para la ronda.
+
+    La ronda y sus dos conjuntos de filas se confirman en la misma transacción.
+    Si el cierre se reintenta, se reutilizan los snapshots completos existentes;
+    un conjunto parcial se considera una inconsistencia y nunca se completa con
+    datos potencialmente calculados en otro momento.
+    """
+    from GestorSQL import (
+        ComunidadesSnapshotClasificacionComunidad,
+        ComunidadesSnapshotClasificacionEquipo,
+    )
+
+    snapshots_equipo = (
+        session.query(ComunidadesSnapshotClasificacionEquipo)
+        .filter_by(torneo_id=torneo_id, ronda_id=ronda.id)
+        .count()
+    )
+    snapshots_comunidad = (
+        session.query(ComunidadesSnapshotClasificacionComunidad)
+        .filter_by(torneo_id=torneo_id, ronda_id=ronda.id)
+        .count()
+    )
+    esperados_equipo = len(clasificacion_equipos)
+    esperados_comunidad = len(clasificacion_comunidades)
+    if snapshots_equipo or snapshots_comunidad:
+        if (snapshots_equipo, snapshots_comunidad) != (
+            esperados_equipo,
+            esperados_comunidad,
+        ):
+            raise RuntimeError(
+                "Los snapshots existentes de la ronda están incompletos "
+                f"(equipos {snapshots_equipo}/{esperados_equipo}, "
+                f"comunidades {snapshots_comunidad}/{esperados_comunidad})."
+            )
+        return snapshots_equipo, snapshots_comunidad
+
+    for fila in clasificacion_equipos:
+        session.add(
+            ComunidadesSnapshotClasificacionEquipo(
+                torneo_id=torneo_id,
+                ronda_id=ronda.id,
+                equipo_id=int(fila["equipo_id"]),
+                posicion=int(fila["posicion"]),
+                puntos_clasificacion=_decimal(fila["puntos"]),
+                buchholz_cut=_decimal(fila["buchholz_cut"]),
+                puntos_enfrentamiento_directo=(
+                    None
+                    if fila.get("h2h_valor") is None
+                    else _decimal(fila["h2h_valor"])
+                ),
+                td_favor=int(fila["td_favor"]),
+                td_contra=int(fila["td_contra"]),
+                partidos_jugados=int(fila["pj"]),
+                victorias=int(fila["pg"]),
+                empates=int(fila["pe"]),
+                derrotas=int(fila["pp"]),
+                cantidad_byes=int(fila["cantidad_byes"]),
+            )
+        )
+    for fila in clasificacion_comunidades:
+        session.add(
+            ComunidadesSnapshotClasificacionComunidad(
+                torneo_id=torneo_id,
+                ronda_id=ronda.id,
+                comunidad_id=int(fila["comunidad_id"]),
+                posicion=int(fila["posicion"]),
+                puntos_zombificaciones=_decimal(fila["puntos_zombificaciones"]),
+                zombies_matados=int(fila["zombies_matados"]),
+                suma_puntos_equipos=_decimal(fila["suma_puntos_equipos"]),
+            )
+        )
+    session.flush()
+    return esperados_equipo, esperados_comunidad
+
+
+def procesar_cierre_ronda_comunidades_si_corresponde(
+    session: Any, torneo_id: int, ronda_numero: int
+) -> dict[str, Any]:
+    """Consolida una ronda resuelta sin realizar operaciones de Discord.
+
+    El cierre de base de datos es atómico e idempotente. La publicación y la
+    limpieza de canales se realizan después del commit desde ``LombardBot``.
+    Según la especificación, una ronda posterior nunca se crea automáticamente.
+    """
+    from GestorSQL import (
+        ComunidadesEnfrentamiento,
+        ComunidadesHistorialTransicion,
+        ComunidadesPartido,
+        ComunidadesRonda,
+        ComunidadesTorneo,
+        ComunidadesTrazaEmparejamiento,
+    )
+
+    torneo = (
+        session.query(ComunidadesTorneo)
+        .filter(ComunidadesTorneo.id == torneo_id)
+        .with_for_update()
+        .one_or_none()
+    )
+    if torneo is None:
+        return {
+            "cerrada": False,
+            "motivo": "TORNEO_NO_EXISTE",
+            "ronda_numero": int(ronda_numero),
+        }
+    ronda = (
+        session.query(ComunidadesRonda)
+        .filter_by(torneo_id=torneo_id, numero=ronda_numero)
+        .with_for_update()
+        .one_or_none()
+    )
+    if ronda is None:
+        return {
+            "cerrada": False,
+            "motivo": "RONDA_NO_EXISTE",
+            "ronda_numero": int(ronda_numero),
+        }
+
+    estados_enfrentamiento_resueltos = (
+        ENFRENTAMIENTO_CERRADO,
+        ENFRENTAMIENTO_ADMINISTRADO,
+    )
+    estados_partido_resueltos = (PARTIDO_FINALIZADO, PARTIDO_ADMINISTRADO)
+    pendientes_enfrentamiento = (
+        session.query(ComunidadesEnfrentamiento)
+        .filter(
+            ComunidadesEnfrentamiento.ronda_id == ronda.id,
+            ~ComunidadesEnfrentamiento.estado.in_(estados_enfrentamiento_resueltos),
+        )
+        .count()
+    )
+    pendientes_partido = (
+        session.query(ComunidadesPartido)
+        .join(
+            ComunidadesEnfrentamiento,
+            ComunidadesEnfrentamiento.id == ComunidadesPartido.enfrentamiento_id,
+        )
+        .filter(
+            ComunidadesEnfrentamiento.ronda_id == ronda.id,
+            ~ComunidadesPartido.estado.in_(estados_partido_resueltos),
+        )
+        .count()
+    )
+    byes_esperados = (
+        session.query(ComunidadesTrazaEmparejamiento)
+        .filter_by(ronda_id=ronda.id, etapa="SELECCION_BYE")
+        .count()
+    )
+    byes_resueltos = (
+        session.query(ComunidadesHistorialTransicion)
+        .filter_by(ronda_id=ronda.id, enfrentamiento_id=None, motivo="BYE")
+        .count()
+    )
+    pendientes_bye = max(0, int(byes_esperados) - int(byes_resueltos))
+    if pendientes_enfrentamiento or pendientes_partido or pendientes_bye:
+        return {
+            "cerrada": False,
+            "motivo": "HAY_PENDIENTES",
+            "pendientes_enfrentamientos": int(pendientes_enfrentamiento),
+            "pendientes_partidos": int(pendientes_partido),
+            "pendientes_byes": pendientes_bye,
+            "ronda_numero": int(ronda_numero),
+        }
+
+    clasificacion_equipos = calcular_clasificacion_equipos(
+        session, torneo_id, hasta_ronda=ronda_numero
+    )
+    clasificacion_comunidades = calcular_clasificacion_comunidades(
+        session,
+        torneo_id,
+        hasta_ronda=ronda_numero,
+        clasificacion_equipos=clasificacion_equipos,
+    )
+    snapshot_equipos, snapshot_comunidades = _guardar_snapshots_cierre_comunidades(
+        session,
+        torneo_id=torneo_id,
+        ronda=ronda,
+        clasificacion_equipos=clasificacion_equipos,
+        clasificacion_comunidades=clasificacion_comunidades,
+    )
+
+    ya_cerrada = ronda.estado == "CERRADA"
+    if not ya_cerrada:
+        ronda.estado = "CERRADA"
+        ronda.cerrada_en = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    es_ultima_ronda = int(ronda_numero) >= int(torneo.rondas_totales)
+    if es_ultima_ronda:
+        torneo.estado = "FINALIZADO"
+    session.flush()
+    return {
+        "cerrada": True,
+        "motivo": "YA_CERRADA" if ya_cerrada else "CERRADA",
+        "idempotente": ya_cerrada,
+        "ronda_id": int(ronda.id),
+        "ronda_numero": int(ronda_numero),
+        "es_ultima_ronda": es_ultima_ronda,
+        "siguiente_ronda_numero": (
+            None if es_ultima_ronda else int(ronda_numero) + 1
+        ),
+        "snapshot_equipos": int(snapshot_equipos),
+        "snapshot_comunidades": int(snapshot_comunidades),
+        "clasificacion_equipos": clasificacion_equipos,
+        "clasificacion_comunidades": clasificacion_comunidades,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Consultas públicas
 # ---------------------------------------------------------------------------
 

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -78,6 +78,7 @@ from ComunidadesCore import (
     ErrorTransferenciaComunidades,
     forzar_elecciones_comunidades,
     generar_ronda_comunidades,
+    procesar_cierre_ronda_comunidades_si_corresponde,
     registrar_resultado_partido_comunidades,
     transferir_cazador_comunidades,
 )
@@ -4851,10 +4852,34 @@ async def comunidades_actualizar(ctx, torneo_id: int, todos: Optional[str] = Non
         if torneo is None:
             await ctx.send(f"❌ No existe un torneo de comunidades con ID `{torneo_id}`.")
             return
+        if torneo.estado == "FINALIZADO":
+            ronda_cerrada = (
+                session.query(GestorSQL.ComunidadesRonda)
+                .filter_by(torneo_id=torneo_id, estado="CERRADA")
+                .order_by(GestorSQL.ComunidadesRonda.numero.desc())
+                .first()
+            )
+            if ronda_cerrada is None:
+                await ctx.send(
+                    f"❌ El torneo `{torneo_id}` está FINALIZADO pero no tiene una ronda cerrada."
+                )
+                return
+            cierre = _consolidar_cierre_ronda_comunidades(
+                session, torneo_id, int(ronda_cerrada.numero)
+            )
+            avisos = await _post_cierre_ronda_comunidades(ctx, session, cierre)
+            mensaje = (
+                f"ℹ️ Torneo `{torneo_id}` ya finalizado; se reintentó el cierre "
+                f"de la ronda {int(ronda_cerrada.numero)}."
+            )
+            if avisos:
+                mensaje += "\n⚠️ " + "; ".join(avisos) + "."
+            await ctx.send(mensaje)
+            return
         if torneo.estado != TORNEO_EN_CURSO:
             await ctx.send(
                 f"❌ El torneo `{torneo_id}` está en estado `{torneo.estado}`; "
-                "solo se actualizan torneos EN_CURSO."
+                "solo se actualizan torneos EN_CURSO o se reintenta un cierre FINALIZADO."
             )
             return
         if not torneo.id_competicion_bbowl:
@@ -4873,7 +4898,26 @@ async def comunidades_actualizar(ctx, torneo_id: int, todos: Optional[str] = Non
             .all()
         )
         if not rondas_abiertas:
-            await ctx.send(f"❌ No hay una ronda ABIERTA para el torneo `{torneo_id}`.")
+            ronda_cerrada = (
+                session.query(GestorSQL.ComunidadesRonda)
+                .filter_by(torneo_id=torneo_id, estado="CERRADA")
+                .order_by(GestorSQL.ComunidadesRonda.numero.desc())
+                .first()
+            )
+            if ronda_cerrada is None:
+                await ctx.send(f"❌ No hay una ronda ABIERTA para el torneo `{torneo_id}`.")
+                return
+            cierre = _consolidar_cierre_ronda_comunidades(
+                session, torneo_id, int(ronda_cerrada.numero)
+            )
+            avisos = await _post_cierre_ronda_comunidades(ctx, session, cierre)
+            mensaje = (
+                f"ℹ️ No hay ronda ABIERTA; se reintentó el cierre de la ronda "
+                f"{int(ronda_cerrada.numero)} sin generar la siguiente."
+            )
+            if avisos:
+                mensaje += "\n⚠️ " + "; ".join(avisos) + "."
+            await ctx.send(mensaje)
             return
         if len(rondas_abiertas) != 1:
             await ctx.send(
@@ -4911,9 +4955,17 @@ async def comunidades_actualizar(ctx, torneo_id: int, todos: Optional[str] = Non
             .all()
         )
         if not partidos_pendientes:
+            cierre = _consolidar_cierre_ronda_comunidades(
+                session, torneo_id, int(ronda.numero)
+            )
+            avisos_cierre = await _post_cierre_ronda_comunidades(
+                ctx, session, cierre
+            )
             mensaje = f"ℹ️ No hay partidos individuales pendientes en la ronda {ronda.numero}."
-            if avisos_previos:
-                mensaje += "\n⚠️ " + "; ".join(avisos_previos) + "."
+            if cierre.get("cerrada"):
+                mensaje += " La ronda quedó consolidada."
+            if avisos_previos or avisos_cierre:
+                mensaje += "\n⚠️ " + "; ".join(avisos_previos + avisos_cierre) + "."
             else:
                 mensaje += " Se comprobaron también las publicaciones consolidadas."
             await ctx.send(mensaje)
@@ -5031,6 +5083,15 @@ async def comunidades_actualizar(ctx, torneo_id: int, todos: Optional[str] = Non
                 for aviso in avisos_publicacion
             )
 
+        cierre = _consolidar_cierre_ronda_comunidades(
+            session, torneo_id, int(ronda.numero)
+        )
+        avisos_cierre = await _post_cierre_ronda_comunidades(ctx, session, cierre)
+        if avisos_cierre:
+            detalles.extend(
+                f"cierre pendiente para reintento: {aviso}" for aviso in avisos_cierre
+            )
+
         resumen = (
             f"📊 **Actualización de comunidades — torneo {torneo_id}, ronda {ronda.numero}**\n"
             f"- Encontrados y registrados: **{encontrados}**\n"
@@ -5095,6 +5156,28 @@ async def _enviar_unico_comunidades(canal, marca: str, contenido: str, **kwargs)
     texto = f"{contenido}\n{marca}" if contenido else marca
     await canal.send(texto, **kwargs)
     return True
+
+
+async def _enviar_largo_unico_comunidades(
+    canal, tipo: str, registro_id: int, contenido: str
+) -> bool:
+    """Publica texto largo en partes, cada una idempotente por separado."""
+    partes = UtilesDiscord.dividir_mensaje_discord(contenido, limite=1800)
+    enviado = False
+    total = len(partes)
+    for indice, parte in enumerate(partes, start=1):
+        cabecera = f"**Parte {indice}/{total}**\n" if total > 1 else ""
+        enviado = (
+            await _enviar_unico_comunidades(
+                canal,
+                _marca_publicacion_comunidades(
+                    f"{tipo}-parte-{indice}", registro_id
+                ),
+                cabecera + parte,
+            )
+            or enviado
+        )
+    return enviado
 
 
 async def _buscar_hilo_resultados_comunidades(canal_foro, titulo: str):
@@ -5675,6 +5758,126 @@ async def _reintentar_publicaciones_ronda_comunidades(ctx, session, ronda_id: in
     return avisos
 
 
+async def _eliminar_canales_ronda_comunidades(ctx, session, ronda_id: int):
+    """Elimina solo canales persistidos de la ronda y permite reintentos."""
+    enfrentamientos = (
+        session.query(GestorSQL.ComunidadesEnfrentamiento)
+        .filter(GestorSQL.ComunidadesEnfrentamiento.ronda_id == int(ronda_id))
+        .order_by(GestorSQL.ComunidadesEnfrentamiento.id)
+        .all()
+    )
+    avisos = []
+    torneo = enfrentamientos[0].torneo if enfrentamientos else None
+    ids_protegidos = {FORO_RESULTADOS_ID}
+    if torneo is not None and torneo.canal_hub_id is not None:
+        ids_protegidos.add(int(torneo.canal_hub_id))
+
+    registros = []
+    for enfrentamiento in enfrentamientos:
+        registros.append((enfrentamiento, "canal_general_discord_id", "general"))
+        for partido in enfrentamiento.partidos:
+            registros.append((partido, "canal_discord_id", "individual"))
+
+    for registro, atributo, tipo in registros:
+        canal_id = getattr(registro, atributo)
+        if canal_id is None:
+            continue
+        canal_id = int(canal_id)
+        if canal_id in ids_protegidos:
+            avisos.append(
+                f"se rechazó eliminar el canal protegido {canal_id} almacenado como {tipo}"
+            )
+            continue
+        canal = await _resolver_canal_notificacion_comunidades(ctx, canal_id)
+        try:
+            if canal is not None:
+                await canal.delete(
+                    reason=f"Cierre de ronda de comunidades {int(ronda_id)}"
+                )
+            setattr(registro, atributo, None)
+            session.commit()
+        except Exception as exc:
+            session.rollback()
+            avisos.append(f"canal {tipo} {canal_id}: {exc}")
+    return avisos
+
+
+async def _post_cierre_ronda_comunidades(ctx, session, cierre: dict):
+    """Publica clasificaciones y limpia Discord tras confirmar el cierre BD."""
+    if not cierre.get("cerrada"):
+        return []
+    torneo_id = int(cierre["torneo_id"])
+    ronda_numero = int(cierre["ronda_numero"])
+    ronda_id = int(cierre["ronda_id"])
+    avisos = []
+    canal_hub = await _resolver_canal_notificacion_comunidades(
+        ctx, cierre.get("canal_hub_id")
+    )
+    try:
+        equipos = consultar_clasificacion_equipos_comunidades(
+            session, torneo_id=torneo_id, ronda=ronda_numero
+        )
+        titulo = (
+            f"🏆 **Clasificación final de equipos · ronda {ronda_numero}**"
+            if cierre["es_ultima_ronda"]
+            else f"✅ **Cierre de ronda {ronda_numero} · clasificación de equipos**"
+        )
+        await _enviar_largo_unico_comunidades(
+            canal_hub,
+            "cierre-equipos",
+            ronda_id,
+            titulo + "\n" + _formatear_equipos_publico(equipos),
+        )
+    except Exception as exc:
+        avisos.append(f"clasificación de equipos en hub: {exc}")
+    try:
+        comunidades = consultar_clasificacion_comunidades_comunidades(
+            session, torneo_id=torneo_id, ronda=ronda_numero
+        )
+        titulo = (
+            f"🏆 **Clasificación final de comunidades · ronda {ronda_numero}**"
+            if cierre["es_ultima_ronda"]
+            else f"✅ **Cierre de ronda {ronda_numero} · clasificación de comunidades**"
+        )
+        siguiente = cierre.get("siguiente_ronda_numero")
+        pie = (
+            "\n\n🏁 **Torneo finalizado.**"
+            if cierre["es_ultima_ronda"]
+            else (
+                f"\n\n➡️ La ronda **{int(siguiente)}** queda pendiente de generación "
+                "manual por un comisario."
+            )
+        )
+        await _enviar_largo_unico_comunidades(
+            canal_hub,
+            "cierre-comunidades",
+            ronda_id,
+            titulo + "\n" + _formatear_comunidades_publico(comunidades) + pie,
+        )
+    except Exception as exc:
+        avisos.append(f"clasificación de comunidades en hub: {exc}")
+
+    avisos.extend(
+        await _eliminar_canales_ronda_comunidades(ctx, session, ronda_id)
+    )
+    return avisos
+
+
+def _consolidar_cierre_ronda_comunidades(session, torneo_id: int, ronda_numero: int):
+    """Confirma el paso de base de datos antes de cualquier operación Discord."""
+    cierre = procesar_cierre_ronda_comunidades_si_corresponde(
+        session, torneo_id, ronda_numero
+    )
+    if cierre.get("cerrada"):
+        session.commit()
+        torneo = session.get(GestorSQL.ComunidadesTorneo, int(torneo_id))
+        cierre["torneo_id"] = int(torneo_id)
+        cierre["canal_hub_id"] = (
+            None if torneo is None else torneo.canal_hub_id
+        )
+    return cierre
+
+
 async def _resolver_canal_notificacion_comunidades(ctx, canal_id):
     if canal_id is None:
         return None
@@ -5811,6 +6014,10 @@ async def comunidades_admin_partido(
         avisos = await publicar_resultado_partido_comunidades(
             ctx, session, resultado.partido.id
         )
+        cierre = _consolidar_cierre_ronda_comunidades(
+            session, torneo_id, ronda_numero
+        )
+        avisos.extend(await _post_cierre_ronda_comunidades(ctx, session, cierre))
         if resultado.idempotente:
             confirmacion = (
                 f"ℹ️ El partido `{partido_indice}` del enfrentamiento "
@@ -6059,6 +6266,11 @@ async def comunidades_generar_ronda(ctx, torneo_id: int, ronda_numero: int):
             except Exception as exc:
                 fallos.append(f"No se pudo publicar el resumen en el hub `{torneo.canal_hub_id}` ({exc}).")
 
+        cierre = _consolidar_cierre_ronda_comunidades(
+            session, torneo_id, ronda_numero
+        )
+        fallos.extend(await _post_cierre_ronda_comunidades(ctx, session, cierre))
+
         if fallos:
             await _publicar_error_administrativo_comunidades(
                 ctx,
@@ -6066,9 +6278,13 @@ async def comunidades_generar_ronda(ctx, torneo_id: int, ronda_numero: int):
                 + "\n".join(f"- {fallo}" for fallo in fallos),
             )
         else:
+            cierre_texto = (
+                " y cerrada automáticamente al contener solo byes"
+                if cierre.get("cerrada") else ""
+            )
             await ctx.send(
                 f"✅ Ronda {ronda_numero} generada: {len(enfrentamientos)} canales creados "
-                f"y resumen publicado en <#{int(torneo.canal_hub_id)}>."
+                f"y resumen publicado en <#{int(torneo.canal_hub_id)}>{cierre_texto}."
             )
     except ErrorSeleccionCategoriaComunidades as exc:
         session.rollback()


### PR DESCRIPTION
### Motivation

- Automatizar el cierre de una ronda de comunidades cuando no quedan enfrentamientos, partidos ni byes pendientes, manteniendo la especificación que prohíbe generar automáticamente la siguiente ronda.  

### Description

- Añade cierre transaccional e idempotente en `ComunidadesCore.py` mediante `procesar_cierre_ronda_comunidades_si_corresponde` y `_guardar_snapshots_cierre_comunidades`, que validan pendientes y guardan exactamente un snapshot por ronda para equipos y comunidades.  
- Separa la confirmación en BD del trabajo sobre Discord: añade en `LombardBot.py` `_consolidar_cierre_ronda_comunidades`, `_post_cierre_ronda_comunidades` y `_eliminar_canales_ronda_comunidades` para publicar clasificaciones en el hub (con marcas idempotentes y fragmentación de mensajes) y eliminar solo los canales asociados a la ronda de forma reintentable.  
- Integra el cierre en los flujos que generan o actualizan rondas y administran partidos (`comunidades_actualizar`, `comunidades_admin_partido`, `comunidades_generar_ronda`) para reintentar publicaciones/limpieza cuando procede y para manejar el caso de rondas formadas únicamente por byes.  
- Añade helper de publicación larga idempotente `_enviar_largo_unico_comunidades` y protecciones para conservar foro y hub; los mensajes del hub se marcan para evitar duplicados en reintentos.  
- Archivos principales modificados: `ComunidadesCore.py` (cierre y snapshots) y `LombardBot.py` (publicación y limpieza reintentable, integración en flujos existentes).  

### Testing

- Ejecutadas comprobaciones estáticas: parseo AST de `ComunidadesCore.py` y `LombardBot.py` con `ast.parse` (OK).  
- Ejecutado `git diff --check` y revisiones estáticas del diff (sin errores de formato).  
- Intento de comprobación dinámica mínima con SQLite falló por ausencia de la dependencia `sqlalchemy` en el entorno, por lo que no se realizaron pruebas que requirieran la ORM; no se instalaron dependencias adicionales.  
- Conforme a la petición, no se ejecutó ninguna prueba de la carpeta `tests/` (validación manual prevista fuera de este cambio).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2540aee518832abe4785507904d285)