### PR TITLE
Separate Spin channels and stop using message ID as source of truth

### DIFF
--- a/ComandosAntiguos.py
+++ b/ComandosAntiguos.py
@@ -340,6 +340,11 @@ class SpinButtonsView(discord.ui.View):
     def __init__(self):
         super().__init__(timeout=None)
 
+    async def obtener_primer_mensaje(self, channel):
+        async for mensaje in channel.history(oldest_first=True, limit=1):
+            return mensaje
+        return None
+
     @discord.ui.button(label="Spin",style=discord.ButtonStyle.green, custom_id='your_bot:spin')
     async def Spin_callback(self, interaction: discord.Interaction,button: discord.ui.Button):
         global UsuarioSpin
@@ -367,10 +372,10 @@ class SpinButtonsView(discord.ui.View):
             button.disabled = True 
             await interaction.message.edit(content=message.content, view=self)
             
-            # Edita el mensaje con el estado actual (se asume que tienes el ID del mensaje a editar)
-            mensaje_id = idMensajeSpin
-            mensaje = await channel.fetch_message(mensaje_id)
-            await mensaje.edit(content=f'**{UsuarioSpin} puede buscar partido**')
+            # El estado público del Spin se edita en el primer mensaje del canal.
+            mensaje = await self.obtener_primer_mensaje(channel)
+            if mensaje:
+                await mensaje.edit(content=f'**{UsuarioSpin} puede buscar partido**')
             
             thread = Thread(target=GestorSQL.insertar_spin, args=(UsuarioSpin, now, 'Spin'))
             thread.start()
@@ -399,10 +404,10 @@ class SpinButtonsView(discord.ui.View):
                 
             button.disabled = True 
             await interaction.message.edit(content=message.content, view=self)
-            # Edita el mensaje para reflejar el cambio de estado
-            mensaje_id = idMensajeSpin
-            mensaje = await channel.fetch_message(mensaje_id)
-            await mensaje.edit(content='El spin está **LIBRE**')
+            # El estado público del Spin se edita en el primer mensaje del canal.
+            mensaje = await self.obtener_primer_mensaje(channel)
+            if mensaje:
+                await mensaje.edit(content='El spin está **LIBRE**')
         # Si no es UsuarioSpin, ignora la pulsación
 
 

--- a/SpinConstantes.py
+++ b/SpinConstantes.py
@@ -21,6 +21,12 @@ AMBITO_SPIN_COMUNIDADES = AmbitoSpin.COMUNIDADES.value
 AMBITOS_SPIN = frozenset(ambito.value for ambito in AmbitoSpin)
 AMBITO_SPIN_TODOS = "TODOS"
 
+# Canal actual de Spin General; se conserva para compatibilidad operativa.
+CANAL_SPIN_GENERAL_ID = 1224128423929315468
+# Canal independiente para Spin Comunidades. Configurar el ID real al activarlo.
+CANAL_SPIN_COMUNIDADES_ID = None
+# El mensaje público que se edita es el primer mensaje del canal, no un ID persistido.
+
 _TEXTOS_AMBITO_SPIN = {
     "general": AMBITO_SPIN_GENERAL,
     "comunidades": AMBITO_SPIN_COMUNIDADES,

--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.sql import case,func
 
 import GestorSQL
-from SpinConstantes import AMBITO_SPIN_GENERAL
+from SpinConstantes import AMBITO_SPIN_GENERAL, CANAL_SPIN_GENERAL_ID
 
 import asyncio
 from datetime import datetime
@@ -23,7 +23,7 @@ from datetime import datetime
 
 
 UsuarioSpin = None
-idMensajeSpin = 1224072683097030698
+
 
 def get_int_value(dictionary, key):
     value = dictionary.get(key)
@@ -245,7 +245,7 @@ Por favor, acuerden una fecha para jugar el primer partido.""" + mensajePreferen
 
 Cuando acordéis una fecha **usad** el comando `/fecha` para que el bot pueda registrar vuestro partido con el horario de España. Esto es **OBLIGATORIO** y para la administración será clave a la hora de tomar decisiones en caso de que alguien no se presente. {fecha}
 
-Justo antes de jugar el partido tendréis que **USAR EL CANAL**  <#1224128423929315468> y **LIBERARLO** al encontrar partido. De esta manera no os emparejará con otra persona.
+Justo antes de jugar el partido tendréis que **USAR EL CANAL**  <#{CANAL_SPIN_GENERAL_ID}> y **LIBERARLO** al encontrar partido. De esta manera no os emparejará con otra persona.
 
 Si hubiera cualquier problema mencionad a los comisarios que están para ayudar.
 """
@@ -256,7 +256,7 @@ Por favor, acuerden una fecha para jugar el primer partido.""" + mensajePreferen
 
 Cuando acordéis una fecha **usad** el comando `/fecha` para que el bot pueda registrar vuestro partido con el horario de España. Esto es **OBLIGATORIO** y para la administración será clave a la hora de tomar decisiones en caso de que alguien no se presente. {fecha}
 
-Justo antes de jugar el partido tendréis que **USAR EL CANAL**  <#1224128423929315468> y **LIBERADLO** al encontrar partido. De esta manera no os emparejará con otra persona.
+Justo antes de jugar el partido tendréis que **USAR EL CANAL**  <#{CANAL_SPIN_GENERAL_ID}> y **LIBERADLO** al encontrar partido. De esta manera no os emparejará con otra persona.
 
 Si hubiera cualquier problema mencionad a los comisarios que están para ayudar.
 """
@@ -327,11 +327,10 @@ class SpinButtonsView(discord.ui.View):
     def __init__(self):
         super().__init__(timeout=None)
         self.spin_timeout_task = None
-        self.mensaje_spin_id = None  # Almacena el ID del mensaje de spin
-        self.canal = None  # Almacena el canal del mensaje de spin
+        self.canal = None  # Canal Spin; el mensaje editado será el primer mensaje del canal.
         self.canal_partido = None # Almacena el canal del partido
 
-    async def auto_release_spin(self, user):
+    async def auto_release_spin(self, user, mensaje_botones=None):
         await asyncio.sleep(300)  # Espera 5 minutos
         global UsuarioSpin
         if UsuarioSpin == user:
@@ -343,20 +342,20 @@ class SpinButtonsView(discord.ui.View):
             # Envía un mensaje privado al usuario informándole que el spin ha sido liberado automáticamente
             await user.send('Tu spin ha sido liberado automáticamente debido a la inactividad.')
 
-            # Recupera el mensaje de spin y actualiza la vista
-            if self.canal and self.mensaje_spin_id:
-                mensaje_spin = await self.canal.fetch_message(self.mensaje_spin_id)
-                # Encuentra y actualiza los botones
+            # Actualiza los botones sin usar un ID persistido como fuente de verdad.
+            if mensaje_botones:
                 for item in self.children:
                     if isinstance(item, discord.ui.Button):
                         if item.label == "Spin":
                             item.disabled = False
                         elif item.label == "Encontrado":
                             item.disabled = True
-                await mensaje_spin.edit(view=self)  # Actualiza la vista con los botones actualizados
-                
-            primer_mensaje = await self.obtener_primer_mensaje(mensaje_spin.channel)
-            await primer_mensaje.edit(content='El spin está **LIBRE**')
+                await mensaje_botones.edit(view=self)
+
+            # El estado público del Spin se edita en el primer mensaje del canal.
+            primer_mensaje = await self.obtener_primer_mensaje(self.canal) if self.canal else None
+            if primer_mensaje:
+                await primer_mensaje.edit(content='El spin está **LIBRE**')
             
             thread = Thread(target=GestorSQL.insertar_spin, args=('LOMBARDBOT', datetime.utcnow(), 'Encontrado', AMBITO_SPIN_GENERAL))
             thread.start()
@@ -372,8 +371,7 @@ class SpinButtonsView(discord.ui.View):
         global UsuarioSpin
         await interaction.response.defer()
         self.canal = interaction.channel
-        self.mensaje_spin_id = interaction.message.id
-               
+
         user = interaction.user
 
         if UsuarioSpin is not None:
@@ -387,7 +385,7 @@ class SpinButtonsView(discord.ui.View):
         # Inicia el temporizador para la liberación automática del spin
         if self.spin_timeout_task:
             self.spin_timeout_task.cancel()  # Cancela el temporizador anterior si existe
-        self.spin_timeout_task = asyncio.create_task(self.auto_release_spin(user))
+        self.spin_timeout_task = asyncio.create_task(self.auto_release_spin(user, interaction.message))
 
         # Buscar usuario en la base de datos
         Session = GestorSQL.sessionmaker(bind=GestorSQL.conexionEngine())
@@ -508,6 +506,7 @@ class SpinButtonsView(discord.ui.View):
         button.disabled = True
         await interaction.message.edit(view=self)
 
+        # El estado público del Spin se edita en el primer mensaje del canal.
         primer_mensaje = await self.obtener_primer_mensaje(interaction.channel)
         await primer_mensaje.edit(content=f'<@{coach1_id_discord}> y <@{coach2_id_discord}> pueden buscar partido')
 
@@ -542,6 +541,7 @@ class SpinButtonsView(discord.ui.View):
             button.disabled = True
             await interaction.message.edit(view=self)
 
+            # El estado público del Spin se edita en el primer mensaje del canal.
             primer_mensaje = await self.obtener_primer_mensaje(channel)
             await primer_mensaje.edit(content='El spin está **LIBRE**')
             thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Encontrado', AMBITO_SPIN_GENERAL))

--- a/docs/inventario_spin_actual.md
+++ b/docs/inventario_spin_actual.md
@@ -12,7 +12,6 @@ Se buscaron estas referencias explícitas:
 - `UsuarioSpin`
 - `AgregarMensajeSpin`
 - `ultimosspins`
-- `idMensajeSpin`
 - `your_bot:spin`
 - `your_bot:encontrado`
 
@@ -21,19 +20,19 @@ Se buscaron estas referencias explícitas:
 | Responsabilidad | Archivo(s) actuales | Observaciones |
 | --- | --- | --- |
 | Vista de botones | `UtilesDiscord.py`, `ComandosAntiguos.py`, uso en `LombardBot.py` | La vista activa parece ser `UtilesDiscord.SpinButtonsView`; `ComandosAntiguos.py` conserva una versión antigua. |
-| Estado global | `UtilesDiscord.py`, referencias antiguas en `ComandosAntiguos.py` | `UsuarioSpin` es una única cola global; `idMensajeSpin` es un ID fijo. |
+| Estado global | `UtilesDiscord.py`, referencias antiguas en `ComandosAntiguos.py` | `UsuarioSpin` es una única cola global; ya no se mantiene un ID fijo del mensaje de Spin como fuente de verdad. |
 | Creación de mensaje de Spin | `LombardBot.py` | Comando prefijado `!AgregaMensajeSpin`, sin argumento de ámbito. |
 | Comando `/ultimosspins` | `LombardBot.py` | Slash command con argumento `minutos`; no filtra por ámbito. |
 | Inserciones en tabla `Spin` | `UtilesDiscord.py`, `GestorSQL.py`, versión antigua en `ComandosAntiguos.py` | `GestorSQL.insertar_spin(usuario, fecha, tipo)` inserta `user`, `fecha`, `tipo`; no existe `ambito`. |
-| Configuración de canal o mensaje | `UtilesDiscord.py`, `LombardBot.py`, menciones de texto en `UtilesDiscord.py` | No hay constantes separadas para canal Spin General/Comunidades. El código activo guarda `mensaje_spin_id` desde la interacción y también existe `idMensajeSpin` fijo. |
+| Configuración de canal o mensaje | `UtilesDiscord.py`, `LombardBot.py`, menciones de texto en `UtilesDiscord.py` | Existen constantes separadas para canal Spin General/Comunidades. El estado público del Spin se edita tomando el primer mensaje del canal. |
 
 ## Detalle por archivo
 
 ### `UtilesDiscord.py`
 
-- Define el estado global actual: `UsuarioSpin = None` e `idMensajeSpin = 1224072683097030698`.
+- Define el estado global actual: `UsuarioSpin = None`.
 - Define `SpinButtonsView`, la vista persistente actual con `timeout=None`.
-- Dentro de la vista almacena estado de instancia: `spin_timeout_task`, `mensaje_spin_id`, `canal` y `canal_partido`.
+- Dentro de la vista almacena estado de instancia: `spin_timeout_task`, `canal` y `canal_partido`.
 - El botón `Spin` usa `custom_id='your_bot:spin'`.
 - El botón `Encontrado` usa `custom_id='your_bot:encontrado'`.
 - `spin_callback` usa una única cola global (`UsuarioSpin`) y busca partidos generales en:
@@ -46,7 +45,7 @@ Se buscaron estas referencias explícitas:
 - `spin_callback` envía mensaje al canal del partido, deshabilita/habilita botones, edita el primer mensaje del canal y registra `tipo='Spin'`.
 - `encontrado_callback` solo libera si pulsa el mismo usuario guardado en `UsuarioSpin`, edita el primer mensaje a libre y registra `tipo='Encontrado'`.
 - `auto_release_spin` libera tras 300 segundos, envía mensaje al canal del partido, DM al usuario, edita botones/primer mensaje y registra `tipo='Encontrado'` con usuario `LOMBARDBOT`.
-- Hay menciones hardcodeadas al canal de Spin en textos de creación de canales: `<#1224128423929315468>`.
+- Los textos de creación de canales referencian `CANAL_SPIN_GENERAL_ID` para mantener compatibilidad con el canal actual.
 
 ### `LombardBot.py`
 
@@ -71,7 +70,7 @@ Se buscaron estas referencias explícitas:
 ### `ComandosAntiguos.py`
 
 - Contiene una implementación antigua de `SpinButtonsView` con los mismos `custom_id` (`your_bot:spin` y `your_bot:encontrado`).
-- Usa `UsuarioSpin` e `idMensajeSpin`, pero en este archivo no aparecen definidos localmente en las referencias revisadas.
+- Usa `UsuarioSpin`; el estado público del Spin se localiza como primer mensaje del canal.
 - Inserta en `Spin` llamando a `GestorSQL.insertar_spin(...)` en el flujo antiguo de `Spin`.
 - Por el nombre del archivo y la existencia de la vista activa en `UtilesDiscord.py`, parece código histórico; conviene confirmar antes de modificarlo.
 
@@ -80,7 +79,7 @@ Se buscaron estas referencias explícitas:
 - Actualmente hay una sola cola global (`UsuarioSpin`), no colas independientes `GENERAL` y `COMUNIDADES`.
 - Los botones usan `your_bot:spin` y `your_bot:encontrado`, sin ámbito en el `custom_id`.
 - La creación actual del mensaje de Spin no acepta argumento de ámbito.
-- `/ultimosspins` no acepta argumento `ambito` ni muestra el ámbito.
-- La tabla/modelo `Spin` no tiene columna `ambito`.
-- No se han encontrado constantes separadas para canal de Spin General y canal de Spin Comunidades.
-- Existe dependencia de IDs de mensaje/canal hardcodeados (`idMensajeSpin` y menciones a canal), aunque parte del código activo también edita el primer mensaje del canal.
+- `/ultimosspins` acepta argumento `ambito` para filtrar el historial.
+- La tabla/modelo `Spin` tiene columna `ambito`.
+- Existen constantes separadas para canal de Spin General y canal de Spin Comunidades.
+- Existe dependencia del ID de canal de Spin General por compatibilidad, centralizada como constante; el mensaje público se edita como primer mensaje del canal.


### PR DESCRIPTION
### Motivation
- Prepare the Spin feature to support independent channels for `GENERAL` and `COMUNIDADES`, keeping compatibility with the current General channel ID. 
- Ensure the public Spin state is not tied to a persisted message ID so the bot can recover by editing the first message of the channel as described in `logicaSpin.md`.

### Description
- Added `CANAL_SPIN_GENERAL_ID` and `CANAL_SPIN_COMUNIDADES_ID` constants to `SpinConstantes.py`, preserving the existing General channel ID for compatibility. 
- Replaced hardcoded channel mentions with `CANAL_SPIN_GENERAL_ID` in `UtilesDiscord.py` and removed the fixed `idMensajeSpin` usage. 
- Updated `SpinButtonsView` in `UtilesDiscord.py` to stop storing a persistent message ID, pass the interaction message to the auto-release path to update the button view, and edit the channel's first message (obtained via `obtener_primer_mensaje`) as the public Spin state. 
- Applied equivalent adjustments to the backup view in `ComandosAntiguos.py` and updated `docs/inventario_spin_actual.md` to reflect the new configuration and source-of-truth behavior. 

### Testing
- Compiled modified modules with `python -m py_compile SpinConstantes.py UtilesDiscord.py`, which succeeded. 
- Verified removal/relocation of hardcoded message/channel ID references with `rg -n "idMensajeSpin|mensaje_spin_id|1224072683097030698"`, confirming no lingering fixed message-ID usage. 
- Performed repository status checks to confirm the expected files were updated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a343f5a9a14832a8f9b27ad40ccb2b6)