### PR TITLE
Mantener Spin existente como GENERAL y compatibilidad de `ambito` en historial

### DIFF
--- a/GestorSQL.py
+++ b/GestorSQL.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     Text, Numeric, Boolean, Enum, JSON, SmallInteger, ForeignKeyConstraint, UniqueConstraint,
     CheckConstraint, Index, text, func,
 )
+from sqlalchemy import inspect
 from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
@@ -140,15 +141,30 @@ class Spin(Base):
 
 
 def insertar_spin(usuario, fecha, tipo, ambito=AMBITO_SPIN_GENERAL):
-    # Esta es la función que inserta un nuevo Spin en la base de datos
+    # Esta es la función que inserta un nuevo Spin en la base de datos.
+    # Los Spins heredados son Spin General, pero el despliegue puede convivir
+    # temporalmente con bases de datos donde aún no exista la columna `ambito`.
     ambito_normalizado = normalizar_ambito_spin(ambito) or AMBITO_SPIN_GENERAL
-    new_spin = Spin(user=usuario, fecha=fecha, tipo=tipo, ambito=ambito_normalizado)
-    Session = sessionmaker(bind=conexionEngine())
+    engine = conexionEngine()
+    Session = sessionmaker(bind=engine)
     session = Session()
     try:
-        session.add(new_spin)
+        columnas_spin = {columna["name"] for columna in inspect(engine).get_columns(Spin.__tablename__)}
+        valores = {"usuario": usuario, "fecha": fecha, "tipo": tipo}
+        if "ambito" in columnas_spin:
+            valores["ambito"] = ambito_normalizado
+            session.execute(
+                text("INSERT INTO Spin (`user`, fecha, tipo, ambito) VALUES (:usuario, :fecha, :tipo, :ambito)"),
+                valores,
+            )
+        else:
+            session.execute(
+                text("INSERT INTO Spin (`user`, fecha, tipo) VALUES (:usuario, :fecha, :tipo)"),
+                valores,
+            )
         session.commit()
     except Exception as e:
+        session.rollback()
         print(f"Error al insertar en la tabla Spin: {e}")
     finally:
         session.close()

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -221,8 +221,9 @@ async def reloj_de_cuco():
 
 @bot.event
 async def on_ready():
+    # Los botones persistentes existentes (`your_bot:spin` / `your_bot:encontrado`)
+    # pertenecen al Spin heredado, que debe seguir operando como GENERAL.
     bot.add_view(UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL))
-    bot.add_view(UtilesDiscord.SpinButtonsView(AMBITO_SPIN_COMUNIDADES))
     await bot.tree.sync()
     #await GestionExcel.ActualizarExcels()
     if not programador_tareas.is_running():
@@ -2305,18 +2306,30 @@ async def obtener_spins_recientes(interaction: discord.Interaction, minutos: int
             await interaction.response.send_message("```Ámbito no válido. Usa General, Comunidades o Todos.```", ephemeral=True)
             return
 
-        # Realizar la consulta filtrando por fecha y, si procede, por ámbito
-        consulta = session.query(GestorSQL.Spin.fecha, GestorSQL.Spin.user, GestorSQL.Spin.tipo, GestorSQL.Spin.ambito).\
-            filter(GestorSQL.Spin.fecha >= tiempo_desde)
-        if ambito_normalizado != AMBITO_SPIN_TODOS:
-            consulta = consulta.filter(GestorSQL.Spin.ambito == ambito_normalizado)
-        resultados = consulta.all()
+        # Realizar la consulta filtrando por fecha y, si procede, por ámbito.
+        # Si la base de datos aún no tiene `Spin.ambito`, los registros heredados
+        # se muestran como GENERAL para mantener la compatibilidad del Spin actual.
+        columnas_spin = {columna["name"] for columna in GestorSQL.inspect(GestorSQL.conexionEngine()).get_columns(GestorSQL.Spin.__tablename__)}
+        if "ambito" in columnas_spin:
+            consulta = session.query(GestorSQL.Spin.fecha, GestorSQL.Spin.user, GestorSQL.Spin.tipo, GestorSQL.Spin.ambito).\
+                filter(GestorSQL.Spin.fecha >= tiempo_desde)
+            if ambito_normalizado != AMBITO_SPIN_TODOS:
+                consulta = consulta.filter(GestorSQL.Spin.ambito == ambito_normalizado)
+            resultados = consulta.all()
+        else:
+            if ambito_normalizado == AMBITO_SPIN_COMUNIDADES:
+                resultados = []
+            else:
+                resultados = [
+                    (fecha, usuario, tipo, AMBITO_SPIN_GENERAL)
+                    for fecha, usuario, tipo in session.query(GestorSQL.Spin.fecha, GestorSQL.Spin.user, GestorSQL.Spin.tipo).filter(GestorSQL.Spin.fecha >= tiempo_desde).all()
+                ]
         
         # Formatear los resultados en Markdown
         tabla_markdown = "```| Fecha (Europe/Madrid) | Usuario | Acción | Ámbito |\n|----------------------|---------|--------|--------|"
         for fecha, usuario, tipo, ambito_registro in resultados:
             fecha_madrid = fecha.replace(tzinfo=ZoneInfo('UTC')).astimezone(ZoneInfo('Europe/Madrid')) if fecha.tzinfo is None else fecha.astimezone(ZoneInfo('Europe/Madrid'))
-            tabla_markdown += f"\n| {fecha_madrid.strftime('%Y-%m-%d %H:%M:%S')} | {usuario} | {tipo} | {ambito_registro or ''} |"
+            tabla_markdown += f"\n| {fecha_madrid.strftime('%Y-%m-%d %H:%M:%S')} | {usuario} | {tipo} | {ambito_registro or AMBITO_SPIN_GENERAL} |"
         
         tabla_markdown += "```"
         


### PR DESCRIPTION
### Motivation
- Garantizar que los botones persistentes de Spin existentes sigan operando en la cola `GENERAL` sin romper el comportamiento actual.
- Mantener la búsqueda de partidos en las fuentes existentes (`Calendario`, `PlayOffsOro`, `PlayOffsPlata`, `PlayOffsBronce`, `Ticket`, `SuizoEmparejamiento`) y el timeout de 5 minutos tal como está especificado en la lógica.
- Preservar el historial con `tipo = Spin` / `tipo = Encontrado` y añadir `ambito = GENERAL` en despliegues que soporten la nueva columna sin romper esquemas antiguos.

### Description
- Limita la vista persistente registrada en `on_ready` a `UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL)` para que los botones persistentes heredados sigan resolviendo contra `GENERAL` (`LombardBot.py`).
- Modifica `/ultimosspins` para inspeccionar el esquema de la tabla `Spin` y, si la columna `ambito` no existe, presentar los registros heredados como `GENERAL`, y devolver vacío para `Comunidades` en esquemas antiguos (`LombardBot.py`).
- Actualiza `insertar_spin` en `GestorSQL.py` para detectar si la columna `ambito` existe y ejecutar un `INSERT` que incluya `ambito` cuando esté presente, o bien insertar sin esa columna en bases de datos antiguas, manteniendo compatibilidad hacia atrás.
- Añade `import inspect` y manejo de `session.rollback()` en errores durante la inserción para mayor robustez (`GestorSQL.py`).

### Testing
- Ejecuté comprobaciones de sintaxis con `ast.parse` sobre `LombardBot.py`, `GestorSQL.py`, `UtilesDiscord.py` y `SpinConstantes.py` y todas devolvieron `syntax OK` (éxito).
- Compilé los módulos con `python -m py_compile LombardBot.py GestorSQL.py UtilesDiscord.py SpinConstantes.py` y no se reportaron errores (éxito).
- Verifiqué diferencias con `git diff --check` y realicé el commit `Mantener Spin existente como GENERAL` (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3441a4cc90832aa98b08d6f7bf9204)