### PR TITLE
Incluir la comunidad junto al nombre de cada equipo en publicaciones y canales de comunidades

### DIFF
--- a/ComunidadesDiscord.py
+++ b/ComunidadesDiscord.py
@@ -302,8 +302,11 @@ def _nombre_canal_partido_comunidades(enfrentamiento: Any, partido: Any) -> str:
 def _mensaje_partido_comunidades(enfrentamiento: Any, partido: Any) -> str:
     atacante_discord_id = int(partido.atacante_usuario.id_discord)
     defensor_discord_id = int(partido.defensor_usuario.id_discord)
+    equipo_local = etiqueta_equipo_comunidades(partido.equipo_local)
+    equipo_visitante = etiqueta_equipo_comunidades(partido.equipo_visitante)
     return (
         f"## Partido {int(partido.indice)} — Mesa {int(enfrentamiento.mesa_numero)}\n"
+        f"**Equipos:** {equipo_local} vs {equipo_visitante}\n"
         f"**Atacante:** <@{atacante_discord_id}>\n"
         f"**Defensor:** <@{defensor_discord_id}>\n\n"
         f"<@{atacante_discord_id}> contra <@{defensor_discord_id}>\n"
@@ -591,6 +594,14 @@ def texto_discord_seguro_comunidades(valor: object) -> str:
     return str(valor or "").replace("@", "@\u200b")
 
 
+def etiqueta_equipo_comunidades(equipo: Any) -> str:
+    """Presenta siempre un equipo junto a la comunidad a la que pertenece."""
+    return (
+        f"{texto_discord_seguro_comunidades(equipo.nombre)} "
+        f"({texto_discord_seguro_comunidades(equipo.comunidad.nombre)})"
+    )
+
+
 def mencion_usuario_comunidades(usuario: Any) -> str:
     """Construye una mención desde un usuario persistido por comunidades."""
     discord_id = getattr(usuario, "id_discord", None)
@@ -604,7 +615,7 @@ def mencion_usuario_comunidades(usuario: Any) -> str:
 def mensaje_eleccion_ephemeral_comunidades(resultado: Any) -> str:
     """Presenta únicamente al equipo que eligió sus identidades privadas."""
     return (
-        f"**Equipo:** {texto_discord_seguro_comunidades(resultado.equipo_nombre)}\n"
+        f"**Equipo:** {etiqueta_equipo_comunidades(resultado.eleccion.equipo)}\n"
         f"**Atacante:** {mencion_usuario_comunidades(resultado.atacante)}\n"
         f"**Defensor:** {mencion_usuario_comunidades(resultado.defensor)}"
     )
@@ -715,7 +726,7 @@ async def ejecutar_seleccion_atacante_comunidades(
         mensaje_privado = mensaje_eleccion_ephemeral_comunidades(resultado)
         mensaje_publico = (
             "El equipo "
-            f"{texto_discord_seguro_comunidades(resultado.equipo_nombre)} "
+            f"{etiqueta_equipo_comunidades(resultado.eleccion.equipo)} "
             "ha elegido atacante"
         )
         requiere_materializacion = bool(resultado.requiere_crear_partidos)

--- a/DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES.md
+++ b/DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES.md
@@ -647,6 +647,7 @@ En la v1 no habrá comandos para editar estos campos: su alta y modificación se
 
 El mensaje resultante del canal general debe explicar:
 
+- los nombres de ambos equipos seguidos, entre paréntesis, por el nombre de su comunidad;
 - que cada equipo dispone de 24 horas para seleccionar atacante;
 - cómo ejecutar `/comunidades_seleccion_atacante`;
 - que la elección es secreta;
@@ -657,7 +658,7 @@ El mensaje resultante del canal general debe explicar:
 
 ### 9.3. Canales individuales
 
-Cuando ambos equipos hayan elegido, se crean dos canales adicionales con permisos, fechas y publicación de resultados equivalentes al suizo actual, pero con mensajes específicos de este formato que identifiquen atacante y defensor.
+Cuando ambos equipos hayan elegido, se crean dos canales adicionales con permisos, fechas y publicación de resultados equivalentes al suizo actual, pero con mensajes específicos de este formato que identifiquen atacante y defensor. Siempre que el mensaje mencione un equipo, debe añadir su comunidad entre paréntesis.
 
 Se distribuyen entre las categorías de partidos configuradas, en orden de alta y con límite de 40 canales por categoría, contando todos los canales existentes.
 
@@ -687,7 +688,7 @@ Reglas:
 4. Puede elegirse a sí mismo o a su compañero.
 5. No puede elegir para otro equipo ni para otro enfrentamiento.
 6. La respuesta al usuario es ephemeral y muestra atacante y defensor.
-7. En el canal público solo aparece: `El equipo NOMBREEQUIPO ha elegido atacante`.
+7. En el canal público solo aparece: `El equipo NOMBREEQUIPO (COMUNIDAD) ha elegido atacante`.
 8. La identidad elegida permanece secreta para el rival.
 9. Puede cambiarse mientras el rival todavía no haya elegido.
 10. Cuando ambos han elegido, las elecciones quedan bloqueadas.
@@ -950,6 +951,10 @@ Columnas mínimas:
 ---
 
 ## 16. Publicaciones y visibilidad
+
+En todos los mensajes, resúmenes y respuestas de comandos de este formato que
+mencionen equipos, el nombre de cada equipo debe ir seguido por el nombre de su
+comunidad entre paréntesis: `NOMBREEQUIPO (COMUNIDAD)`.
 
 ### 16.1. Foro de resultados
 

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -118,6 +118,7 @@ from ComunidadesConstantes import (
 from ComunidadesDiscord import (
     ErrorMaterializacionDiscordComunidades,
     ErrorSeleccionCategoriaComunidades,
+    etiqueta_equipo_comunidades,
     ejecutar_seleccion_atacante_comunidades,
     materializar_partidos_comunidades,
     mencion_usuario_comunidades,
@@ -4593,8 +4594,8 @@ def _mensaje_canal_enfrentamiento_comunidades(torneo, ronda, enfrentamiento) -> 
     return (
         f"{plantilla}\n\n"
         f"## Mesa {int(enfrentamiento.mesa_numero)}: "
-        f"{_texto_discord_seguro(enfrentamiento.equipo_a.nombre)} vs "
-        f"{_texto_discord_seguro(enfrentamiento.equipo_b.nombre)}\n"
+        f"{etiqueta_equipo_comunidades(enfrentamiento.equipo_a)} vs "
+        f"{etiqueta_equipo_comunidades(enfrentamiento.equipo_b)}\n"
         f"Jugadores: {menciones}\n\n"
         "### Selección de atacante\n"
         "Cada equipo dispone de **24 horas** para seleccionar atacante con "
@@ -4603,8 +4604,8 @@ def _mensaje_canal_enfrentamiento_comunidades(torneo, ronda, enfrentamiento) -> 
         "Después se crearán dos partidos: el atacante de cada equipo jugará "
         "contra el defensor rival.\n\n"
         f"**Fecha límite de la ronda:** {ronda.fecha_fin.strftime('%Y-%m-%d %H:%M')}\n"
-        f"**Estado inicial de {_texto_discord_seguro(enfrentamiento.equipo_a.nombre)}:** {estado_a}\n"
-        f"**Estado inicial de {_texto_discord_seguro(enfrentamiento.equipo_b.nombre)}:** {estado_b}\n\n"
+        f"**Estado inicial de {etiqueta_equipo_comunidades(enfrentamiento.equipo_a)}:** {estado_a}\n"
+        f"**Estado inicial de {etiqueta_equipo_comunidades(enfrentamiento.equipo_b)}:** {estado_b}\n\n"
         "### Resolución resumida\n"
         "Se suman los puntos internos de los dos partidos. Si hay empate, se "
         "comparan primero los TD anotados por los atacantes y después la "
@@ -4628,12 +4629,12 @@ def _resumen_ronda_comunidades(torneo, ronda, enfrentamientos, bye_equipo) -> st
         )
         lineas.append(
             f"**Mesa {int(enfrentamiento.mesa_numero)}:** "
-            f"{_texto_discord_seguro(enfrentamiento.equipo_a.nombre)} vs "
-            f"{_texto_discord_seguro(enfrentamiento.equipo_b.nombre)} — {canal}"
+            f"{etiqueta_equipo_comunidades(enfrentamiento.equipo_a)} vs "
+            f"{etiqueta_equipo_comunidades(enfrentamiento.equipo_b)} — {canal}"
         )
     if bye_equipo is not None:
         lineas.extend(
-            ["", f"**BYE:** {_texto_discord_seguro(bye_equipo.nombre)} (sin canal)"]
+            ["", f"**BYE:** {etiqueta_equipo_comunidades(bye_equipo)} (sin canal)"]
         )
     return "\n".join(lineas)
 
@@ -4719,7 +4720,7 @@ def _formatear_consulta_elecciones_comunidades(torneo_id, ronda_numero, filas):
             f"enfrentamiento `{int(enfrentamiento.id)}`**"
         )
         for eleccion in fila.elecciones:
-            equipo = str(eleccion.equipo.nombre).replace("@", "@\u200b")
+            equipo = etiqueta_equipo_comunidades(eleccion.equipo)
             if eleccion.pendiente:
                 lineas.append(f"- **{equipo}** — ⏳ PENDIENTE")
                 continue
@@ -5493,13 +5494,13 @@ def _formatear_ronda_publica(resultado: dict) -> str:
         eb = _estado_con_emojis_comunidades(fila["estado_b"]["estado_temporal"], fila["estado_b"]["es_zombie"])
         canal = f"<#{int(fila['canal_general_discord_id'])}>" if fila["canal_general_discord_id"] else "⚠️ sin canal"
         lineas += [f"### Mesa {fila['mesa']} · {_estado_publico_comunidades(fila['estado'])}",
-                   f"{ea} **{_texto_discord_seguro(fila['equipo_a'].nombre)}** vs {eb} **{_texto_discord_seguro(fila['equipo_b'].nombre)}**",
+                   f"{ea} **{etiqueta_equipo_comunidades(fila['equipo_a'])}** vs {eb} **{etiqueta_equipo_comunidades(fila['equipo_b'])}**",
                    f"📺 Canal general: {canal}"]
         if fila["estado"] in (ENFRENTAMIENTO_CERRADO, ENFRENTAMIENTO_ADMINISTRADO):
             lineas.append(f"🏁 Internos **{_decimal_publico_comunidades(fila['puntos_internos_a'])}-{_decimal_publico_comunidades(fila['puntos_internos_b'])}** · Clasificación **{_decimal_publico_comunidades(fila['puntos_clasificacion_a'])}-{_decimal_publico_comunidades(fila['puntos_clasificacion_b'])}**")
         lineas.append("")
     if resultado["bye_equipo"] is not None:
-        lineas.append(f"🛌 **BYE:** {_texto_discord_seguro(resultado['bye_equipo'].nombre)}")
+        lineas.append(f"🛌 **BYE:** {etiqueta_equipo_comunidades(resultado['bye_equipo'])}")
     lineas.append("🔐 Las elecciones de atacante no se muestran en esta consulta pública.")
     return "\n".join(lineas)
 
@@ -5512,7 +5513,7 @@ def _formatear_equipos_publico(resultado: dict) -> str:
     for f in resultado["filas"]:
         estado = _estado_con_emojis_comunidades(f["estado_temporal"], f["es_zombie"])
         h2h = "-" if f["h2h_valor"] is None else _decimal_publico_comunidades(f["h2h_valor"])
-        lineas += [f"**{f['posicion']}.** {estado} **{_texto_discord_seguro(f['nombre'])}** · 🏘️ {_texto_discord_seguro(f['comunidad_nombre'])}",
+        lineas += [f"**{f['posicion']}.** {estado} **{_texto_discord_seguro(f['nombre'])} ({_texto_discord_seguro(f['comunidad_nombre'])})**",
                    f"🏆 PTS **{_decimal_publico_comunidades(f['puntos'])}** · PJ {f['pj']} ({f['pg']}/{f['pe']}/{f['pp']}) · 🛌 {f['cantidad_byes']} · BH {_decimal_publico_comunidades(f['buchholz_cut'])} · H2H {h2h} · TD {f['td_favor']}-{f['td_contra']} ({f['diferencia_td']:+d})"]
     if resultado["fuente"] == "SNAPSHOT":
         lineas.append("\nℹ️ Los puntos son históricos; los emojis muestran el estado actual.")
@@ -5534,7 +5535,7 @@ def _formatear_equipo_publico(resultado: dict) -> str:
     equipo, fila = resultado["equipo"], resultado["clasificacion"]
     estado = _estado_con_emojis_comunidades(equipo.estado_temporal, equipo.es_zombie)
     lineas = _cabecera_publica_comunidades(resultado["torneo"], "Consulta de equipo")
-    lineas += [f"Equipo: {estado} **{_texto_discord_seguro(equipo.nombre)}**", f"🏘️ Comunidad: **{_texto_discord_seguro(equipo.comunidad.nombre)}**", "", "### Integrantes"]
+    lineas += [f"Equipo: {estado} **{etiqueta_equipo_comunidades(equipo)}**", "", "### Integrantes"]
     for m in resultado["miembros"]:
         lineas.append(f"{m.posicion}. {_mencion_publica_comunidades(m.usuario)} · 🧬 **{_texto_discord_seguro(m.raza)}**")
     if fila:
@@ -5549,7 +5550,7 @@ def _formatear_estados_publico(resultado: dict) -> str:
         lineas.append("ℹ️ Todavía no hay equipos inscritos.")
     for dato in resultado["filas"]:
         e, f = dato["equipo"], dato["clasificacion"]
-        lineas.append(f"**{f['posicion']}.** {_estado_con_emojis_comunidades(e.estado_temporal, e.es_zombie)} **{_texto_discord_seguro(e.nombre)}** · 🏘️ {_texto_discord_seguro(e.comunidad.nombre)}")
+        lineas.append(f"**{f['posicion']}.** {_estado_con_emojis_comunidades(e.estado_temporal, e.es_zombie)} **{etiqueta_equipo_comunidades(e)}**")
     lineas.append("\nLeyenda: ⚪ neutro · 🏹 cazador · 🩸 herido · 🧟 zombie · 🏹🧟 cazador Z.")
     return "\n".join(lineas)
 
@@ -5561,7 +5562,12 @@ def _formatear_canales_publico(resultado: dict) -> str:
         lineas.append("ℹ️ No hay enfrentamientos ni canales en esta ronda.")
     for f in resultado["filas"]:
         general = f"<#{int(f['canal_general_discord_id'])}>" if f["canal_general_discord_id"] else "⚠️ sin canal"
-        lineas += [f"### Mesa {f['mesa']} · {_estado_publico_comunidades(f['estado'])}", f"**{_texto_discord_seguro(f['equipo_a'].nombre)}** vs **{_texto_discord_seguro(f['equipo_b'].nombre)}**", f"📺 General: {general}"]
+        lineas += [
+            f"### Mesa {f['mesa']} · {_estado_publico_comunidades(f['estado'])}",
+            f"**{etiqueta_equipo_comunidades(f['equipo_a'])}** vs "
+            f"**{etiqueta_equipo_comunidades(f['equipo_b'])}**",
+            f"📺 General: {general}",
+        ]
         if not f["partidos"]:
             lineas.append("🔐 Individuales: aún no materializados.")
         for p in f["partidos"]:
@@ -5611,6 +5617,8 @@ async def comunidades_estado_canales(interaction: discord.Interaction, torneo_id
 def _texto_partido_comunidades(partido) -> str:
     return (
         f"🏟️ **Resultado individual · Partido {int(partido.indice)}**\n"
+        f"{etiqueta_equipo_comunidades(partido.equipo_local)} vs "
+        f"{etiqueta_equipo_comunidades(partido.equipo_visitante)}\n"
         f"{_texto_discord_seguro(_nombre_usuario_comunidades(partido.usuario_local))} "
         f"**{int(partido.td_local)}-{int(partido.td_visitante)}** "
         f"{_texto_discord_seguro(_nombre_usuario_comunidades(partido.usuario_visitante))}\n"
@@ -5654,7 +5662,7 @@ def _textos_transiciones_comunidades(session, enfrentamiento):
             transicion.estado_temporal_posterior,
             bool(transicion.es_zombie_posterior),
         )
-        nombre = _texto_discord_seguro(equipo.nombre)
+        nombre = etiqueta_equipo_comunidades(equipo)
         lineas.append(
             f"- **{nombre}**: {anterior} → {posterior} (`{transicion.motivo}`)"
         )
@@ -5680,8 +5688,8 @@ def _textos_transiciones_comunidades(session, enfrentamiento):
 
 
 def _texto_global_comunidades(session, enfrentamiento, *, para_hub=False) -> str:
-    equipo_a = _texto_discord_seguro(enfrentamiento.equipo_a.nombre)
-    equipo_b = _texto_discord_seguro(enfrentamiento.equipo_b.nombre)
+    equipo_a = etiqueta_equipo_comunidades(enfrentamiento.equipo_a)
+    equipo_b = etiqueta_equipo_comunidades(enfrentamiento.equipo_b)
     if bool(enfrentamiento.es_doble_forfait):
         desenlace = "doble forfait global"
     elif enfrentamiento.ganador_equipo_id is None:
@@ -5714,8 +5722,8 @@ async def publicar_transferencia_comunidades_en_hub(ctx, transferencia) -> bool:
     contenido = (
         f"{emoji} **Transferencia de estado**\n"
         f"Comunidad: **{_texto_discord_seguro(transferencia.comunidad.nombre)}** · "
-        f"Origen: **{_texto_discord_seguro(transferencia.equipo_origen.nombre)}** · "
-        f"Destino: **{_texto_discord_seguro(transferencia.equipo_destino.nombre)}** · "
+        f"Origen: **{etiqueta_equipo_comunidades(transferencia.equipo_origen)}** · "
+        f"Destino: **{etiqueta_equipo_comunidades(transferencia.equipo_destino)}** · "
         f"Tipo: **{transferencia.tipo}**"
     )
     return await _enviar_unico_comunidades(canal, marca, contenido)
@@ -6094,8 +6102,8 @@ def _datos_resultado_admin_comunidades(tipo, td_local, td_visitante):
 def _mensaje_resultado_admin_comunidades(resultado, tipo):
     partido = resultado.partido
     enfrentamiento = resultado.enfrentamiento
-    local = _texto_discord_seguro(partido.equipo_local.nombre)
-    visitante = _texto_discord_seguro(partido.equipo_visitante.nombre)
+    local = etiqueta_equipo_comunidades(partido.equipo_local)
+    visitante = etiqueta_equipo_comunidades(partido.equipo_visitante)
     mensaje = (
         f"🛠️ **Partido {int(partido.indice)} administrado**\n"
         f"{local} **{int(partido.td_local)}-{int(partido.td_visitante)}** {visitante}\n"
@@ -6107,8 +6115,8 @@ def _mensaje_resultado_admin_comunidades(resultado, tipo):
         return mensaje + "\nEl enfrentamiento continúa pendiente del otro partido."
 
     global_ = resultado.resultado_global
-    equipo_a = _texto_discord_seguro(enfrentamiento.equipo_a.nombre)
-    equipo_b = _texto_discord_seguro(enfrentamiento.equipo_b.nombre)
+    equipo_a = etiqueta_equipo_comunidades(enfrentamiento.equipo_a)
+    equipo_b = etiqueta_equipo_comunidades(enfrentamiento.equipo_b)
     if bool(enfrentamiento.es_doble_forfait):
         desenlace = "doble forfait global"
     elif global_.ganador is None:
@@ -9378,4 +9386,3 @@ async def func_proximos_partidos_suizo_emparejamiento(bot, usuario, torneo_id, c
         
 # Ejecutar el bot con el token correspondiente
 bot.run(discord_bot_token)
-

--- a/tests/test_comunidades_materializacion_partidos.py
+++ b/tests/test_comunidades_materializacion_partidos.py
@@ -238,6 +238,7 @@ def test_materializa_dos_canales_con_permisos_mensajes_y_estado():
         }
         assert "**Atacante:** <@102>" in guild.creaciones[0]["canal"].mensajes[0]
         assert "**Defensor:** <@202>" in guild.creaciones[0]["canal"].mensajes[0]
+        assert "**Equipos:** Equipo A (A) vs Equipo B (B)" in guild.creaciones[0]["canal"].mensajes[0]
         assert "**Fecha límite:** 2026-07-08 22:00" in guild.creaciones[0]["canal"].mensajes[0]
         enfrentamiento = session.get(ComunidadesEnfrentamiento, enfrentamiento_id)
         assert enfrentamiento.estado == "PARTIDOS_CREADOS"

--- a/tests/test_comunidades_seleccion_atacante_command.py
+++ b/tests/test_comunidades_seleccion_atacante_command.py
@@ -65,8 +65,12 @@ class InteraccionDoble:
 
 
 def resultado_eleccion(*, completar=False):
+    equipo = SimpleNamespace(
+        nombre="Equipo @A",
+        comunidad=SimpleNamespace(nombre="Comunidad @Uno"),
+    )
     return SimpleNamespace(
-        eleccion=SimpleNamespace(enfrentamiento_id=77),
+        eleccion=SimpleNamespace(enfrentamiento_id=77, equipo=equipo),
         atacante=SimpleNamespace(id_discord=101, nombre_discord="Uno"),
         defensor=SimpleNamespace(id_discord=102, nombre_discord="Dos"),
         equipo_nombre="Equipo @A",
@@ -110,10 +114,12 @@ def test_primera_eleccion_responde_privado_publica_sin_identidades_y_no_material
 
     privado, ephemeral = interaccion.response.mensajes[0]
     assert ephemeral is True
-    assert "**Equipo:** Equipo @\u200bA" in privado
+    assert "**Equipo:** Equipo @\u200bA (Comunidad @\u200bUno)" in privado
     assert "**Atacante:** <@101>" in privado
     assert "**Defensor:** <@102>" in privado
-    assert interaccion.channel.mensajes == ["El equipo Equipo @\u200bA ha elegido atacante"]
+    assert interaccion.channel.mensajes == [
+        "El equipo Equipo @\u200bA (Comunidad @\u200bUno) ha elegido atacante"
+    ]
     assert llamadas == [{
         "enfrentamiento_id": 77,
         "actor_discord_id": 101,
@@ -152,7 +158,7 @@ def test_segunda_eleccion_anuncia_materializa_una_vez_y_confirma_canales():
     )
 
     assert interaccion.channel.mensajes == [
-        "El equipo Equipo @\u200bA ha elegido atacante",
+        "El equipo Equipo @\u200bA (Comunidad @\u200bUno) ha elegido atacante",
         "Se van a crear los encuentros",
         "Encuentros creados: <#901> y <#902>",
     ]
@@ -228,7 +234,7 @@ def test_fallo_materializacion_conserva_eleccion_notifica_y_cierra_sesion():
     assert "secreto interno" in avisos[0]
     assert "secreto interno" not in interaccion.followup.mensajes[0][0]
     assert interaccion.channel.mensajes == [
-        "El equipo Equipo @\u200bA ha elegido atacante",
+        "El equipo Equipo @\u200bA (Comunidad @\u200bUno) ha elegido atacante",
         "Se van a crear los encuentros",
     ]
 


### PR DESCRIPTION
### Motivation

- La especificación del torneo de comunidades exige que, cuando se mencionen equipos en mensajes, resúmenes o respuestas de comandos, el nombre del equipo muestre también la comunidad a la que pertenece; había implementaciones que no incluían esa información en varios puntos de publicación.

### Description

- Se añadió la función `etiqueta_equipo_comunidades(equipo)` en `ComunidadesDiscord.py` para formatear de forma segura `Equipo (Comunidad)` y evitar menciones accidentales mediante `texto_discord_seguro_comunidades`.
- Se aplicó ese formato a los mensajes y plantillas relevantes: canales generales e individuales, mensajes de materialización de partidos, avisos públicos/privados de selección de atacante, resúmenes de ronda, consultas públicas (ronda, equipos, comunidades, estados y canales), resultados individuales/globales, transiciones, transferencias y mensajes administrativos en `LombardBot.py` y `ComunidadesDiscord.py`.
- Se actualizó la documentación fuente `DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES.md` para dejar explícito el requisito `NOMBREEQUIPO (COMUNIDAD)` en mensajes y resúmenes cuando proceda.
- Se ajustaron y ampliaron pruebas unitarias para verificar el nuevo formato y el escape de menciones en `tests/test_comunidades_materializacion_partidos.py` y `tests/test_comunidades_seleccion_atacante_command.py`.

### Testing

- Se compiló estáticamente `ComunidadesDiscord.py` y `LombardBot.py` con `python -m py_compile` y no hubo errores.
- Se ejecutaron pruebas focalizadas con `PYTHONPATH=. pytest -q tests/test_comunidades_materializacion_partidos.py tests/test_comunidades_seleccion_atacante_command.py tests/test_comunidades_administracion_elecciones_command.py tests/test_comunidades_resultados.py`, obteniendo 35 pruebas superadas (estas ejercitan las rutas modificadas).
- Se lanzó la suite completa con `PYTHONPATH=. pytest -q`, con resultado global de 460 pruebas superadas, 1 omitida y 5 fallos de integración preexistentes no relacionados con estos cambios (referidos a estados/materialización y detalles internos del core); los fallos no son introducidos por esta modificación.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d285956bc832a9d658d4c454dfdd1)