### PR TITLE
Centralizar constantes de ámbito de Spin

### DIFF
--- a/GestorSQL.py
+++ b/GestorSQL.py
@@ -10,6 +10,8 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
 
+from SpinConstantes import AMBITO_SPIN_GENERAL, normalizar_ambito_spin
+
 
 Base = declarative_base()
 
@@ -134,11 +136,13 @@ class Spin(Base):
     user = Column('user', String)
     fecha = Column('fecha', DateTime)
     tipo = Column('tipo', String)
+    ambito = Column('ambito', String, default=AMBITO_SPIN_GENERAL)
 
 
-def insertar_spin( usuario, fecha, tipo):
+def insertar_spin(usuario, fecha, tipo, ambito=AMBITO_SPIN_GENERAL):
     # Esta es la función que inserta un nuevo Spin en la base de datos
-    new_spin = Spin(user=usuario, fecha=fecha, tipo=tipo)
+    ambito_normalizado = normalizar_ambito_spin(ambito) or AMBITO_SPIN_GENERAL
+    new_spin = Spin(user=usuario, fecha=fecha, tipo=tipo, ambito=ambito_normalizado)
     Session = sessionmaker(bind=conexionEngine())
     session = Session()
     try:

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -1,4 +1,4 @@
-﻿import os
+import os
 import asyncio
 from pickle import LONG
 from re import A
@@ -31,6 +31,10 @@ import UtilesDiscord
 import GestorSQL
 import Encuesta
 from UtilesDiscord import DiscordClientSingleton
+from SpinConstantes import (
+    AMBITO_SPIN_TODOS,
+    normalizar_ambito_spin,
+)
 import GestionExcel
 import aiohttp
 import Imagenes
@@ -2272,8 +2276,14 @@ async def PruebaBD(ctx):
     session.close()
     
 @bot.tree.command(name="ultimosspins")
+@app_commands.describe(ambito="Ámbito de Spin: General, Comunidades o Todos")
+@app_commands.choices(ambito=[
+    app_commands.Choice(name="General", value="General"),
+    app_commands.Choice(name="Comunidades", value="Comunidades"),
+    app_commands.Choice(name="Todos", value="Todos"),
+])
 @commands.has_any_role('Moderadores', 'Administrador', 'Comisario')
-async def obtener_spins_recientes(interaction: discord.Interaction, minutos: int):
+async def obtener_spins_recientes(interaction: discord.Interaction, minutos: int, ambito: str = "Todos"):
     Session = sessionmaker(bind=GestorSQL.conexionEngine())
     session = Session()
     
@@ -2281,16 +2291,23 @@ async def obtener_spins_recientes(interaction: discord.Interaction, minutos: int
     tiempo_desde = datetime.utcnow() - timedelta(minutes=minutos)
     
     try:
-        # Realizar la consulta filtrando por fecha
-        resultados = session.query(GestorSQL.Spin.fecha, GestorSQL.Spin.user, GestorSQL.Spin.tipo).\
-            filter(GestorSQL.Spin.fecha >= tiempo_desde).\
-            all()
+        ambito_normalizado = normalizar_ambito_spin(ambito, permitir_todos=True)
+        if ambito_normalizado is None:
+            await interaction.response.send_message("```Ámbito no válido. Usa General, Comunidades o Todos.```", ephemeral=True)
+            return
+
+        # Realizar la consulta filtrando por fecha y, si procede, por ámbito
+        consulta = session.query(GestorSQL.Spin.fecha, GestorSQL.Spin.user, GestorSQL.Spin.tipo, GestorSQL.Spin.ambito).\
+            filter(GestorSQL.Spin.fecha >= tiempo_desde)
+        if ambito_normalizado != AMBITO_SPIN_TODOS:
+            consulta = consulta.filter(GestorSQL.Spin.ambito == ambito_normalizado)
+        resultados = consulta.all()
         
         # Formatear los resultados en Markdown
-        tabla_markdown = "```| Fecha (Europe/Madrid) | Usuario | Acción |\n|----------------------|---------|--------|"
-        for fecha, usuario, tipo in resultados:
+        tabla_markdown = "```| Fecha (Europe/Madrid) | Usuario | Acción | Ámbito |\n|----------------------|---------|--------|--------|"
+        for fecha, usuario, tipo, ambito_registro in resultados:
             fecha_madrid = fecha.replace(tzinfo=ZoneInfo('UTC')).astimezone(ZoneInfo('Europe/Madrid')) if fecha.tzinfo is None else fecha.astimezone(ZoneInfo('Europe/Madrid'))
-            tabla_markdown += f"\n| {fecha_madrid.strftime('%Y-%m-%d %H:%M:%S')} | {usuario} | {tipo} |"
+            tabla_markdown += f"\n| {fecha_madrid.strftime('%Y-%m-%d %H:%M:%S')} | {usuario} | {tipo} | {ambito_registro or ''} |"
         
         tabla_markdown += "```"
         

--- a/SpinConstantes.py
+++ b/SpinConstantes.py
@@ -1,0 +1,50 @@
+"""Constantes y normalización para la mecánica Spin.
+
+Según ``logicaSpin.md``, los ámbitos internos soportados son exactamente
+``GENERAL`` y ``COMUNIDADES``. Los textos visibles para usuarios se normalizan
+antes de usarse en la lógica o persistirse.
+"""
+
+from enum import Enum
+import unicodedata
+
+
+class AmbitoSpin(str, Enum):
+    """Ámbitos internos canónicos de Spin."""
+
+    GENERAL = "GENERAL"
+    COMUNIDADES = "COMUNIDADES"
+
+
+AMBITO_SPIN_GENERAL = AmbitoSpin.GENERAL.value
+AMBITO_SPIN_COMUNIDADES = AmbitoSpin.COMUNIDADES.value
+AMBITOS_SPIN = frozenset(ambito.value for ambito in AmbitoSpin)
+AMBITO_SPIN_TODOS = "TODOS"
+
+_TEXTOS_AMBITO_SPIN = {
+    "general": AMBITO_SPIN_GENERAL,
+    "comunidades": AMBITO_SPIN_COMUNIDADES,
+}
+_TEXTOS_AMBITO_SPIN_TODOS = {
+    **_TEXTOS_AMBITO_SPIN,
+    "todos": AMBITO_SPIN_TODOS,
+}
+
+
+def _normalizar_texto_ambito(texto):
+    texto = str(texto or "").strip()
+    texto = unicodedata.normalize("NFKD", texto)
+    texto = "".join(c for c in texto if not unicodedata.combining(c))
+    return texto.casefold()
+
+
+def normalizar_ambito_spin(texto, *, permitir_todos=False):
+    """Convierte textos de usuario a ámbitos internos de Spin.
+
+    Acepta los textos visibles ``General``, ``Comunidades`` y, cuando
+    ``permitir_todos`` es verdadero, ``Todos``. También acepta directamente los
+    valores internos ``GENERAL`` y ``COMUNIDADES``.
+    """
+
+    opciones = _TEXTOS_AMBITO_SPIN_TODOS if permitir_todos else _TEXTOS_AMBITO_SPIN
+    return opciones.get(_normalizar_texto_ambito(texto))

--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.sql import case,func
 
 import GestorSQL
+from SpinConstantes import AMBITO_SPIN_GENERAL
 
 import asyncio
 from datetime import datetime
@@ -357,7 +358,7 @@ class SpinButtonsView(discord.ui.View):
             primer_mensaje = await self.obtener_primer_mensaje(mensaje_spin.channel)
             await primer_mensaje.edit(content='El spin está **LIBRE**')
             
-            thread = Thread(target=GestorSQL.insertar_spin, args=('LOMBARDBOT', datetime.utcnow(), 'Encontrado'))
+            thread = Thread(target=GestorSQL.insertar_spin, args=('LOMBARDBOT', datetime.utcnow(), 'Encontrado', AMBITO_SPIN_GENERAL))
             thread.start()
 
 
@@ -512,7 +513,7 @@ class SpinButtonsView(discord.ui.View):
 
         await interaction.followup.send("Ahora puedes buscar partido.", ephemeral=True)
 
-        thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Spin'))
+        thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Spin', AMBITO_SPIN_GENERAL))
         thread.start()
             
     @discord.ui.button(label="Encontrado", style=discord.ButtonStyle.blurple, custom_id='your_bot:encontrado')
@@ -543,7 +544,7 @@ class SpinButtonsView(discord.ui.View):
 
             primer_mensaje = await self.obtener_primer_mensaje(channel)
             await primer_mensaje.edit(content='El spin está **LIBRE**')
-            thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Encontrado'))
+            thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Encontrado', AMBITO_SPIN_GENERAL))
             thread.start()
 
             


### PR DESCRIPTION
### Motivation
- Evitar strings dispersos para los ámbitos de la mecánica Spin y garantizar una única fuente de verdad para los ámbitos internos `GENERAL` y `COMUNIDADES` según `logicaSpin.md`.
- Permitir normalizar textos visibles (`General`, `Comunidades`, `Todos`) antes de persistir o consultar historial de spins.

### Description
- Añadido el módulo `SpinConstantes.py` que define `AmbitoSpin` (enum), las constantes `AMBITO_SPIN_GENERAL`, `AMBITO_SPIN_COMUNIDADES`, `AMBITO_SPIN_TODOS` y la función `normalizar_ambito_spin(texto, permitir_todos=False)` para convertir etiquetas de usuario a valores internos canónicos.
- Actualizado `GestorSQL.py` para añadir la columna `ambito` en la tabla `Spin` y modificar `insertar_spin` para aceptar un argumento `ambito`, normalizarlo y persistir el valor interno (por defecto `GENERAL`).
- Actualizado `UtilesDiscord.py` para usar `AMBITO_SPIN_GENERAL` al registrar eventos de Spin actuales (`Spin` / `Encontrado`) y así evitar literals repartidos por el código.
- Actualizado `LombardBot.py` para ampliar el comando `/ultimosspins` con una opción `ambito` (choices: `General`, `Comunidades`, `Todos`), normalizar la entrada, aplicar filtro por `ambito` en la consulta cuando proceda y mostrar el ámbito en la tabla de salida.

### Testing
- Compilación estática de módulos con `python3 -m py_compile SpinConstantes.py GestorSQL.py UtilesDiscord.py LombardBot.py`, que pasó correctamente.
- Pruebas de normalización ejecutadas con un pequeño script que verifica `normalizar_ambito_spin('General')`, `('GENERAL')`, `('Comunidades')` y `('Todos', permitir_todos=True)`, todas las aserciones OK (salida: `normalización spin OK`).
- Revisión de diferencias y chequeos con `git diff --check` sin errores reportados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a343d315574832a83fa0aa8cb5aeb31)