### PR TITLE
Añadir cobertura integral del torneo de comunidades

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    mysql_ddl: valida el DDL de comunidades contra un MySQL/MariaDB proporcionado por entorno

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from datetime import datetime
+from itertools import count
+import random
+from pathlib import Path
+from typing import Callable
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from ComunidadesCore import (
+    anadir_comunidad_comunidades,
+    anadir_equipo_comunidades,
+    crear_torneo_comunidades,
+    generar_ronda_comunidades,
+    forzar_elecciones_comunidades,
+    materializar_identidades_partidos_comunidades,
+)
+from GestorSQL import Base, ComunidadesMiembro
+
+
+RAZAS_FIXTURE = (
+    "Amazonas",
+    "Caos Elegido",
+    "Elfos Silvanos",
+    "Enanos",
+    "Hombres Lagarto",
+    "Humanos",
+    "Nobleza Imperial",
+    "No muertos",
+    "Nordicos",
+    "Orcos",
+    "Renegados",
+    "Union Elfica",
+)
+
+
+@pytest.fixture
+def comunidades_session() -> Session:
+    """SQLite aislado con las mismas claves foráneas que los tests de persistencia."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _activar_claves_foraneas(dbapi_connection, _connection_record):
+        dbapi_connection.execute("PRAGMA foreign_keys=ON")
+
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+@pytest.fixture
+def torneo_comunidades_factory(comunidades_session: Session) -> Callable:
+    secuencia = count(1)
+
+    def crear(*, rondas: int = 2, nombre: str | None = None):
+        numero = next(secuencia)
+        torneo = crear_torneo_comunidades(
+            comunidades_session,
+            nombre=nombre or f"Torneo integración {numero}",
+            rondas_totales=rondas,
+            fecha_fin_ronda1=datetime(2026, 7, 8, 22, 0),
+            dias_por_ronda=7,
+            canal_hub_id=800_000 + numero,
+            creado_por_discord_id=900_000 + numero,
+        )
+        torneo.id_competicion_bbowl = f"bbowl-{numero}"
+        torneo.plantilla_mensaje_ronda1 = "Ronda inicial"
+        torneo.plantilla_mensaje_rondas_siguientes = "Ronda {ronda}"
+        comunidades_session.flush()
+        return torneo
+
+    return crear
+
+
+@pytest.fixture
+def comunidad_comunidades_factory(comunidades_session: Session) -> Callable:
+    def crear(torneo, nombre: str):
+        return anadir_comunidad_comunidades(
+            comunidades_session, torneo_id=int(torneo.id), nombre=nombre
+        )
+
+    return crear
+
+
+@pytest.fixture
+def equipo_comunidades_factory(comunidades_session: Session) -> Callable:
+    secuencia = count(1)
+
+    def crear(
+        torneo,
+        comunidad,
+        *,
+        nombre: str | None = None,
+        razas: tuple[str, str] | None = None,
+        estado: str = "NEUTRO",
+        zombie: bool = False,
+    ):
+        numero = next(secuencia)
+        razas_equipo = razas or (
+            RAZAS_FIXTURE[(numero * 2 - 2) % len(RAZAS_FIXTURE)],
+            RAZAS_FIXTURE[(numero * 2 - 1) % len(RAZAS_FIXTURE)],
+        )
+        equipo = anadir_equipo_comunidades(
+            comunidades_session,
+            torneo_id=int(torneo.id),
+            nombre=nombre or f"Equipo {numero:02d}",
+            comunidad_nombre=comunidad.nombre,
+            jugador1_discord_id=1_000_000 + numero * 10 + 1,
+            jugador1_nombre_discord=f"Jugador {numero:02d} A",
+            raza1=razas_equipo[0],
+            jugador2_discord_id=1_000_000 + numero * 10 + 2,
+            jugador2_nombre_discord=f"Jugador {numero:02d} B",
+            raza2=razas_equipo[1],
+        )
+        equipo.estado_temporal = estado
+        equipo.es_zombie = zombie
+        comunidades_session.flush()
+        return equipo
+
+    return crear
+
+
+@pytest.fixture
+def escenario_comunidades_factory(
+    comunidades_session: Session,
+    torneo_comunidades_factory: Callable,
+    comunidad_comunidades_factory: Callable,
+    equipo_comunidades_factory: Callable,
+) -> Callable:
+    """Crea un torneo inscrito con distribución circular entre comunidades."""
+
+    def crear(*, equipos: int = 4, comunidades: int = 4, rondas: int = 2):
+        torneo = torneo_comunidades_factory(rondas=rondas)
+        comunidades_creadas = [
+            comunidad_comunidades_factory(torneo, f"Comunidad {indice + 1}")
+            for indice in range(comunidades)
+        ]
+        equipos_creados = [
+            equipo_comunidades_factory(
+                torneo,
+                comunidades_creadas[indice % comunidades],
+                nombre=f"Equipo {indice + 1}",
+            )
+            for indice in range(equipos)
+        ]
+        comunidades_session.commit()
+        return torneo, comunidades_creadas, equipos_creados
+
+    return crear
+
+
+@pytest.fixture
+def ronda_comunidades_factory(comunidades_session: Session) -> Callable:
+    """Genera rondas reales con una semilla explícita y reproducible."""
+
+    def crear(torneo, numero: int, *, semilla: int = 1, actor_id: int = 999_999):
+        return generar_ronda_comunidades(
+            comunidades_session,
+            int(torneo.id),
+            numero,
+            actor_id,
+            random.Random(semilla),
+        )
+
+    return crear
+
+
+@pytest.fixture
+def materializar_enfrentamiento(comunidades_session: Session) -> Callable:
+    """Fuerza elecciones deterministas y crea las dos identidades BO1."""
+
+    def materializar(enfrentamiento, *, ronda_numero: int):
+        miembros_a = (
+            comunidades_session.query(ComunidadesMiembro)
+            .filter_by(equipo_id=enfrentamiento.equipo_a_id)
+            .order_by(ComunidadesMiembro.posicion)
+            .all()
+        )
+        miembros_b = (
+            comunidades_session.query(ComunidadesMiembro)
+            .filter_by(equipo_id=enfrentamiento.equipo_b_id)
+            .order_by(ComunidadesMiembro.posicion)
+            .all()
+        )
+        forzar_elecciones_comunidades(
+            comunidades_session,
+            torneo_id=int(enfrentamiento.torneo_id),
+            ronda_numero=ronda_numero,
+            enfrentamiento_id=int(enfrentamiento.id),
+            atacante_equipo_a_discord_id=int(miembros_a[0].usuario.id_discord),
+            atacante_equipo_b_discord_id=int(miembros_b[0].usuario.id_discord),
+            actor_discord_id=999_999,
+        )
+        resultado = materializar_identidades_partidos_comunidades(
+            comunidades_session, enfrentamiento_id=int(enfrentamiento.id)
+        )
+        comunidades_session.flush()
+        return resultado.partidos
+
+    return materializar
+
+
+@pytest.fixture
+def ddl_mysql_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "BD" / "comunidades_schema.sql"

--- a/tests/test_comunidades_estados_integracion.py
+++ b/tests/test_comunidades_estados_integracion.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import random
+
+from ComunidadesCore import administrar_partido_comunidades, generar_ronda_comunidades
+from GestorSQL import (
+    ComunidadesComunidad,
+    ComunidadesEnfrentamiento,
+    ComunidadesHistorialTransicion,
+    ComunidadesRonda,
+)
+
+
+def _ganar_ambos_partidos(
+    session, torneo, enfrentamiento, ganador_id, materializar_enfrentamiento
+):
+    partidos = materializar_enfrentamiento(enfrentamiento, ronda_numero=1)
+    for partido in partidos:
+        marcador = (2, 0) if int(partido.equipo_local_id) == int(ganador_id) else (0, 2)
+        administrar_partido_comunidades(
+            session,
+            torneo_id=int(torneo.id),
+            ronda_numero=1,
+            enfrentamiento_id=int(enfrentamiento.id),
+            partido_indice=int(partido.indice),
+            td_local=marcador[0],
+            td_visitante=marcador[1],
+        )
+
+
+def test_zombificacion_y_kill_se_resuelven_con_la_fotografia_inicial(
+    comunidades_session,
+    torneo_comunidades_factory,
+    comunidad_comunidades_factory,
+    equipo_comunidades_factory,
+    materializar_enfrentamiento,
+):
+    torneo = torneo_comunidades_factory(rondas=1)
+    comunidades = [
+        comunidad_comunidades_factory(torneo, nombre)
+        for nombre in ("Cazadores", "Heridos", "Cazadores Z", "Zombies")
+    ]
+    equipos = [
+        equipo_comunidades_factory(
+            torneo, comunidades[0], nombre="Cazador", estado="CAZADOR"
+        ),
+        equipo_comunidades_factory(
+            torneo, comunidades[1], nombre="Herido", estado="HERIDO"
+        ),
+        equipo_comunidades_factory(
+            torneo, comunidades[2], nombre="Cazador Z", estado="CAZADOR_Z"
+        ),
+        equipo_comunidades_factory(
+            torneo,
+            comunidades[3],
+            nombre="Zombie herido",
+            estado="HERIDO",
+            zombie=True,
+        ),
+    ]
+    comunidades_session.commit()
+
+    generar_ronda_comunidades(
+        comunidades_session, torneo.id, 1, 999_999, random.Random(4)
+    )
+    ronda = comunidades_session.query(ComunidadesRonda).one()
+    enfrentamientos = comunidades_session.query(ComunidadesEnfrentamiento).all()
+    por_equipos = {
+        frozenset((enfrentamiento.equipo_a.nombre, enfrentamiento.equipo_b.nombre)): enfrentamiento
+        for enfrentamiento in enfrentamientos
+    }
+    assert set(por_equipos) == {
+        frozenset(("Cazador", "Herido")),
+        frozenset(("Cazador Z", "Zombie herido")),
+    }
+
+    for nombres, nombre_ganador in (
+        (frozenset(("Cazador", "Herido")), "Cazador"),
+        (frozenset(("Cazador Z", "Zombie herido")), "Cazador Z"),
+    ):
+        enfrentamiento = por_equipos[nombres]
+        ganador = next(
+            equipo
+            for equipo in (enfrentamiento.equipo_a, enfrentamiento.equipo_b)
+            if equipo.nombre == nombre_ganador
+        )
+        _ganar_ambos_partidos(
+            comunidades_session,
+            torneo,
+            enfrentamiento,
+            ganador.id,
+            materializar_enfrentamiento,
+        )
+    comunidades_session.commit()
+
+    actualizados = {equipo.nombre: equipo for equipo in equipos}
+    assert actualizados["Herido"].es_zombie is True
+    assert actualizados["Zombie herido"].es_zombie is True
+    motivos = {
+        transicion.motivo
+        for transicion in comunidades_session.query(ComunidadesHistorialTransicion)
+        .filter_by(ronda_id=ronda.id)
+        .all()
+    }
+    assert {"ZOMBIFICACION", "KILL"}.issubset(motivos)
+    contadores = {
+        comunidad.nombre: (comunidad.puntos_zombificaciones, comunidad.zombies_matados)
+        for comunidad in comunidades_session.query(ComunidadesComunidad).all()
+    }
+    assert contadores["Cazadores"][0] > 0
+    assert contadores["Cazadores Z"][1] == 1

--- a/tests/test_comunidades_flujo_integracion.py
+++ b/tests/test_comunidades_flujo_integracion.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import random
+from decimal import Decimal
+
+from ComunidadesCore import (
+    administrar_partido_comunidades,
+    generar_ronda_comunidades,
+    procesar_cierre_ronda_comunidades_si_corresponde,
+    regenerar_ronda_comunidades,
+)
+from GestorSQL import (
+    ComunidadesEnfrentamiento,
+    ComunidadesRonda,
+    ComunidadesSnapshotClasificacionComunidad,
+    ComunidadesSnapshotClasificacionEquipo,
+)
+
+
+def _resolver_ronda_administrativamente(
+    session, torneo, ronda_numero, materializar_enfrentamiento
+):
+    ronda = (
+        session.query(ComunidadesRonda)
+        .filter_by(torneo_id=torneo.id, numero=ronda_numero)
+        .one()
+    )
+    enfrentamientos = (
+        session.query(ComunidadesEnfrentamiento)
+        .filter_by(ronda_id=ronda.id)
+        .order_by(ComunidadesEnfrentamiento.mesa_numero)
+        .all()
+    )
+    for indice, enfrentamiento in enumerate(enfrentamientos):
+        partidos = materializar_enfrentamiento(
+            enfrentamiento, ronda_numero=ronda_numero
+        )
+        marcadores = ((2, 0), (1, 1)) if indice % 2 == 0 else ((0, 1), (2, 0))
+        for partido, (td_local, td_visitante) in zip(partidos, marcadores):
+            administrar_partido_comunidades(
+                session,
+                torneo_id=int(torneo.id),
+                ronda_numero=ronda_numero,
+                enfrentamiento_id=int(enfrentamiento.id),
+                partido_indice=int(partido.indice),
+                td_local=td_local,
+                td_visitante=td_visitante,
+            )
+    session.commit()
+    return enfrentamientos
+
+
+def test_ciclo_de_dos_rondas_desde_inscripcion_hasta_final_con_snapshots(
+    comunidades_session,
+    escenario_comunidades_factory,
+    materializar_enfrentamiento,
+):
+    torneo, comunidades, equipos = escenario_comunidades_factory(
+        equipos=4, comunidades=4, rondas=2
+    )
+
+    ronda_1 = generar_ronda_comunidades(
+        comunidades_session, torneo.id, 1, 999_999, random.Random(101)
+    )
+    assert ronda_1["nivel_fallback"] == "BASE"
+    assert len(ronda_1["enfrentamiento_ids"]) == 2
+
+    enfrentamientos_1 = _resolver_ronda_administrativamente(
+        comunidades_session, torneo, 1, materializar_enfrentamiento
+    )
+    assert all(enfrentamiento.estado == "ADMINISTRADO" for enfrentamiento in enfrentamientos_1)
+    assert all(
+        len(enfrentamiento.partidos) == 2
+        and {partido.resultado_origen for partido in enfrentamiento.partidos} == {"ADMIN"}
+        for enfrentamiento in enfrentamientos_1
+    )
+
+    cierre_1 = procesar_cierre_ronda_comunidades_si_corresponde(
+        comunidades_session, torneo.id, 1
+    )
+    comunidades_session.commit()
+    assert cierre_1["cerrada"] is True
+    assert cierre_1["es_ultima_ronda"] is False
+    assert cierre_1["snapshot_equipos"] == len(equipos)
+    assert cierre_1["snapshot_comunidades"] == len(comunidades)
+
+    ronda_2 = generar_ronda_comunidades(
+        comunidades_session, torneo.id, 2, 999_999, random.Random(202)
+    )
+    assert len(ronda_2["enfrentamiento_ids"]) == 2
+    _resolver_ronda_administrativamente(
+        comunidades_session, torneo, 2, materializar_enfrentamiento
+    )
+
+    cierre_2 = procesar_cierre_ronda_comunidades_si_corresponde(
+        comunidades_session, torneo.id, 2
+    )
+    comunidades_session.commit()
+    assert cierre_2["cerrada"] is True
+    assert cierre_2["es_ultima_ronda"] is True
+    assert comunidades_session.get(type(torneo), torneo.id).estado == "FINALIZADO"
+    assert comunidades_session.query(ComunidadesSnapshotClasificacionEquipo).count() == 8
+    assert comunidades_session.query(ComunidadesSnapshotClasificacionComunidad).count() == 8
+    assert sum(equipo.partidos_jugados for equipo in equipos) == 8
+    assert sum(equipo.puntos_clasificacion for equipo in equipos) > Decimal("0")
+
+
+def test_bye_y_regeneracion_revierten_todo_el_estado_de_la_ronda(
+    comunidades_session,
+    escenario_comunidades_factory,
+):
+    torneo, _, equipos = escenario_comunidades_factory(
+        equipos=5, comunidades=5, rondas=2
+    )
+    original = generar_ronda_comunidades(
+        comunidades_session, torneo.id, 1, 999_999, random.Random(7)
+    )
+    bye_original = original["bye_equipo_id"]
+    ronda_original = original["ronda_id"]
+    equipo_bye = comunidades_session.get(type(equipos[0]), bye_original)
+    assert equipo_bye.cantidad_byes == 1
+    assert equipo_bye.puntos_clasificacion == Decimal("1.50")
+
+    regenerada = regenerar_ronda_comunidades(
+        comunidades_session,
+        torneo.id,
+        1,
+        999_999,
+        random.Random(19),
+    )
+    assert regenerada["ronda_anterior_id"] == ronda_original
+    assert regenerada["ronda_id"] != ronda_original
+    assert comunidades_session.get(ComunidadesRonda, ronda_original) is None
+    assert sum(equipo.cantidad_byes for equipo in equipos) == 1
+    assert sum(equipo.puntos_clasificacion for equipo in equipos) == Decimal("1.50")
+    assert comunidades_session.query(ComunidadesRonda).count() == 1
+
+
+def test_transferencia_tras_cerrar_ambos_enfrentamientos_es_idempotente(
+    comunidades_session,
+    torneo_comunidades_factory,
+    comunidad_comunidades_factory,
+    equipo_comunidades_factory,
+    materializar_enfrentamiento,
+):
+    from ComunidadesCore import transferir_cazador_comunidades
+    from GestorSQL import ComunidadesHistorialTransicion, ComunidadesMiembro
+
+    torneo = torneo_comunidades_factory(rondas=2)
+    comunidad_origen = comunidad_comunidades_factory(torneo, "Comunidad compartida")
+    otras = [
+        comunidad_comunidades_factory(torneo, "Rival 1"),
+        comunidad_comunidades_factory(torneo, "Rival 2"),
+    ]
+    origen = equipo_comunidades_factory(torneo, comunidad_origen, nombre="Origen")
+    destino = equipo_comunidades_factory(torneo, comunidad_origen, nombre="Destino")
+    equipo_comunidades_factory(torneo, otras[0], nombre="Rival A")
+    equipo_comunidades_factory(torneo, otras[1], nombre="Rival B")
+    comunidades_session.commit()
+
+    generar_ronda_comunidades(
+        comunidades_session, torneo.id, 1, 999_999, random.Random(31)
+    )
+    _resolver_ronda_administrativamente(
+        comunidades_session, torneo, 1, materializar_enfrentamiento
+    )
+
+    transicion_origen = (
+        comunidades_session.query(ComunidadesHistorialTransicion)
+        .filter_by(equipo_id=origen.id)
+        .one()
+    )
+    transicion_origen.motivo = "VICTORIA"
+    transicion_origen.estado_temporal_posterior = "CAZADOR"
+    origen.estado_temporal = "CAZADOR"
+    destino.estado_temporal = "NEUTRO"
+    comunidades_session.commit()
+
+    actor = (
+        comunidades_session.query(ComunidadesMiembro)
+        .filter_by(equipo_id=origen.id, posicion=1)
+        .one()
+        .usuario.id_discord
+    )
+    transferencia = transferir_cazador_comunidades(
+        comunidades_session,
+        torneo_id=int(torneo.id),
+        equipo_destino_nombre=destino.nombre,
+        actor_discord_id=int(actor),
+        clave_idempotencia="integracion-transferencia-1",
+    )
+    repetida = transferir_cazador_comunidades(
+        comunidades_session,
+        torneo_id=int(torneo.id),
+        equipo_destino_nombre=destino.nombre,
+        actor_discord_id=int(actor),
+        clave_idempotencia="integracion-transferencia-1",
+    )
+
+    assert repetida.id == transferencia.id
+    assert origen.estado_temporal == "NEUTRO"
+    assert destino.estado_temporal == "CAZADOR"
+    assert [
+        transicion.motivo
+        for transicion in comunidades_session.query(ComunidadesHistorialTransicion)
+        .filter_by(equipo_id=destino.id)
+        .order_by(ComunidadesHistorialTransicion.id)
+        .all()
+    ][-1] == "TRANSFERENCIA"
+
+
+def test_api_mockeada_registra_los_dos_resultados_sin_red(
+    comunidades_session,
+    escenario_comunidades_factory,
+    materializar_enfrentamiento,
+):
+    from ComunidadesCore import registrar_resultado_partido_comunidades
+
+    class ApiBloodBowlDoble:
+        def __init__(self):
+            self.llamadas = []
+
+        def obtener_partidos(self, token, competicion_id):
+            self.llamadas.append((token, competicion_id))
+            return [
+                {"uuid": "api-partido-1", "local": 2, "visitante": 0},
+                {"uuid": "api-partido-2", "local": 1, "visitante": 1},
+            ]
+
+    torneo, _, _ = escenario_comunidades_factory(
+        equipos=2, comunidades=2, rondas=1
+    )
+    resultado_ronda = generar_ronda_comunidades(
+        comunidades_session, torneo.id, 1, 999_999, random.Random(11)
+    )
+    enfrentamiento = comunidades_session.get(
+        ComunidadesEnfrentamiento, resultado_ronda["enfrentamiento_ids"][0]
+    )
+    partidos = materializar_enfrentamiento(enfrentamiento, ronda_numero=1)
+    api = ApiBloodBowlDoble()
+
+    for partido, match in zip(
+        partidos, api.obtener_partidos("token-falso", torneo.id_competicion_bbowl)
+    ):
+        registrar_resultado_partido_comunidades(
+            comunidades_session,
+            partido_id=int(partido.id),
+            td_local=match["local"],
+            td_visitante=match["visitante"],
+            origen="API",
+            partido_bloodbowl_id=match["uuid"],
+        )
+    comunidades_session.commit()
+
+    assert api.llamadas == [("token-falso", torneo.id_competicion_bbowl)]
+    assert enfrentamiento.estado == "CERRADO"
+    assert {partido.partido_bloodbowl_id for partido in partidos} == {
+        "api-partido-1",
+        "api-partido-2",
+    }
+    assert {partido.resultado_origen for partido in partidos} == {"API"}

--- a/tests/test_comunidades_mysql_ddl.py
+++ b/tests/test_comunidades_mysql_ddl.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy import create_engine, inspect
+
+
+TABLAS_CRITICAS = {
+    "comunidades_torneo",
+    "comunidades_comunidad",
+    "comunidades_equipo",
+    "comunidades_ronda",
+    "comunidades_enfrentamiento",
+    "comunidades_partido",
+    "comunidades_historial_transicion",
+    "comunidades_snapshot_clasificacion_equipo",
+    "comunidades_snapshot_clasificacion_comunidad",
+}
+
+
+def _sentencias_mysql(sql: str):
+    acumulado = []
+    for linea in sql.splitlines():
+        limpia = linea.strip()
+        if not limpia or limpia.startswith("--"):
+            continue
+        acumulado.append(linea)
+        if limpia.endswith(";"):
+            yield "\n".join(acumulado)
+            acumulado = []
+    if acumulado:
+        yield "\n".join(acumulado)
+
+
+@pytest.mark.mysql_ddl
+def test_ddl_comunidades_se_aplica_en_mysql_compatible(ddl_mysql_path):
+    dsn = os.getenv("LOMBARDBOT_TEST_MYSQL_DSN")
+    if not dsn:
+        pytest.skip(
+            "Define LOMBARDBOT_TEST_MYSQL_DSN para validar el DDL en MySQL/MariaDB."
+        )
+
+    engine = create_engine(dsn)
+    try:
+        assert engine.dialect.name in {"mysql", "mariadb"}
+        ddl = ddl_mysql_path.read_text(encoding="utf-8")
+        with engine.begin() as connection:
+            connection.exec_driver_sql(
+                "CREATE TABLE IF NOT EXISTS usuarios ("
+                "idUsuarios INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (idUsuarios)"
+                ") ENGINE=InnoDB"
+            )
+            connection.exec_driver_sql("SET FOREIGN_KEY_CHECKS = 0")
+            for tabla in reversed(inspect(connection).get_table_names()):
+                if tabla.startswith("comunidades_"):
+                    connection.exec_driver_sql(f"DROP TABLE IF EXISTS `{tabla}`")
+            connection.exec_driver_sql("SET FOREIGN_KEY_CHECKS = 1")
+            for sentencia in _sentencias_mysql(ddl):
+                connection.exec_driver_sql(sentencia)
+
+        tablas = set(inspect(engine).get_table_names())
+        assert TABLAS_CRITICAS <= tablas
+        columnas_equipo = {
+            columna["name"]
+            for columna in inspect(engine).get_columns("comunidades_equipo")
+        }
+        assert {"estado_temporal", "es_zombie", "cantidad_byes"} <= columnas_equipo
+    finally:
+        engine.dispose()


### PR DESCRIPTION
### Motivation
- Añadir una suite de pruebas integradas que verifique los flujos críticos del formato de torneos por parejas y comunidades desde inscripción hasta cierre y regeneración.
- Proveer fixtures reutilizables y escenarios deterministas para facilitar pruebas reproducibles sin depencias de red ni Discord real.
- Validar de forma opt-in el DDL MySQL/MariaDB para detectar discrepancias entre el modelo ORM y el esquema SQL.

### Description
- Añade fixtures y utilidades en `tests/conftest.py` para crear sesiones SQLite en memoria, torneos, comunidades, equipos, rondas y materializar enfrentamientos con semilla RNG para determinismo.
- Añade tests integrales que cubren: generación y materialización de rondas, selección y materialización de atacantes, administración de partidos (dos resultados BO1), cierre y snapshots, bye, regeneración de ronda, transferencias idempotentes y efectos de zombificación/kill usando la fotografía inicial. (archivos: `tests/test_comunidades_flujo_integracion.py`, `tests/test_comunidades_estados_integracion.py`).
- Añade un test opt-in para aplicar el DDL MySQL/MariaDB y validar la presencia de tablas/columnas críticas mediante la variable de entorno `LOMBARDBOT_TEST_MYSQL_DSN` (archivo: `tests/test_comunidades_mysql_ddl.py`), y registra el marcador `mysql_ddl` en `pytest.ini`.
- Proporciona una API Blood Bowl simulada y patrones de materialización para evitar llamadas de red y mockea comportamiento de Discord en los escenarios que lo requieren, manteniendo las pruebas deterministas y aisladas.

### Testing
- Se ejecutó la comprobación estática y sintáctica con `python -m py_compile` sobre los nuevos módulos y fixtures y no se ejecutó la suite `pytest`, conforme a la indicación de no lanzar tests automáticos en carpeta `tests`.
- Se comprobó `git diff --cached --check` para asegurar que no hay errores de formato ni marcas pendientes y se inspeccionó el código con análisis AST para verificar la presencia y conteo de escenarios.
- La validación MySQL/DLL está incluida pero marcada opt-in y no fue ejecutada en este entorno porque requiere `LOMBARDBOT_TEST_MYSQL_DSN` y un servidor MySQL/MariaDB accesible.
- Nota: ningún test de `tests/` fue ejecutado automáticamente en este cambio; solo se realizaron compilaciones y validaciones estáticas para asegurar integridad sintáctica.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25482923e4832a8365cb42be79c003)