### PR TITLE
Format community labels and extract channel message builder for comunidades

### DIFF
--- a/ComunidadesDiscord.py
+++ b/ComunidadesDiscord.py
@@ -597,8 +597,8 @@ def texto_discord_seguro_comunidades(valor: object) -> str:
 def etiqueta_equipo_comunidades(equipo: Any) -> str:
     """Presenta siempre un equipo junto a la comunidad a la que pertenece."""
     return (
-        f"{texto_discord_seguro_comunidades(equipo.nombre)} "
-        f"({texto_discord_seguro_comunidades(equipo.comunidad.nombre)})"
+        f"[{texto_discord_seguro_comunidades(equipo.comunidad.nombre)}] "
+        f"{texto_discord_seguro_comunidades(equipo.nombre)}"
     )
 
 
@@ -610,6 +610,87 @@ def mencion_usuario_comunidades(usuario: Any) -> str:
             getattr(usuario, "nombre_discord", "Jugador")
         )
     return f"<@{int(discord_id)}>"
+
+
+def mensajes_canal_enfrentamiento_comunidades(
+    torneo: Any, ronda: Any, enfrentamiento: Any
+) -> Tuple[str, Optional[str]]:
+    """Construye el mensaje general y, si existe, el aviso configurable posterior."""
+    fotos = {int(foto.equipo_id): foto for foto in enfrentamiento.fotografias_estado}
+
+    def estado_visible(fotografia: Any) -> str:
+        partes = []
+        if bool(fotografia.es_zombie):
+            partes.append("ZOMBIE")
+        estado_temporal = str(fotografia.estado_temporal or "NEUTRO")
+        if estado_temporal != "NEUTRO" or not partes:
+            partes.append(estado_temporal.replace("_", " "))
+        return " + ".join(partes)
+
+    equipos = (enfrentamiento.equipo_a, enfrentamiento.equipo_b)
+    lineas_jugadores = []
+    preferencias = []
+    for equipo in equipos:
+        if lineas_jugadores:
+            lineas_jugadores.append("")
+        lineas_jugadores.append(f"**{etiqueta_equipo_comunidades(equipo)}**")
+        for miembro in sorted(equipo.miembros, key=lambda item: int(item.posicion)):
+            usuario = miembro.usuario
+            nombre_bloodbowl = texto_discord_seguro_comunidades(
+                getattr(usuario, "nombre_bloodbowl", None)
+                or "Nombre de Blood Bowl no indicado"
+            )
+            raza = texto_discord_seguro_comunidades(miembro.raza)
+            lineas_jugadores.append(
+                f"- {mencion_usuario_comunidades(usuario)} — "
+                f"**{nombre_bloodbowl}** — {raza}"
+            )
+            preferencia = getattr(
+                getattr(usuario, "preferencias_fecha", None), "preferencia", ""
+            )
+            if preferencia and str(preferencia).strip():
+                preferencias.append(
+                    f"- {mencion_usuario_comunidades(usuario)} suele poder jugar "
+                    f"{texto_discord_seguro_comunidades(str(preferencia).strip())}"
+                )
+
+    estado_a = estado_visible(fotos[int(enfrentamiento.equipo_a_id)])
+    estado_b = estado_visible(fotos[int(enfrentamiento.equipo_b_id)])
+    seccion_preferencias = ""
+    if preferencias:
+        seccion_preferencias = "\n\n### Preferencias horarias\n" + "\n".join(
+            preferencias
+        )
+
+    jugadores = "\n".join(lineas_jugadores)
+    mensaje_general = (
+        f"## Mesa {int(enfrentamiento.mesa_numero)}: "
+        f"{etiqueta_equipo_comunidades(enfrentamiento.equipo_a)} vs "
+        f"{etiqueta_equipo_comunidades(enfrentamiento.equipo_b)}\n\n"
+        "### Jugadores\n"
+        f"{jugadores}"
+        f"{seccion_preferencias}\n\n"
+        "### Selección de atacante\n"
+        "Cada equipo dispone de **24 horas** para seleccionar atacante con "
+        "`/comunidades_seleccion_atacante`. La elección es secreta hasta que "
+        "ambos equipos hayan elegido.\n"
+        "Después se crearán dos partidos: el atacante de cada equipo jugará "
+        "contra el defensor rival.\n\n"
+        f"**Fecha límite de la ronda:** {ronda.fecha_fin.strftime('%Y-%m-%d %H:%M')}\n"
+        f"**Estado inicial de {etiqueta_equipo_comunidades(enfrentamiento.equipo_a)}:** {estado_a}\n"
+        f"**Estado inicial de {etiqueta_equipo_comunidades(enfrentamiento.equipo_b)}:** {estado_b}\n\n"
+        "### Resolución resumida\n"
+        "Se suman los puntos internos de los dos partidos. Si hay empate, se "
+        "comparan primero los TD anotados por los atacantes y después la "
+        "diferencia global de TD; si persiste, el enfrentamiento termina empatado."
+    )
+    plantilla = (
+        torneo.plantilla_mensaje_ronda1
+        if int(ronda.numero) == 1
+        else torneo.plantilla_mensaje_rondas_siguientes
+    )
+    mensaje_adicional = str(plantilla).strip() if plantilla is not None else ""
+    return mensaje_general, mensaje_adicional or None
 
 
 def mensaje_eleccion_ephemeral_comunidades(resultado: Any) -> str:

--- a/DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES.md
+++ b/DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES.md
@@ -338,7 +338,7 @@ Argumentos:
 
 El torneo se crea en estado `CREADO`. La creación no exige informar todavía el ID de competición de Blood Bowl.
 
-Como los dos campos de plantilla son obligatorios, el sistema los inicializa con valores técnicos pendientes de configuración. El mensaje de confirmación recuerda que, antes de generar la ronda 1, deben rellenarse directamente en base de datos `plantilla_mensaje_ronda1` y `plantilla_mensaje_rondas_siguientes`. En la v1 no existe un comando para editar estas plantillas.
+Los dos campos de plantilla son `NOT NULL`, por lo que el sistema los inicializa con valores técnicos pendientes de configuración. Antes de generar la ronda 1 deben revisarse directamente en base de datos `plantilla_mensaje_ronda1` y `plantilla_mensaje_rondas_siguientes`. Una cadena vacía desactiva el mensaje adicional de la ronda correspondiente. En la v1 no existe un comando para editar estas plantillas.
 
 ### 6.2. Configurar competición de Blood Bowl
 
@@ -638,16 +638,20 @@ Si tiene 40 canales, se prueba la siguiente categoría según orden de alta. Si 
 
 ### 9.2. Contenido del canal general
 
-Los mensajes de los canales son configurables por torneo mediante dos campos de texto obligatorios en la tabla del torneo, con los nombres `mensajeInicial` y `mensajesSubsiguientes`:
+Los mensajes adicionales de los canales son configurables por torneo mediante dos campos de texto `NOT NULL` en la tabla del torneo:
 
-- `mensajeInicial` se utiliza en los canales creados para la ronda 1;
-- `mensajesSubsiguientes` se utiliza en los canales creados para las rondas 2 y siguientes.
+- `plantilla_mensaje_ronda1` se utiliza en los canales creados para la ronda 1;
+- `plantilla_mensaje_rondas_siguientes` se utiliza en los canales creados para las rondas 2 y siguientes.
 
-En la v1 no habrá comandos para editar estos campos: su alta y modificación se realizarán directamente en base de datos. El texto exacto no queda hardcodeado en el bot. Si las plantillas contienen marcadores, la implementación solo podrá sustituir los marcadores admitidos expresamente por el contrato técnico correspondiente.
+En la v1 no habrá comandos para editar estos campos: su alta y modificación se realizarán directamente en base de datos. Una cadena vacía indica que no debe publicarse ningún mensaje adicional para esas rondas. El texto exacto no queda hardcodeado en el bot. Si las plantillas contienen marcadores, la implementación solo podrá sustituir los marcadores admitidos expresamente por el contrato técnico correspondiente.
 
-El mensaje resultante del canal general debe explicar:
+Al crear el canal se publica primero un mensaje automático estructurado. Después se publica, como segundo mensaje independiente, la plantilla correspondiente a la ronda, salvo que esté vacía.
 
-- los nombres de ambos equipos seguidos, entre paréntesis, por el nombre de su comunidad;
+El mensaje automático del canal general debe explicar:
+
+- los nombres de ambos equipos precedidos por el nombre de su comunidad con el formato `[Nombre comunidad] Nombre equipo`;
+- los cuatro jugadores agrupados por equipo, indicando para cada uno su mención de Discord, nombre de Blood Bowl y la raza registrada en `comunidades_miembro` para este torneo;
+- después de los jugadores, las preferencias horarias guardadas mediante `/preferenciahorario`, únicamente para quienes hayan informado una;
 - que cada equipo dispone de 24 horas para seleccionar atacante;
 - cómo ejecutar `/comunidades_seleccion_atacante`;
 - que la elección es secreta;
@@ -658,7 +662,7 @@ El mensaje resultante del canal general debe explicar:
 
 ### 9.3. Canales individuales
 
-Cuando ambos equipos hayan elegido, se crean dos canales adicionales con permisos, fechas y publicación de resultados equivalentes al suizo actual, pero con mensajes específicos de este formato que identifiquen atacante y defensor. Siempre que el mensaje mencione un equipo, debe añadir su comunidad entre paréntesis.
+Cuando ambos equipos hayan elegido, se crean dos canales adicionales con permisos, fechas y publicación de resultados equivalentes al suizo actual, pero con mensajes específicos de este formato que identifiquen atacante y defensor. Siempre que el mensaje mencione un equipo, debe anteponer su comunidad con el formato `[Nombre comunidad] Nombre equipo`.
 
 Se distribuyen entre las categorías de partidos configuradas, en orden de alta y con límite de 40 canales por categoría, contando todos los canales existentes.
 
@@ -968,8 +972,8 @@ Columnas mínimas:
 ## 16. Publicaciones y visibilidad
 
 En todos los mensajes, resúmenes y respuestas de comandos de este formato que
-mencionen equipos, el nombre de cada equipo debe ir seguido por el nombre de su
-comunidad entre paréntesis: `NOMBREEQUIPO (COMUNIDAD)`.
+mencionen equipos, el nombre de la comunidad debe aparecer delante del nombre
+del equipo y entre corchetes: `[COMUNIDAD] NOMBREEQUIPO`.
 
 ### 16.1. Foro de resultados
 

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -124,6 +124,7 @@ from ComunidadesDiscord import (
     ejecutar_seleccion_atacante_comunidades,
     materializar_partidos_comunidades,
     mencion_usuario_comunidades,
+    mensajes_canal_enfrentamiento_comunidades,
     parsear_decimal,
     parsear_fecha_limite,
     planificar_categorias_comunidades,
@@ -4333,8 +4334,9 @@ async def comunidades_crear(
         f"**{torneo.fecha_fin_ronda1.strftime('%Y-%m-%d %H:%M')}** | "
         f"Días por ronda: **{torneo.dias_por_ronda}**\n"
         f"Canal hub: **{torneo.canal_hub_id}**\n"
-        "⚠️ Antes de generar la ronda 1, rellena directamente en BD "
-        "`plantilla_mensaje_ronda1` y `plantilla_mensaje_rondas_siguientes`. "
+        "⚠️ Antes de generar la ronda 1, revisa directamente en BD "
+        "`plantilla_mensaje_ronda1` y `plantilla_mensaje_rondas_siguientes`; "
+        "déjalas vacías si no quieres publicar el mensaje adicional. "
         "En esta versión no existe un comando para editarlas."
     )
 
@@ -4562,57 +4564,6 @@ def _normalizar_nombre_canal_comunidades(valor: object) -> str:
     texto = unicodedata.normalize("NFKD", str(valor)).encode("ascii", "ignore").decode()
     texto = re.sub(r"[^a-zA-Z0-9]+", "-", texto.lower()).strip("-")
     return texto or "equipo"
-
-
-def _estado_visible_comunidades(fotografia) -> str:
-    partes = []
-    if bool(fotografia.es_zombie):
-        partes.append("ZOMBIE")
-    estado_temporal = str(fotografia.estado_temporal or "NEUTRO")
-    if estado_temporal != "NEUTRO" or not partes:
-        partes.append(estado_temporal.replace("_", " "))
-    return " + ".join(partes)
-
-
-def _mensaje_canal_enfrentamiento_comunidades(torneo, ronda, enfrentamiento) -> str:
-    plantilla = (
-        torneo.plantilla_mensaje_ronda1
-        if int(ronda.numero) == 1
-        else torneo.plantilla_mensaje_rondas_siguientes
-    )
-    fotos = {int(foto.equipo_id): foto for foto in enfrentamiento.fotografias_estado}
-    estado_a = _estado_visible_comunidades(fotos[int(enfrentamiento.equipo_a_id)])
-    estado_b = _estado_visible_comunidades(fotos[int(enfrentamiento.equipo_b_id)])
-    miembros = [
-        miembro
-        for equipo in (enfrentamiento.equipo_a, enfrentamiento.equipo_b)
-        for miembro in sorted(equipo.miembros, key=lambda item: int(item.posicion))
-    ]
-    menciones = " ".join(
-        f"<@{int(miembro.usuario.id_discord)}>"
-        for miembro in miembros
-        if miembro.usuario is not None and miembro.usuario.id_discord is not None
-    )
-    return (
-        f"{plantilla}\n\n"
-        f"## Mesa {int(enfrentamiento.mesa_numero)}: "
-        f"{etiqueta_equipo_comunidades(enfrentamiento.equipo_a)} vs "
-        f"{etiqueta_equipo_comunidades(enfrentamiento.equipo_b)}\n"
-        f"Jugadores: {menciones}\n\n"
-        "### Selección de atacante\n"
-        "Cada equipo dispone de **24 horas** para seleccionar atacante con "
-        "`/comunidades_seleccion_atacante`. La elección es secreta hasta que "
-        "ambos equipos hayan elegido.\n"
-        "Después se crearán dos partidos: el atacante de cada equipo jugará "
-        "contra el defensor rival.\n\n"
-        f"**Fecha límite de la ronda:** {ronda.fecha_fin.strftime('%Y-%m-%d %H:%M')}\n"
-        f"**Estado inicial de {etiqueta_equipo_comunidades(enfrentamiento.equipo_a)}:** {estado_a}\n"
-        f"**Estado inicial de {etiqueta_equipo_comunidades(enfrentamiento.equipo_b)}:** {estado_b}\n\n"
-        "### Resolución resumida\n"
-        "Se suman los puntos internos de los dos partidos. Si hay empate, se "
-        "comparan primero los TD anotados por los atacantes y después la "
-        "diferencia global de TD; si persiste, el enfrentamiento termina empatado."
-    )
 
 
 def _resumen_ronda_comunidades(torneo, ronda, enfrentamientos, bye_equipo) -> str:
@@ -6354,9 +6305,16 @@ async def _crear_canales_ronda_comunidades(ctx, session, resultado, categorias):
             enfrentamiento.canal_general_discord_id = int(canal.id)
             session.commit()
             try:
-                await UtilesDiscord.enviar_mensaje_largo(
-                    canal, _mensaje_canal_enfrentamiento_comunidades(torneo, ronda, enfrentamiento)
+                mensaje_general, mensaje_adicional = (
+                    mensajes_canal_enfrentamiento_comunidades(
+                        torneo, ronda, enfrentamiento
+                    )
                 )
+                await UtilesDiscord.enviar_mensaje_largo(
+                    canal, mensaje_general
+                )
+                if mensaje_adicional:
+                    await UtilesDiscord.enviar_mensaje_largo(canal, mensaje_adicional)
             except Exception as exc:
                 fallos.append(
                     f"Mesa {int(enfrentamiento.mesa_numero)} / enfrentamiento "

--- a/tests/test_comunidades_materializacion_partidos.py
+++ b/tests/test_comunidades_materializacion_partidos.py
@@ -238,7 +238,7 @@ def test_materializa_dos_canales_con_permisos_mensajes_y_estado():
         }
         assert "**Atacante:** <@102>" in guild.creaciones[0]["canal"].mensajes[0]
         assert "**Defensor:** <@202>" in guild.creaciones[0]["canal"].mensajes[0]
-        assert "**Equipos:** Equipo A (A) vs Equipo B (B)" in guild.creaciones[0]["canal"].mensajes[0]
+        assert "**Equipos:** [A] Equipo A vs [B] Equipo B" in guild.creaciones[0]["canal"].mensajes[0]
         assert "**Fecha límite:** 2026-07-08 22:00" in guild.creaciones[0]["canal"].mensajes[0]
         enfrentamiento = session.get(ComunidadesEnfrentamiento, enfrentamiento_id)
         assert enfrentamiento.estado == "PARTIDOS_CREADOS"

--- a/tests/test_comunidades_mensajes.py
+++ b/tests/test_comunidades_mensajes.py
@@ -1,0 +1,122 @@
+from datetime import datetime
+from types import SimpleNamespace
+
+from ComunidadesDiscord import (
+    etiqueta_equipo_comunidades,
+    mensajes_canal_enfrentamiento_comunidades,
+)
+
+
+def _usuario(discord_id, nombre_bloodbowl, preferencia=None, raza_usuario="Incorrecta"):
+    preferencias_fecha = (
+        SimpleNamespace(preferencia=preferencia) if preferencia is not None else None
+    )
+    return SimpleNamespace(
+        id_discord=discord_id,
+        nombre_bloodbowl=nombre_bloodbowl,
+        nombre_discord=f"Discord {discord_id}",
+        preferencias_fecha=preferencias_fecha,
+        raza=raza_usuario,
+    )
+
+
+def _equipo(equipo_id, nombre, comunidad, miembros):
+    return SimpleNamespace(
+        id=equipo_id,
+        nombre=nombre,
+        comunidad=SimpleNamespace(nombre=comunidad),
+        miembros=miembros,
+    )
+
+
+def _enfrentamiento():
+    equipo_a = _equipo(
+        1,
+        "Valientes",
+        "Butter",
+        [
+            SimpleNamespace(
+                posicion=2,
+                raza="Skaven",
+                usuario=_usuario(102, "RataBB"),
+            ),
+            SimpleNamespace(
+                posicion=1,
+                raza="Orcos",
+                usuario=_usuario(101, "OrcoBB", "laborables desde las 20:00"),
+            ),
+        ],
+    )
+    equipo_b = _equipo(
+        2,
+        "Nocturnos",
+        "Hispana",
+        [
+            SimpleNamespace(
+                posicion=1,
+                raza="Humanos",
+                usuario=_usuario(201, "HumanoBB", "fines de semana"),
+            ),
+            SimpleNamespace(
+                posicion=2,
+                raza="Enanos",
+                usuario=_usuario(202, "EnanoBB", "   "),
+            ),
+        ],
+    )
+    return SimpleNamespace(
+        mesa_numero=3,
+        equipo_a=equipo_a,
+        equipo_b=equipo_b,
+        equipo_a_id=1,
+        equipo_b_id=2,
+        fotografias_estado=[
+            SimpleNamespace(equipo_id=1, es_zombie=False, estado_temporal="NEUTRO"),
+            SimpleNamespace(equipo_id=2, es_zombie=True, estado_temporal="HERIDO"),
+        ],
+    )
+
+
+def test_etiqueta_equipo_antepone_la_comunidad_entre_corchetes():
+    equipo = _equipo(1, "Equipo @A", "Comunidad @B", [])
+
+    assert etiqueta_equipo_comunidades(equipo) == (
+        "[Comunidad @\u200bB] Equipo @\u200bA"
+    )
+
+
+def test_mensaje_general_muestra_datos_del_torneo_y_preferencias_despues_de_jugadores():
+    torneo = SimpleNamespace(
+        plantilla_mensaje_ronda1="Aviso de primera ronda",
+        plantilla_mensaje_rondas_siguientes="Aviso posterior",
+    )
+    ronda = SimpleNamespace(numero=1, fecha_fin=datetime(2026, 7, 8, 22, 0))
+
+    general, adicional = mensajes_canal_enfrentamiento_comunidades(
+        torneo, ronda, _enfrentamiento()
+    )
+
+    assert "## Mesa 3: [Butter] Valientes vs [Hispana] Nocturnos" in general
+    assert "- <@101> — **OrcoBB** — Orcos" in general
+    assert "- <@102> — **RataBB** — Skaven" in general
+    assert "Incorrecta" not in general
+    assert general.index("<@101> — **OrcoBB**") < general.index("### Preferencias horarias")
+    assert "<@101> suele poder jugar laborables desde las 20:00" in general
+    assert "<@201> suele poder jugar fines de semana" in general
+    assert "<@202> suele poder jugar" not in general
+    assert adicional == "Aviso de primera ronda"
+
+
+def test_plantilla_vacia_no_genera_mensaje_adicional():
+    torneo = SimpleNamespace(
+        plantilla_mensaje_ronda1="Aviso inicial",
+        plantilla_mensaje_rondas_siguientes="   ",
+    )
+    ronda = SimpleNamespace(numero=2, fecha_fin=datetime(2026, 7, 15, 22, 0))
+
+    general, adicional = mensajes_canal_enfrentamiento_comunidades(
+        torneo, ronda, _enfrentamiento()
+    )
+
+    assert general.startswith("## Mesa 3:")
+    assert adicional is None

--- a/tests/test_comunidades_seleccion_atacante_command.py
+++ b/tests/test_comunidades_seleccion_atacante_command.py
@@ -114,11 +114,11 @@ def test_primera_eleccion_responde_privado_publica_sin_identidades_y_no_material
 
     privado, ephemeral = interaccion.response.mensajes[0]
     assert ephemeral is True
-    assert "**Equipo:** Equipo @\u200bA (Comunidad @\u200bUno)" in privado
+    assert "**Equipo:** [Comunidad @\u200bUno] Equipo @\u200bA" in privado
     assert "**Atacante:** <@101>" in privado
     assert "**Defensor:** <@102>" in privado
     assert interaccion.channel.mensajes == [
-        "El equipo Equipo @\u200bA (Comunidad @\u200bUno) ha elegido atacante"
+        "El equipo [Comunidad @\u200bUno] Equipo @\u200bA ha elegido atacante"
     ]
     assert llamadas == [{
         "enfrentamiento_id": 77,
@@ -158,7 +158,7 @@ def test_segunda_eleccion_anuncia_materializa_una_vez_y_confirma_canales():
     )
 
     assert interaccion.channel.mensajes == [
-        "El equipo Equipo @\u200bA (Comunidad @\u200bUno) ha elegido atacante",
+        "El equipo [Comunidad @\u200bUno] Equipo @\u200bA ha elegido atacante",
         "Se van a crear los encuentros",
         "Encuentros creados: <#901> y <#902>",
     ]
@@ -234,7 +234,7 @@ def test_fallo_materializacion_conserva_eleccion_notifica_y_cierra_sesion():
     assert "secreto interno" in avisos[0]
     assert "secreto interno" not in interaccion.followup.mensajes[0][0]
     assert interaccion.channel.mensajes == [
-        "El equipo Equipo @\u200bA (Comunidad @\u200bUno) ha elegido atacante",
+        "El equipo [Comunidad @\u200bUno] Equipo @\u200bA ha elegido atacante",
         "Se van a crear los encuentros",
     ]
 


### PR DESCRIPTION
### Motivation

- Unify how team names and their communities are presented and allow configurable per-round additional messages to be optional.  
- Centralize the construction of the general channel message for an enfrentamiento to reuse it from the bot and tests.  
- Update documentation and commands to reflect that message templates may be empty and therefore suppress additional messages.

### Description

- Changed `etiqueta_equipo_comunidades` presentation to `"[COMUNIDAD] NOMBREEQUIPO"` and ensured `@` mentions are sanitized via `texto_discord_seguro_comunidades`.  
- Added `mensajes_canal_enfrentamiento_comunidades(torneo, ronda, enfrentamiento)` in `ComunidadesDiscord.py` to build the structured automatic message and an optional template message (returns `(mensaje_general, mensaje_adicional|None)`).  
- Replaced the in-module message building in `LombardBot.py` with a call to `mensajes_canal_enfrentamiento_comunidades` and now send the automatic message first and the template as a second independent message only if non-empty.  
- Updated user-facing text when creating a torneo to explain that `plantilla_mensaje_ronda1` and `plantilla_mensaje_rondas_siguientes` may be left empty to disable the additional message.  
- Adjusted tests to the new label format and message behavior and added `tests/test_comunidades_mensajes.py` to cover message content and template suppression.

### Testing

- Ran unit tests touching comunidades: `tests/test_comunidades_mensajes.py`, `tests/test_comunidades_materializacion_partidos.py`, and `tests/test_comunidades_seleccion_atacante_command.py`, and they all passed.  
- Ran the modified test suite paths under pytest to validate message generation and channel materialization, and assertions for new label format succeeded.  
- Existing materialization and selection tests were executed after updates and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f0ada0b48832a85125df14cf9fdab)