### PR TITLE
Add inventory document for current Spin implementation

### DIFF
--- a/docs/inventario_spin_actual.md
+++ b/docs/inventario_spin_actual.md
@@ -1,0 +1,86 @@
+# Inventario actual de Spin
+
+Fuente de verdad para la lógica objetivo: [`logicaSpin.md`](../logicaSpin.md).
+
+Este inventario solo documenta el estado actual del código antes de modificar lógica. No cambia comportamiento.
+
+## Referencias buscadas
+
+Se buscaron estas referencias explícitas:
+
+- `SpinButtonsView`
+- `UsuarioSpin`
+- `AgregarMensajeSpin`
+- `ultimosspins`
+- `idMensajeSpin`
+- `your_bot:spin`
+- `your_bot:encontrado`
+
+## Resumen por responsabilidad
+
+| Responsabilidad | Archivo(s) actuales | Observaciones |
+| --- | --- | --- |
+| Vista de botones | `UtilesDiscord.py`, `ComandosAntiguos.py`, uso en `LombardBot.py` | La vista activa parece ser `UtilesDiscord.SpinButtonsView`; `ComandosAntiguos.py` conserva una versión antigua. |
+| Estado global | `UtilesDiscord.py`, referencias antiguas en `ComandosAntiguos.py` | `UsuarioSpin` es una única cola global; `idMensajeSpin` es un ID fijo. |
+| Creación de mensaje de Spin | `LombardBot.py` | Comando prefijado `!AgregaMensajeSpin`, sin argumento de ámbito. |
+| Comando `/ultimosspins` | `LombardBot.py` | Slash command con argumento `minutos`; no filtra por ámbito. |
+| Inserciones en tabla `Spin` | `UtilesDiscord.py`, `GestorSQL.py`, versión antigua en `ComandosAntiguos.py` | `GestorSQL.insertar_spin(usuario, fecha, tipo)` inserta `user`, `fecha`, `tipo`; no existe `ambito`. |
+| Configuración de canal o mensaje | `UtilesDiscord.py`, `LombardBot.py`, menciones de texto en `UtilesDiscord.py` | No hay constantes separadas para canal Spin General/Comunidades. El código activo guarda `mensaje_spin_id` desde la interacción y también existe `idMensajeSpin` fijo. |
+
+## Detalle por archivo
+
+### `UtilesDiscord.py`
+
+- Define el estado global actual: `UsuarioSpin = None` e `idMensajeSpin = 1224072683097030698`.
+- Define `SpinButtonsView`, la vista persistente actual con `timeout=None`.
+- Dentro de la vista almacena estado de instancia: `spin_timeout_task`, `mensaje_spin_id`, `canal` y `canal_partido`.
+- El botón `Spin` usa `custom_id='your_bot:spin'`.
+- El botón `Encontrado` usa `custom_id='your_bot:encontrado'`.
+- `spin_callback` usa una única cola global (`UsuarioSpin`) y busca partidos generales en:
+  - `Calendario`;
+  - `PlayOffsOro`;
+  - `PlayOffsPlata`;
+  - `PlayOffsBronce`;
+  - `Ticket`;
+  - `SuizoEmparejamiento`.
+- `spin_callback` envía mensaje al canal del partido, deshabilita/habilita botones, edita el primer mensaje del canal y registra `tipo='Spin'`.
+- `encontrado_callback` solo libera si pulsa el mismo usuario guardado en `UsuarioSpin`, edita el primer mensaje a libre y registra `tipo='Encontrado'`.
+- `auto_release_spin` libera tras 300 segundos, envía mensaje al canal del partido, DM al usuario, edita botones/primer mensaje y registra `tipo='Encontrado'` con usuario `LOMBARDBOT`.
+- Hay menciones hardcodeadas al canal de Spin en textos de creación de canales: `<#1224128423929315468>`.
+
+### `LombardBot.py`
+
+- En `on_ready`, registra la vista persistente con `bot.add_view(UtilesDiscord.SpinButtonsView())`.
+- El comando `!AgregarVista` añade `UtilesDiscord.SpinButtonsView()` a un mensaje existente.
+- El comando prefijado `!AgregaMensajeSpin` crea el mensaje de Spin actual:
+  - envía el texto libre `"'El spin está **LIBRE**'"`;
+  - envía otro mensaje con `"¡Úsame para Spinear!"` y la vista `UtilesDiscord.SpinButtonsView()`;
+  - reinicia `UtilesDiscord.UsuarioSpin = None`.
+- El comando slash `/ultimosspins` consulta `GestorSQL.Spin.fecha`, `GestorSQL.Spin.user` y `GestorSQL.Spin.tipo` desde un intervalo en minutos y devuelve una tabla sin ámbito.
+
+### `GestorSQL.py`
+
+- Define el modelo ORM `Spin` con tabla `Spin` y columnas:
+  - `idSpin = Column('idCalendario', Integer, primary_key=True)`;
+  - `user`;
+  - `fecha`;
+  - `tipo`.
+- Define `insertar_spin(usuario, fecha, tipo)`, que crea `Spin(user=usuario, fecha=fecha, tipo=tipo)` y hace commit.
+- No hay columna ni parámetro `ambito` en el modelo o función de inserción.
+
+### `ComandosAntiguos.py`
+
+- Contiene una implementación antigua de `SpinButtonsView` con los mismos `custom_id` (`your_bot:spin` y `your_bot:encontrado`).
+- Usa `UsuarioSpin` e `idMensajeSpin`, pero en este archivo no aparecen definidos localmente en las referencias revisadas.
+- Inserta en `Spin` llamando a `GestorSQL.insertar_spin(...)` en el flujo antiguo de `Spin`.
+- Por el nombre del archivo y la existencia de la vista activa en `UtilesDiscord.py`, parece código histórico; conviene confirmar antes de modificarlo.
+
+## Diferencias relevantes frente a `logicaSpin.md`
+
+- Actualmente hay una sola cola global (`UsuarioSpin`), no colas independientes `GENERAL` y `COMUNIDADES`.
+- Los botones usan `your_bot:spin` y `your_bot:encontrado`, sin ámbito en el `custom_id`.
+- La creación actual del mensaje de Spin no acepta argumento de ámbito.
+- `/ultimosspins` no acepta argumento `ambito` ni muestra el ámbito.
+- La tabla/modelo `Spin` no tiene columna `ambito`.
+- No se han encontrado constantes separadas para canal de Spin General y canal de Spin Comunidades.
+- Existe dependencia de IDs de mensaje/canal hardcodeados (`idMensajeSpin` y menciones a canal), aunque parte del código activo también edita el primer mensaje del canal.


### PR DESCRIPTION
### Motivation
- Capture the current code state for all Spin-related points using `logicaSpin.md` as the source of truth so subsequent logic changes are planned from an accurate inventory. 

### Description
- Add `docs/inventario_spin_actual.md` which lists where `SpinButtonsView`, `UsuarioSpin`, `AgregarMensajeSpin`, `ultimosspins`, `idMensajeSpin`, `your_bot:spin` and `your_bot:encontrado` are implemented or referenced, maps responsibilities to `UtilesDiscord.py`, `LombardBot.py`, `GestorSQL.py` and `ComandosAntiguos.py`, and documents gaps vs the target `logicaSpin.md`; this is documentation-only and does not change runtime behavior. 

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34397a6778832a9d3fa376f52b8b73)