### PR TITLE
Soporta /fecha en partidos de comunidades

### DIFF
--- a/BD/comunidades_schema.sql
+++ b/BD/comunidades_schema.sql
@@ -300,6 +300,7 @@ CREATE TABLE IF NOT EXISTS comunidades_partido (
   defensor_usuario_id INT NOT NULL,
   canal_discord_id BIGINT NULL,
   partido_bloodbowl_id VARCHAR(45) NULL,
+  fecha DATETIME NULL,
   td_local INT NULL,
   td_visitante INT NULL,
   puntos_internos_local DECIMAL(8,2) NULL,

--- a/ComunidadesDiscord.py
+++ b/ComunidadesDiscord.py
@@ -310,7 +310,9 @@ def _mensaje_partido_comunidades(enfrentamiento: Any, partido: Any) -> str:
         f"**Atacante:** <@{atacante_discord_id}>\n"
         f"**Defensor:** <@{defensor_discord_id}>\n\n"
         f"<@{atacante_discord_id}> contra <@{defensor_discord_id}>\n"
-        f"**Fecha límite:** {enfrentamiento.ronda.fecha_fin.strftime('%Y-%m-%d %H:%M')}"
+        f"**Fecha límite:** {enfrentamiento.ronda.fecha_fin.strftime('%Y-%m-%d %H:%M')}\n"
+        "Cuando acordéis el día y la hora del partido, registrad la quedada "
+        "en este canal con `/fecha`."
     )
 
 

--- a/GestorSQL.py
+++ b/GestorSQL.py
@@ -728,6 +728,7 @@ class ComunidadesPartido(Base):
     defensor_usuario_id = Column(Integer, ForeignKey('usuarios.idUsuarios', ondelete='RESTRICT'), nullable=False)
     canal_discord_id = Column(BigInteger, nullable=True)
     partido_bloodbowl_id = Column(String(45), nullable=True)
+    fecha = Column(DateTime, nullable=True)
     td_local = Column(Integer, nullable=True)
     td_visitante = Column(Integer, nullable=True)
     puntos_internos_local = Column(Numeric(8, 2), nullable=True)

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -2099,6 +2099,7 @@ async def fecha(interaction: discord.Interaction, dia: int, mes: int, hora: int,
     Session = sessionmaker(bind=GestorSQL.conexionEngine())
     with Session() as session:
         es_suizo = False
+        es_comunidades = False
         registro = session.query(GestorSQL.Calendario).filter(GestorSQL.Calendario.canalAsociado == id_canal).first()
 
         if registro is None:
@@ -2112,9 +2113,13 @@ async def fecha(interaction: discord.Interaction, dia: int, mes: int, hora: int,
                         if registro is None:
                             registro = session.query(GestorSQL.SuizoEmparejamiento).filter(GestorSQL.SuizoEmparejamiento.canal_id == id_canal).first()
                             if registro is None:
-                                await interaction.response.send_message("Este no es un canal de quedadas 😡", ephemeral=True)
-                                return
-                            es_suizo = True
+                                registro = session.query(GestorSQL.ComunidadesPartido).filter(GestorSQL.ComunidadesPartido.canal_discord_id == id_canal).first()
+                                if registro is None:
+                                    await interaction.response.send_message("Este no es un canal de quedadas 😡", ephemeral=True)
+                                    return
+                                es_comunidades = True
+                            else:
+                                es_suizo = True
 
         try:
             punto = ""
@@ -2122,6 +2127,8 @@ async def fecha(interaction: discord.Interaction, dia: int, mes: int, hora: int,
             fecha_nueva = datetime(year=datetime.now().year, month=mes, day=dia, hour=hora, minute=minuto, tzinfo=tz)
             if es_suizo:
                 fecha_final_base = registro.ronda.fecha_fin if registro.ronda else None
+            elif es_comunidades:
+                fecha_final_base = registro.enfrentamiento.ronda.fecha_fin if registro.enfrentamiento and registro.enfrentamiento.ronda else None
             else:
                 fecha_final_base = registro.fechaFinal
 

--- a/tests/test_comunidades_materializacion_partidos.py
+++ b/tests/test_comunidades_materializacion_partidos.py
@@ -240,6 +240,7 @@ def test_materializa_dos_canales_con_permisos_mensajes_y_estado():
         assert "**Defensor:** <@202>" in guild.creaciones[0]["canal"].mensajes[0]
         assert "**Equipos:** [A] Equipo A vs [B] Equipo B" in guild.creaciones[0]["canal"].mensajes[0]
         assert "**Fecha límite:** 2026-07-08 22:00" in guild.creaciones[0]["canal"].mensajes[0]
+        assert "registrad la quedada en este canal con `/fecha`" in guild.creaciones[0]["canal"].mensajes[0]
         enfrentamiento = session.get(ComunidadesEnfrentamiento, enfrentamiento_id)
         assert enfrentamiento.estado == "PARTIDOS_CREADOS"
         assert [partido.canal_discord_id for partido in enfrentamiento.partidos] == [901, 902]


### PR DESCRIPTION
### Motivation
- Hacer que el comando `/fecha` funcione también en los canales de los partidos individuales del torneo de comunidades y que la fecha quede persistida como en otros formatos. 
- Informar en el mensaje del canal individual que los jugadores deben usar `/fecha` para registrar la quedada.

### Description
- Añadida la columna `fecha` al DDL de `comunidades_partido` y al modelo ORM `ComunidadesPartido` para persistir la quedada del partido. 
- Actualizado el mensaje automático de los canales individuales en `ComunidadesDiscord.py` para indicar explícitamente: "registrad la quedada en este canal con `/fecha`". 
- Extendida la implementación de `/fecha` en `LombardBot.py` para reconocer `ComunidadesPartido` por `canal_discord_id`, validar la fecha contra `enfrentamiento.ronda.fecha_fin` y escribir la fecha en el registro correspondiente. 
- Añadida comprobación en los tests para verificar que el mensaje del partido contiene la instrucción de usar `/fecha`.

### Testing
- Ejecutado `PYTHONPATH=. pytest -q tests/test_comunidades_materializacion_partidos.py tests/test_comunidades_mensajes.py tests/test_comunidades_modelos.py tests/test_comunidades_mysql_ddl.py` y todos los tests relevantes pasaron (`23 passed, 1 skipped`).
- Compilados los módulos con `python -m compileall -q ComunidadesDiscord.py GestorSQL.py LombardBot.py` sin errores.
- Los cambios fueron validados por los tests de materialización y mensajes de comunidades que confirmaron la presencia de la instrucción sobre `/fecha` y el correcto modelado de la columna `fecha`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3081a538cc832a8bbc0527c2fce901)