### PR TITLE
Harden comunidades concurrency and idempotency

### DIFF
--- a/BD/comunidades_schema.sql
+++ b/BD/comunidades_schema.sql
@@ -175,6 +175,7 @@ CREATE TABLE IF NOT EXISTS comunidades_enfrentamiento (
   CONSTRAINT uk_comunidades_enfrentamiento_ronda_mesa UNIQUE (ronda_id, mesa_numero),
   CONSTRAINT uk_comunidades_enfrentamiento_ronda_equipo_a UNIQUE (ronda_id, equipo_a_id),
   CONSTRAINT uk_comunidades_enfrentamiento_ronda_equipo_b UNIQUE (ronda_id, equipo_b_id),
+  CONSTRAINT uk_com_enfrentamiento_canal UNIQUE (canal_general_discord_id),
   CONSTRAINT ck_comunidades_enfrentamiento_mesa CHECK (mesa_numero > 0),
   CONSTRAINT ck_comunidades_enfrentamiento_equipos CHECK (equipo_a_id <> equipo_b_id),
   CONSTRAINT ck_comunidades_enfrentamiento_ganador CHECK (
@@ -313,6 +314,7 @@ CREATE TABLE IF NOT EXISTS comunidades_partido (
   CONSTRAINT uk_com_partido_enfrentamiento_indice
     UNIQUE (enfrentamiento_id, indice),
   CONSTRAINT uk_com_partido_bloodbowl UNIQUE (partido_bloodbowl_id),
+  CONSTRAINT uk_com_partido_canal UNIQUE (canal_discord_id),
   CONSTRAINT ck_com_partido_indice CHECK (indice IN (1, 2)),
   CONSTRAINT ck_com_partido_equipos CHECK (equipo_local_id <> equipo_visitante_id),
   CONSTRAINT ck_com_partido_usuarios CHECK (usuario_local_id <> usuario_visitante_id),
@@ -455,8 +457,10 @@ CREATE TABLE IF NOT EXISTS comunidades_historial_transferencia (
   equipo_destino_id INT NOT NULL,
   tipo ENUM('CAZADOR','CAZADOR_Z') NOT NULL,
   ejecutada_por_discord_id BIGINT NOT NULL,
+  clave_idempotencia VARCHAR(190) NOT NULL,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (id),
+  CONSTRAINT uk_com_transferencia_idempotencia UNIQUE (clave_idempotencia),
   CONSTRAINT ck_com_transferencia_equipos
     CHECK (equipo_origen_id <> equipo_destino_id),
   KEY idx_com_transferencia_ronda_torneo (ronda_id, torneo_id),
@@ -544,6 +548,30 @@ CREATE TABLE IF NOT EXISTS comunidades_snapshot_clasificacion_comunidad (
   CONSTRAINT fk_com_snap_com_comunidad
     FOREIGN KEY (comunidad_id, torneo_id)
     REFERENCES comunidades_comunidad(id, torneo_id)
+    ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+-- Claves idempotentes persistidas para efectos que no comparten transacción
+-- con MySQL (Discord/API). Una clave PENDIENTE funciona como lease recuperable;
+-- COMPLETADA conserva el ID externo y evita repetir el efecto tras reinicios.
+CREATE TABLE IF NOT EXISTS comunidades_operacion_idempotente (
+  id INT AUTO_INCREMENT,
+  clave VARCHAR(190) NOT NULL,
+  tipo VARCHAR(45) NOT NULL,
+  estado ENUM('PENDIENTE','COMPLETADA') NOT NULL DEFAULT 'PENDIENTE',
+  torneo_id INT NOT NULL,
+  ronda_id INT NULL,
+  enfrentamiento_id INT NULL,
+  partido_id INT NULL,
+  recurso_externo_id VARCHAR(120) NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  CONSTRAINT uk_com_operacion_clave UNIQUE (clave),
+  KEY idx_com_operacion_contexto
+    (torneo_id, ronda_id, enfrentamiento_id, partido_id),
+  CONSTRAINT fk_com_operacion_torneo
+    FOREIGN KEY (torneo_id) REFERENCES comunidades_torneo(id)
     ON DELETE CASCADE
 ) ENGINE=InnoDB;
 

--- a/ComunidadesCore.py
+++ b/ComunidadesCore.py
@@ -13,6 +13,8 @@ from enum import Enum
 from functools import cmp_to_key
 from typing import Any, Iterable, Optional
 
+from sqlalchemy.exc import IntegrityError
+
 from ComunidadesConstantes import (
     ESTADO_TEMPORAL_CAZADOR,
     ESTADO_TEMPORAL_CAZADOR_Z,
@@ -38,6 +40,93 @@ from ComunidadesConstantes import (
     TORNEO_EN_CURSO,
     validar_puntuacion,
 )
+
+
+def reservar_operacion_idempotente_comunidades(
+    session: Any,
+    *,
+    clave: str,
+    tipo: str,
+    torneo_id: int,
+    ronda_id: Optional[int] = None,
+    enfrentamiento_id: Optional[int] = None,
+    partido_id: Optional[int] = None,
+    lease_segundos: int = 300,
+) -> bool:
+    """Reserva una operación externa; permite recuperar leases abandonados."""
+    from GestorSQL import ComunidadesOperacionIdempotente
+
+    ahora = datetime.now(timezone.utc).replace(tzinfo=None)
+    operacion = (
+        session.query(ComunidadesOperacionIdempotente)
+        .filter(ComunidadesOperacionIdempotente.clave == clave)
+        .with_for_update()
+        .one_or_none()
+    )
+    if operacion is None:
+        try:
+            with session.begin_nested():
+                session.add(
+                    ComunidadesOperacionIdempotente(
+                        clave=clave,
+                        tipo=tipo,
+                        torneo_id=torneo_id,
+                        ronda_id=ronda_id,
+                        enfrentamiento_id=enfrentamiento_id,
+                        partido_id=partido_id,
+                    )
+                )
+                session.flush()
+            return True
+        except IntegrityError:
+            operacion = (
+                session.query(ComunidadesOperacionIdempotente)
+                .filter(ComunidadesOperacionIdempotente.clave == clave)
+                .with_for_update()
+                .one()
+            )
+    if operacion.estado == "COMPLETADA":
+        return False
+    actualizado = operacion.updated_at or operacion.created_at or ahora
+    if ahora - actualizado < timedelta(seconds=lease_segundos):
+        return False
+    operacion.updated_at = ahora
+    operacion.tipo = tipo
+    operacion.torneo_id = torneo_id
+    operacion.ronda_id = ronda_id
+    operacion.enfrentamiento_id = enfrentamiento_id
+    operacion.partido_id = partido_id
+    session.flush()
+    return True
+
+
+def completar_operacion_idempotente_comunidades(
+    session: Any, *, clave: str, recurso_externo_id: Optional[object] = None
+) -> None:
+    from GestorSQL import ComunidadesOperacionIdempotente
+
+    operacion = (
+        session.query(ComunidadesOperacionIdempotente)
+        .filter(ComunidadesOperacionIdempotente.clave == clave)
+        .with_for_update()
+        .one()
+    )
+    operacion.estado = "COMPLETADA"
+    operacion.recurso_externo_id = (
+        None if recurso_externo_id is None else str(recurso_externo_id)
+    )
+    session.flush()
+
+
+def liberar_operacion_idempotente_comunidades(session: Any, *, clave: str) -> None:
+    """Libera solo reservas pendientes para que el siguiente reintento continúe."""
+    from GestorSQL import ComunidadesOperacionIdempotente
+
+    session.query(ComunidadesOperacionIdempotente).filter(
+        ComunidadesOperacionIdempotente.clave == clave,
+        ComunidadesOperacionIdempotente.estado == "PENDIENTE",
+    ).delete(synchronize_session=False)
+    session.flush()
 
 
 class ErrorConfiguracionComunidades(ValueError):
@@ -1770,6 +1859,7 @@ def transferir_cazador_comunidades(
     torneo_id: int,
     equipo_destino_nombre: str,
     actor_discord_id: int,
+    clave_idempotencia: str,
 ):
     """Transfiere atómicamente un cazador obtenido en la ronda vigente.
 
@@ -1795,6 +1885,28 @@ def transferir_cazador_comunidades(
         _error_transferencia(
             "ACTOR_INVALIDO", "El ID Discord del actor debe ser un entero mayor que cero."
         )
+    clave_idempotencia = str(clave_idempotencia or "").strip()
+    if not clave_idempotencia or len(clave_idempotencia) > 190:
+        _error_transferencia(
+            "CLAVE_IDEMPOTENCIA_INVALIDA",
+            "La transferencia requiere una clave idempotente válida.",
+        )
+    existente = (
+        session.query(ComunidadesHistorialTransferencia)
+        .filter(
+            ComunidadesHistorialTransferencia.clave_idempotencia
+            == clave_idempotencia
+        )
+        .one_or_none()
+    )
+    if existente is not None:
+        if int(existente.torneo_id) != torneo_id:
+            _error_transferencia(
+                "CLAVE_IDEMPOTENCIA_CONFLICTIVA",
+                "La clave idempotente pertenece a otro torneo.",
+            )
+        return existente
+
     equipo_destino_nombre = str(equipo_destino_nombre or "").strip()
     if not equipo_destino_nombre:
         _error_transferencia(
@@ -1830,7 +1942,6 @@ def transferir_cazador_comunidades(
                 ComunidadesEquipo.torneo_id == torneo_id,
                 Usuario.id_discord == actor_discord_id,
             )
-            .with_for_update()
             .one_or_none()
         )
         if origen is None:
@@ -1845,7 +1956,6 @@ def transferir_cazador_comunidades(
                 ComunidadesEquipo.torneo_id == torneo_id,
                 ComunidadesEquipo.nombre == equipo_destino_nombre,
             )
-            .with_for_update()
             .one_or_none()
         )
         if destino is None:
@@ -1857,6 +1967,16 @@ def transferir_cazador_comunidades(
             _error_transferencia(
                 "MISMO_EQUIPO", "El equipo origen y el destino deben ser distintos."
             )
+        equipos_bloqueados = (
+            session.query(ComunidadesEquipo)
+            .filter(ComunidadesEquipo.id.in_(sorted((int(origen.id), int(destino.id)))))
+            .order_by(ComunidadesEquipo.id)
+            .with_for_update()
+            .all()
+        )
+        por_id = {int(equipo.id): equipo for equipo in equipos_bloqueados}
+        origen = por_id[int(origen.id)]
+        destino = por_id[int(destino.id)]
         if int(origen.comunidad_id) != int(destino.comunidad_id):
             _error_transferencia(
                 "COMUNIDAD_DISTINTA",
@@ -1952,11 +2072,25 @@ def transferir_cazador_comunidades(
             equipo_destino_id=destino.id,
             tipo=tipo,
             ejecutada_por_discord_id=actor_discord_id,
+            clave_idempotencia=clave_idempotencia,
         )
         session.add(transferencia)
         session.flush()
         session.commit()
         return transferencia
+    except IntegrityError:
+        session.rollback()
+        existente = (
+            session.query(ComunidadesHistorialTransferencia)
+            .filter(
+                ComunidadesHistorialTransferencia.clave_idempotencia
+                == clave_idempotencia
+            )
+            .one_or_none()
+        )
+        if existente is not None:
+            return existente
+        raise
     except Exception:
         session.rollback()
         raise
@@ -2766,22 +2900,44 @@ def registrar_resultado_partido_comunidades(
         )
 
     with session.begin_nested():
-        partido = (
-            session.query(ComunidadesPartido)
+        referencia = (
+            session.query(
+                ComunidadesPartido.id, ComunidadesPartido.enfrentamiento_id
+            )
             .filter(ComunidadesPartido.id == partido_id)
-            .with_for_update()
             .one_or_none()
+        )
+        if referencia is None:
+            _error_registro_resultado(
+                "PARTIDO_NO_EXISTE", f"No existe el partido {partido_id}."
+            )
+        # Todos los resultados del mismo enfrentamiento bloquean primero la
+        # misma fila padre y después sus partidos en orden estable. Así dos
+        # resultados simultáneos no invierten el orden de locks ni resuelven
+        # dos veces los contadores globales.
+        enfrentamiento = (
+            session.query(ComunidadesEnfrentamiento)
+            .filter(ComunidadesEnfrentamiento.id == referencia.enfrentamiento_id)
+            .with_for_update()
+            .one()
+        )
+        partidos_bloqueados = tuple(
+            session.query(ComunidadesPartido)
+            .filter(
+                ComunidadesPartido.enfrentamiento_id == enfrentamiento.id
+            )
+            .order_by(ComunidadesPartido.id)
+            .with_for_update()
+            .all()
+        )
+        partido = next(
+            (item for item in partidos_bloqueados if int(item.id) == partido_id),
+            None,
         )
         if partido is None:
             _error_registro_resultado(
                 "PARTIDO_NO_EXISTE", f"No existe el partido {partido_id}."
             )
-        enfrentamiento = (
-            session.query(ComunidadesEnfrentamiento)
-            .filter(ComunidadesEnfrentamiento.id == partido.enfrentamiento_id)
-            .with_for_update()
-            .one()
-        )
         if partido_bloodbowl_id is not None:
             duplicado = (
                 session.query(ComunidadesPartido.id)
@@ -2860,11 +3016,7 @@ def registrar_resultado_partido_comunidades(
         session.flush()
 
         partidos = tuple(
-            session.query(ComunidadesPartido)
-            .filter(ComunidadesPartido.enfrentamiento_id == enfrentamiento.id)
-            .order_by(ComunidadesPartido.indice)
-            .with_for_update()
-            .all()
+            sorted(partidos_bloqueados, key=lambda item: int(item.indice))
         )
         if len(partidos) != 2:
             _error_registro_resultado(

--- a/ComunidadesDiscord.py
+++ b/ComunidadesDiscord.py
@@ -2,11 +2,13 @@
 
 from dataclasses import dataclass
 from datetime import datetime
+import logging
 from decimal import Decimal, InvalidOperation
 from typing import Any, Optional, Tuple
 
 
 MAX_CANALES_POR_CATEGORIA_COMUNIDADES = 40
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -350,8 +352,17 @@ async def materializar_partidos_comunidades(
     fallo revierte la base de datos y elimina los canales creados en el intento.
     """
     import discord
-    from ComunidadesCore import materializar_identidades_partidos_comunidades
-    from GestorSQL import ComunidadesEnfrentamiento, ComunidadesPartido
+    from ComunidadesCore import (
+        completar_operacion_idempotente_comunidades,
+        liberar_operacion_idempotente_comunidades,
+        materializar_identidades_partidos_comunidades,
+        reservar_operacion_idempotente_comunidades,
+    )
+    from GestorSQL import (
+        ComunidadesEnfrentamiento,
+        ComunidadesOperacionIdempotente,
+        ComunidadesPartido,
+    )
 
     try:
         materializar_identidades_partidos_comunidades(
@@ -460,6 +471,33 @@ async def materializar_partidos_comunidades(
             )
 
         canal = None
+        clave_operacion = f"canal-partido:{partido_id}"
+        reservada = True
+        if not atomico:
+            reservada = reservar_operacion_idempotente_comunidades(
+                session,
+                clave=clave_operacion,
+                tipo="CANAL_PARTIDO",
+                torneo_id=int(enfrentamiento.torneo_id),
+                ronda_id=int(enfrentamiento.ronda_id),
+                enfrentamiento_id=int(enfrentamiento.id),
+                partido_id=partido_id,
+            )
+            session.commit()
+        if not reservada:
+            operacion = (
+                session.query(ComunidadesOperacionIdempotente)
+                .filter(ComunidadesOperacionIdempotente.clave == clave_operacion)
+                .one()
+            )
+            if operacion.estado == "COMPLETADA" and operacion.recurso_externo_id:
+                partido.canal_discord_id = int(operacion.recurso_externo_id)
+                session.commit()
+                continue
+            _error_materializacion_discord(
+                "MATERIALIZACION_EN_CURSO",
+                "Otro proceso está creando uno de los canales del enfrentamiento.",
+            )
         try:
             canal = await guild.create_text_channel(
                 name=_nombre_canal_partido_comunidades(enfrentamiento, partido),
@@ -476,6 +514,9 @@ async def materializar_partidos_comunidades(
             if atomico:
                 session.flush()
             else:
+                completar_operacion_idempotente_comunidades(
+                    session, clave=clave_operacion, recurso_externo_id=canal.id
+                )
                 session.commit()
             canales_creados += 1
         except Exception as exc:
@@ -494,12 +535,32 @@ async def materializar_partidos_comunidades(
                     )
                 except Exception as error_limpieza:
                     errores_limpieza.append(str(error_limpieza))
-            if errores_limpieza:
-                limpieza = (
-                    "; no se pudieron eliminar todos los canales huérfanos ("
-                    + "; ".join(errores_limpieza)
-                    + ")"
+            if errores_limpieza and canal is not None and not atomico:
+                # Si Discord creó el canal pero no permite borrarlo, persistimos
+                # su ID para que ningún reintento cree un segundo huérfano.
+                partido = session.get(ComunidadesPartido, partido_id)
+                partido.canal_discord_id = int(canal.id)
+                completar_operacion_idempotente_comunidades(
+                    session, clave=clave_operacion, recurso_externo_id=canal.id
                 )
+                session.commit()
+                limpieza = "; el canal creado quedó asociado para su recuperación"
+            elif not atomico:
+                liberar_operacion_idempotente_comunidades(
+                    session, clave=clave_operacion
+                )
+                session.commit()
+            elif errores_limpieza:
+                limpieza = "; Discord no permitió eliminar todos los canales del intento"
+            LOGGER.exception(
+                "Fallo al crear canal de partido",
+                extra={
+                    "torneo_id": int(enfrentamiento.torneo_id),
+                    "ronda_id": int(enfrentamiento.ronda_id),
+                    "enfrentamiento_id": int(enfrentamiento.id),
+                    "partido_id": partido_id,
+                },
+            )
             _error_materializacion_discord(
                 "FALLO_CREACION_CANAL",
                 f"Falló el canal del partido {indice_partido} ({exc}){limpieza}.",

--- a/GestorSQL.py
+++ b/GestorSQL.py
@@ -594,6 +594,7 @@ class ComunidadesEnfrentamiento(Base):
         UniqueConstraint('ronda_id', 'mesa_numero', name='uk_comunidades_enfrentamiento_ronda_mesa'),
         UniqueConstraint('ronda_id', 'equipo_a_id', name='uk_comunidades_enfrentamiento_ronda_equipo_a'),
         UniqueConstraint('ronda_id', 'equipo_b_id', name='uk_comunidades_enfrentamiento_ronda_equipo_b'),
+        UniqueConstraint('canal_general_discord_id', name='uk_com_enfrentamiento_canal'),
         CheckConstraint('mesa_numero > 0', name='ck_comunidades_enfrentamiento_mesa'),
         CheckConstraint('equipo_a_id <> equipo_b_id', name='ck_comunidades_enfrentamiento_equipos'),
         CheckConstraint('ganador_equipo_id IS NULL OR ganador_equipo_id IN (equipo_a_id, equipo_b_id)', name='ck_comunidades_enfrentamiento_ganador'),
@@ -704,6 +705,7 @@ class ComunidadesPartido(Base):
     __table_args__ = (
         UniqueConstraint('enfrentamiento_id', 'indice', name='uk_com_partido_enfrentamiento_indice'),
         UniqueConstraint('partido_bloodbowl_id', name='uk_com_partido_bloodbowl'),
+        UniqueConstraint('canal_discord_id', name='uk_com_partido_canal'),
         CheckConstraint('indice IN (1, 2)', name='ck_com_partido_indice'),
         CheckConstraint('equipo_local_id <> equipo_visitante_id', name='ck_com_partido_equipos'),
         CheckConstraint('usuario_local_id <> usuario_visitante_id', name='ck_com_partido_usuarios'),
@@ -810,6 +812,9 @@ class ComunidadesHistorialTransicion(Base):
 class ComunidadesHistorialTransferencia(Base):
     __tablename__ = 'comunidades_historial_transferencia'
     __table_args__ = (
+        UniqueConstraint(
+            'clave_idempotencia', name='uk_com_transferencia_idempotencia'
+        ),
         CheckConstraint('equipo_origen_id <> equipo_destino_id', name='ck_com_transferencia_equipos'),
         ForeignKeyConstraint(['comunidad_id', 'torneo_id'], ['comunidades_comunidad.id', 'comunidades_comunidad.torneo_id'], name='fk_com_transferencia_comunidad', ondelete='CASCADE'),
         ForeignKeyConstraint(['equipo_origen_id', 'torneo_id'], ['comunidades_equipo.id', 'comunidades_equipo.torneo_id'], name='fk_com_transferencia_origen', ondelete='CASCADE'),
@@ -824,6 +829,7 @@ class ComunidadesHistorialTransferencia(Base):
     equipo_destino_id = Column(Integer, nullable=False)
     tipo = Column(_comunidades_enum('CAZADOR', 'CAZADOR_Z', name='comunidades_transferencia_tipo'), nullable=False)
     ejecutada_por_discord_id = Column(BigInteger, nullable=False)
+    clave_idempotencia = Column(String(190), nullable=False)
     created_at = Column(DateTime, nullable=False, server_default=func.current_timestamp())
 
     comunidad = relationship('ComunidadesComunidad', back_populates='transferencias', foreign_keys=[comunidad_id, torneo_id], overlaps=_COMUNIDADES_RELATIONSHIP_OVERLAPS)
@@ -880,6 +886,46 @@ class ComunidadesSnapshotClasificacionComunidad(Base):
     created_at = Column(DateTime, nullable=False, server_default=func.current_timestamp())
 
     comunidad = relationship('ComunidadesComunidad', back_populates='snapshots_clasificacion', foreign_keys=[comunidad_id, torneo_id], overlaps=_COMUNIDADES_RELATIONSHIP_OVERLAPS)
+
+
+class ComunidadesOperacionIdempotente(Base):
+    """Reserva persistida para coordinar efectos externos y reintentos.
+
+    La clave es estable y legible (por ejemplo ``publicacion:global-hub:42`` o
+    ``canal-partido:81``). El estado PENDIENTE actúa como lease recuperable y
+    COMPLETADA conserva el identificador del recurso externo creado.
+    """
+
+    __tablename__ = 'comunidades_operacion_idempotente'
+    __table_args__ = (
+        UniqueConstraint('clave', name='uk_com_operacion_clave'),
+        CheckConstraint(
+            "estado IN ('PENDIENTE','COMPLETADA')",
+            name='ck_com_operacion_estado',
+        ),
+        Index(
+            'idx_com_operacion_contexto',
+            'torneo_id', 'ronda_id', 'enfrentamiento_id', 'partido_id',
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    clave = Column(String(190), nullable=False)
+    tipo = Column(String(45), nullable=False)
+    estado = Column(
+        _comunidades_enum(
+            'PENDIENTE', 'COMPLETADA', name='comunidades_operacion_estado'
+        ),
+        nullable=False,
+        server_default=text("'PENDIENTE'"),
+    )
+    torneo_id = Column(Integer, ForeignKey('comunidades_torneo.id', ondelete='CASCADE'), nullable=False)
+    ronda_id = Column(Integer, nullable=True)
+    enfrentamiento_id = Column(Integer, nullable=True)
+    partido_id = Column(Integer, nullable=True)
+    recurso_externo_id = Column(String(120), nullable=True)
+    created_at = Column(DateTime, nullable=False, server_default=func.current_timestamp())
+    updated_at = Column(DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp())
 
 
 class ComunidadesTrazaEmparejamiento(Base):

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -44,6 +44,7 @@ from sqlalchemy.orm import object_session, sessionmaker, relationship
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import case,func
 import inspect
+import logging
 import mysql.connector
 import Inscripcion
 import Reformas
@@ -79,6 +80,9 @@ from ComunidadesCore import (
     forzar_elecciones_comunidades,
     generar_ronda_comunidades,
     procesar_cierre_ronda_comunidades_si_corresponde,
+    reservar_operacion_idempotente_comunidades,
+    completar_operacion_idempotente_comunidades,
+    liberar_operacion_idempotente_comunidades,
     registrar_resultado_partido_comunidades,
     regenerar_ronda_comunidades,
     transferir_cazador_comunidades,
@@ -4274,9 +4278,10 @@ async def _ejecutar_configuracion_comunidades(ctx, operacion, mensaje_error: str
     except ErrorConfiguracionComunidades as exc:
         session.rollback()
         await ctx.send(f"❌ {exc.detalle}")
-    except Exception as exc:
+    except Exception:
         session.rollback()
-        await ctx.send(f"❌ {mensaje_error}: {exc}")
+        LOGGER_COMUNIDADES.exception("Fallo de configuración de comunidades")
+        await ctx.send(f"❌ {mensaje_error}. La administración ha sido avisada.")
     finally:
         session.close()
     return None
@@ -5070,10 +5075,21 @@ async def comunidades_actualizar(ctx, torneo_id: int, todos: Optional[str] = Non
                 session.rollback()
                 errores += 1
                 detalles.append(f"{partido_bloodbowl_id}: [{exc.codigo}] {exc.detalle}")
-            except Exception as exc:
+            except Exception:
                 session.rollback()
                 errores += 1
-                detalles.append(f"{partido_bloodbowl_id}: error inesperado ({exc}).")
+                LOGGER_COMUNIDADES.exception(
+                    "Fallo al registrar resultado API",
+                    extra={
+                        "torneo_id": torneo_id,
+                        "ronda_numero": int(ronda.numero),
+                        "enfrentamiento_id": int(partido.enfrentamiento_id),
+                        "partido_id": int(partido.id),
+                    },
+                )
+                detalles.append(
+                    f"{partido_bloodbowl_id}: error interno; administración avisada."
+                )
 
         avisos_publicacion = await _reintentar_publicaciones_ronda_comunidades(
             ctx, session, ronda.id, matches
@@ -5118,15 +5134,23 @@ async def comunidades_actualizar(ctx, torneo_id: int, todos: Optional[str] = Non
             if len(detalles) > 15:
                 resumen += f"\n- … y {len(detalles) - 15} incidencias más."
         await UtilesDiscord.enviar_mensaje_largo(ctx, resumen)
-    except Exception as exc:
+    except Exception:
         session.rollback()
+        LOGGER_COMUNIDADES.exception(
+            "Fallo en actualización API de comunidades",
+            extra={"torneo_id": torneo_id, "ronda_numero": None,
+                   "enfrentamiento_id": None, "partido_id": None},
+        )
         await ctx.send(
             "❌ No se pudo completar la actualización de comunidades. "
-            f"Los {encontrados} resultados ya confirmados permanecen guardados ({exc})."
+            f"Los {encontrados} resultados ya confirmados permanecen guardados. "
+            "La administración ha sido avisada."
         )
     finally:
         session.close()
 
+
+LOGGER_COMUNIDADES = logging.getLogger("lombardbot.comunidades")
 
 FORO_RESULTADOS_ID = 1223765590146158653
 
@@ -5148,15 +5172,127 @@ async def _canal_contiene_marca_comunidades(canal, marca: str) -> bool:
     return False
 
 
+def _contexto_publicacion_comunidades(session, tipo: str, registro_id: int):
+    """Resuelve el contexto de una clave de publicación sin confiar en Discord."""
+    if tipo.startswith("partido-"):
+        partido = session.get(GestorSQL.ComunidadesPartido, registro_id)
+        if partido is None:
+            raise LookupError("partido de publicación inexistente")
+        enfrentamiento = partido.enfrentamiento
+        return {
+            "torneo_id": int(partido.torneo_id),
+            "ronda_id": int(enfrentamiento.ronda_id),
+            "enfrentamiento_id": int(partido.enfrentamiento_id),
+            "partido_id": int(partido.id),
+        }
+    if tipo.startswith("global-"):
+        enfrentamiento = session.get(GestorSQL.ComunidadesEnfrentamiento, registro_id)
+        if enfrentamiento is None:
+            raise LookupError("enfrentamiento de publicación inexistente")
+        return {
+            "torneo_id": int(enfrentamiento.torneo_id),
+            "ronda_id": int(enfrentamiento.ronda_id),
+            "enfrentamiento_id": int(enfrentamiento.id),
+        }
+    if tipo.startswith("transferencia-"):
+        transferencia = session.get(
+            GestorSQL.ComunidadesHistorialTransferencia, registro_id
+        )
+        if transferencia is None:
+            raise LookupError("transferencia de publicación inexistente")
+        return {
+            "torneo_id": int(transferencia.torneo_id),
+            "ronda_id": int(transferencia.ronda_id),
+        }
+    if tipo.startswith("cierre-") or tipo == "hilo-foro":
+        ronda = session.get(GestorSQL.ComunidadesRonda, registro_id)
+        if ronda is None:
+            raise LookupError("ronda de publicación inexistente")
+        return {"torneo_id": int(ronda.torneo_id), "ronda_id": int(ronda.id)}
+    raise ValueError(f"tipo de publicación no registrado: {tipo}")
+
+
+def _reservar_publicacion_comunidades(marca: str, *, lease_segundos: int = 300):
+    coincidencia = re.fullmatch(
+        r"\|\|pub:comunidades:(?P<tipo>[^:]+):(?P<id>\d+)\|\|", marca
+    )
+    if coincidencia is None:
+        raise ValueError("marca de publicación de comunidades inválida")
+    tipo = coincidencia.group("tipo")
+    registro_id = int(coincidencia.group("id"))
+    clave = f"publicacion:{tipo}:{registro_id}"
+    Session = sessionmaker(bind=GestorSQL.conexionEngine())
+    session = Session()
+    try:
+        contexto = _contexto_publicacion_comunidades(session, tipo, registro_id)
+        reservada = reservar_operacion_idempotente_comunidades(
+            session,
+            clave=clave,
+            tipo="PUBLICACION",
+            lease_segundos=lease_segundos,
+            **contexto,
+        )
+        session.commit()
+        return clave, reservada, contexto
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def _finalizar_publicacion_comunidades(
+    clave: str, *, mensaje_id=None, liberar: bool = False
+):
+    Session = sessionmaker(bind=GestorSQL.conexionEngine())
+    session = Session()
+    try:
+        if liberar:
+            liberar_operacion_idempotente_comunidades(session, clave=clave)
+        else:
+            completar_operacion_idempotente_comunidades(
+                session, clave=clave, recurso_externo_id=mensaje_id
+            )
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
 async def _enviar_unico_comunidades(canal, marca: str, contenido: str, **kwargs) -> bool:
-    """Publica una vez usando una marca estable que también sobrevive a reintentos."""
+    """Publica una vez con reserva persistida y marca verificable en Discord."""
     if canal is None:
         raise RuntimeError("canal de publicación no disponible")
     if await _canal_contiene_marca_comunidades(canal, marca):
+        clave, reservada, _ = _reservar_publicacion_comunidades(
+            marca, lease_segundos=0
+        )
+        if reservada:
+            _finalizar_publicacion_comunidades(clave)
+        return False
+    clave, reservada, contexto = _reservar_publicacion_comunidades(marca)
+    if not reservada:
         return False
     texto = f"{contenido}\n{marca}" if contenido else marca
-    await canal.send(texto, **kwargs)
-    return True
+    try:
+        mensaje = await canal.send(texto, **kwargs)
+        _finalizar_publicacion_comunidades(
+            clave, mensaje_id=getattr(mensaje, "id", None)
+        )
+        return True
+    except Exception:
+        try:
+            _finalizar_publicacion_comunidades(clave, liberar=True)
+        except Exception:
+            LOGGER_COMUNIDADES.exception(
+                "No se pudo liberar una publicación fallida", extra=contexto
+            )
+        LOGGER_COMUNIDADES.exception(
+            "Fallo al publicar un efecto de comunidades", extra=contexto
+        )
+        raise
 
 
 async def _enviar_largo_unico_comunidades(
@@ -5335,8 +5471,11 @@ async def _ejecutar_consulta_publica_comunidades(interaction, consulta, formatea
         except ErrorConsultaComunidades as exc:
             await interaction.followup.send(f"❌ {exc.detalle}", ephemeral=True)
             return
-        except Exception as exc:
-            await interaction.followup.send(f"❌ No se pudo completar la consulta: {exc}", ephemeral=True)
+        except Exception:
+            LOGGER_COMUNIDADES.exception("Fallo en consulta pública de comunidades")
+            await interaction.followup.send(
+                "❌ No se pudo completar la consulta.", ephemeral=True
+            )
             return
         await UtilesDiscord.responder_interaction_largo(interaction, mensaje)
     finally:
@@ -5603,14 +5742,21 @@ async def comunidades_transferir_cazador(
                 torneo_id=torneo_id,
                 equipo_destino_nombre=equipo_destino,
                 actor_discord_id=int(interaction.user.id),
+                clave_idempotencia=f"discord-transferencia:{int(interaction.id)}",
             )
         except ErrorTransferenciaComunidades as exc:
             await interaction.followup.send(f"❌ {exc.detalle}", ephemeral=True)
             return
-        except Exception as exc:
+        except Exception:
             session.rollback()
+            LOGGER_COMUNIDADES.exception(
+                "Fallo al transferir estado",
+                extra={"torneo_id": torneo_id, "ronda_numero": None,
+                       "enfrentamiento_id": None, "partido_id": None},
+            )
             await interaction.followup.send(
-                f"❌ No se pudo transferir el estado: {exc}", ephemeral=True
+                "❌ No se pudo transferir el estado. La administración ha sido avisada.",
+                ephemeral=True,
             )
             return
 
@@ -5683,22 +5829,43 @@ async def publicar_resultado_partido_comunidades(
         if foro is None or not isinstance(foro, discord.ForumChannel):
             raise RuntimeError("foro de resultados no disponible")
         titulo = f"{partido.enfrentamiento.torneo.nombre} J{partido.enfrentamiento.ronda.numero}"
+        ronda_id = int(partido.enfrentamiento.ronda_id)
+        marca_hilo = _marca_publicacion_comunidades("hilo-foro", ronda_id)
+        clave_hilo, reserva_hilo, _ = _reservar_publicacion_comunidades(
+            marca_hilo
+        )
         hilo = await _buscar_hilo_resultados_comunidades(foro, titulo)
-        if hilo is None:
-            creado = await foro.create_thread(name=titulo, content=f"Resultados de {titulo}")
-            hilo = creado.thread
-        elif getattr(hilo, "archived", False):
+        if hilo is None and reserva_hilo:
+            try:
+                creado = await foro.create_thread(
+                    name=titulo, content=f"Resultados de {titulo}\n{marca_hilo}"
+                )
+                hilo = creado.thread
+                _finalizar_publicacion_comunidades(
+                    clave_hilo, mensaje_id=getattr(hilo, "id", None)
+                )
+            except Exception:
+                _finalizar_publicacion_comunidades(clave_hilo, liberar=True)
+                raise
+        elif hilo is None:
+            raise RuntimeError("otro proceso está creando el hilo de resultados")
+        elif reserva_hilo:
+            _finalizar_publicacion_comunidades(
+                clave_hilo, mensaje_id=getattr(hilo, "id", None)
+            )
+        if getattr(hilo, "archived", False):
             await hilo.edit(archived=False)
         marca = _marca_publicacion_comunidades("partido-foro", partido.id)
-        if not await _canal_contiene_marca_comunidades(hilo, marca):
-            ruta = _crear_imagen_resultado_comunidades(session, partido, match)
-            if not ruta:
-                raise RuntimeError("no se pudo generar la imagen")
-            try:
-                with open(ruta, "rb") as imagen:
-                    await hilo.send(marca, file=File(imagen))
-            finally:
-                Imagenes.eliminar_imagen(ruta)
+        ruta = _crear_imagen_resultado_comunidades(session, partido, match)
+        if not ruta:
+            raise RuntimeError("no se pudo generar la imagen")
+        try:
+            with open(ruta, "rb") as imagen:
+                await _enviar_unico_comunidades(
+                    hilo, marca, "", file=File(imagen)
+                )
+        finally:
+            Imagenes.eliminar_imagen(ruta)
     except Exception as exc:
         avisos.append(f"foro del partido {partido.id}: {exc}")
 
@@ -6033,9 +6200,20 @@ async def comunidades_admin_partido(
         if avisos:
             confirmacion += "\n⚠️ Pendiente de reintento: " + "; ".join(avisos) + "."
         await ctx.send(confirmacion)
-    except Exception as exc:
+    except Exception:
         session.rollback()
-        await ctx.send(f"❌ Error inesperado al administrar el partido: {exc}")
+        LOGGER_COMUNIDADES.exception(
+            "Fallo al administrar partido",
+            extra={
+                "torneo_id": torneo_id,
+                "ronda_numero": ronda_numero,
+                "enfrentamiento_id": enfrentamiento_id,
+                "partido_id": None,
+            },
+        )
+        await ctx.send(
+            "❌ Error interno al administrar el partido. La administración ha sido avisada."
+        )
     finally:
         session.close()
 


### PR DESCRIPTION
### Motivation

- Evitar efectos duplicados y recursos Discord huérfanos en operaciones concurrentes (elecciones, materialización de partidos, publicaciones, transferencias y cierre de ronda).  
- Garantizar idempotencia persistida y leasing recuperable para operaciones que no comparten transacción con MySQL.  
- Asegurar cierre/rollback y logging contextual (torneo, ronda, enfrentamiento, partido) sin filtrar excepciones internas a canales públicos.

### Description

- Añade tabla persistida `comunidades_operacion_idempotente` con clave única, estado `PENDIENTE/COMPLETADA`, contexto (torneo/ronda/enfrentamiento/partido) y columna `recurso_externo_id` para conservar IDs de Discord cuando sea necesario; incorpora la creación SQL correspondiente.  
- Implementa helpers de dominio `reservar_operacion_idempotente_comunidades`, `completar_operacion_idempotente_comunidades` y `liberar_operacion_idempotente_comunidades` y los integra en la materialización de canales y publicaciones para coordinar reintentos y leases.  
- Refuerza constraints únicos en esquema y modelos: única asociación de `canal_general_discord_id` por enfrentamiento y `canal_discord_id` por partido; añade clave única de idempotencia para transferencias (`clave_idempotencia`).  
- Serializa locks al registrar resultados: primero bloquea la fila de enfrentamiento y luego bloquea todos sus partidos en orden estable (por `id`) antes de actualizar/resolver, evitando duplicación de resoluciones y contadores.  
- Transferencias: introduce `clave_idempotencia` para evitar efectos repetidos, valida/reusa entradas existentes y bloquea equipos en orden por ID para evitar races.  
- Publicaciones Discord idempotentes: reserva persistida + marca en contenido de Discord; publicación reintentable y captura de hilo/foro para evitar duplicados; si un canal creado no puede borrarse en fallo, su ID se persiste para evitar huérfanos.  
- Manejo de errores y logging: los errores inesperados ya no exponen detalles internos en mensajes públicos; se registran en logger con contexto operativo y se informa al usuario en forma segura.  
- Sesiones: preserva `rollback` y `session.close()` en todos los flujos nuevos y ajustados; helpers de publicación usan sesión propia y garantizan commit/rollback/close.  
- Cambios aplicados en archivos clave: `BD/comunidades_schema.sql`, `GestorSQL.py`, `ComunidadesCore.py`, `ComunidadesDiscord.py`, `LombardBot.py` (commit: "Harden comunidades concurrency and idempotency").

### Testing

- Se compiló por sintaxis: `python -m py_compile ComunidadesCore.py ComunidadesDiscord.py GestorSQL.py LombardBot.py` (OK).  
- Se ejecutaron comprobaciones estáticas: `git diff --check` y análisis AST (`ast.parse`) de los módulos modificados (OK).  
- Se verificó la presencia de las constraints/idempotencia en el metadata y en el SQL generado (inspección estática).  
- Nota: la prueba de importación del metadata ORM que exigiría ejecutar código que importa SQLAlchemy no se pudo completar en este entorno porque `sqlalchemy` no está instalado (informado en la PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a254573e130832aa284d614f3070b92)