### PR TITLE
Unifica formato público de equipos de comunidades

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -4447,6 +4447,16 @@ def _texto_discord_seguro(valor: object) -> str:
     return discord.utils.escape_mentions(texto)
 
 
+def _etiqueta_equipo_escalar_comunidades(
+    nombre: object, comunidad_nombre: object
+) -> str:
+    """Presenta un equipo desde valores escalares con el formato público común."""
+    return (
+        f"[{_texto_discord_seguro(comunidad_nombre)}] "
+        f"{_texto_discord_seguro(nombre)}"
+    )
+
+
 @bot.command(name="comunidades_add_comunidad")
 async def comunidades_add_comunidad(ctx, torneo_id: int, *, nombre: str):
     if not es_comisario(ctx):
@@ -5449,7 +5459,10 @@ def _formatear_equipos_publico(resultado: dict) -> str:
     for f in resultado["filas"]:
         estado = _estado_con_emojis_comunidades(f["estado_temporal"], f["es_zombie"])
         h2h = "-" if f["h2h_valor"] is None else _decimal_publico_comunidades(f["h2h_valor"])
-        lineas += [f"**{f['posicion']}.** {estado} **{_texto_discord_seguro(f['nombre'])} ({_texto_discord_seguro(f['comunidad_nombre'])})**",
+        etiqueta = _etiqueta_equipo_escalar_comunidades(
+            f["nombre"], f["comunidad_nombre"]
+        )
+        lineas += [f"**{f['posicion']}.** {estado} **{etiqueta}**",
                    f"🏆 PTS **{_decimal_publico_comunidades(f['puntos'])}** · PJ {f['pj']} ({f['pg']}/{f['pe']}/{f['pp']}) · 🛌 {f['cantidad_byes']} · BH {_decimal_publico_comunidades(f['buchholz_cut'])} · H2H {h2h} · TD {f['td_favor']}-{f['td_contra']} ({f['diferencia_td']:+d})"]
     if resultado["fuente"] == "SNAPSHOT":
         lineas.append("\nℹ️ Los puntos son históricos; los emojis muestran el estado actual.")


### PR DESCRIPTION
### Motivation
- Evitar composiciones manuales del tipo `nombre (comunidad_nombre)` en la salida pública y normalizar el formato obligatorio `[comunidad_nombre] nombre` escapando ambos valores para evitar menciones accidentales.
- Reutilizar una única regla de presentación para datos escalares y así no duplicar la lógica ya existente en `etiqueta_equipo_comunidades`.

### Description
- Añade la utilidad ` _etiqueta_equipo_escalar_comunidades(nombre, comunidad_nombre)` que presenta valores escalares con el formato público `[COMUNIDAD] NOMBRE`, aplicando `_texto_discord_seguro` a ambos componentes.
- Sustituye la composición manual en ` _formatear_equipos_publico` para usar la nueva función en lugar de `f"{nombre} ({comunidad_nombre})"`.
- Mantiene el uso de `etiqueta_equipo_comunidades` para los lugares donde ya se manejaba un objeto `ComunidadesEquipo`, evitando reglas duplicadas.

### Testing
- Ejecutado `python -m py_compile LombardBot.py` y la compilación fue satisfactoria.
- Ejecutado `pytest -q tests/test_comunidades_mensajes.py` pero falló por falta de la dependencia `sqlalchemy` en el entorno (`ModuleNotFoundError`), por lo que no fue posible ejecutar los tests de integración unitarios aquí.
- Realizadas comprobaciones estáticas (`rg`/búsquedas) para identificar composiciones manuales y `git diff --check` sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a300eb404b4832a9fb0d6411db15ac3)