### PR TITLE
Extrae resolución de partidos de Spin General

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -438,8 +438,14 @@ def _spin_match_desde_partido_general(partido):
     )
 
 
-def buscar_partido_spin_general(session, usuario_db):
-    """Devuelve el partido de Spin General normalizado o ``None``."""
+def resolver_partido_spin_general(session, usuario_db):
+    """Resuelve el partido elegible de Spin General o ``None``.
+
+    ``logicaSpin.md`` define Spin General como la búsqueda agregada en
+    Calendario, PlayOffsOro, PlayOffsPlata, PlayOffsBronce, Ticket y
+    SuizoEmparejamiento, conservando los filtros existentes y devolviendo un
+    ``SpinMatchResult`` normalizado.
+    """
 
     partidos_calendario = session.query(GestorSQL.Calendario).filter(
         or_(GestorSQL.Calendario.coach1 == usuario_db.idUsuarios, GestorSQL.Calendario.coach2 == usuario_db.idUsuarios),
@@ -485,6 +491,12 @@ def buscar_partido_spin_general(session, usuario_db):
         for partido in partidos_calendario + partidos_playoffs_oro + partidos_playoffs_plata + partidos_playoffs_bronce + partidos_ticket + partidos_suizo
     ]
     return min(resultados, key=_clave_orden_spin) if resultados else None
+
+
+def buscar_partido_spin_general(session, usuario_db):
+    """Alias heredado para resolver el partido de Spin General."""
+
+    return resolver_partido_spin_general(session, usuario_db)
 
 
 def buscar_partido_spin_comunidades(session, usuario_db):
@@ -539,7 +551,7 @@ def buscar_partido_spin_comunidades(session, usuario_db):
 def buscar_partido_spin(session, usuario_db, ambito):
     if ambito == AMBITO_SPIN_COMUNIDADES:
         return buscar_partido_spin_comunidades(session, usuario_db)
-    return buscar_partido_spin_general(session, usuario_db)
+    return resolver_partido_spin_general(session, usuario_db)
 
 
 class SpinButtonsView(discord.ui.View):


### PR DESCRIPTION
### Motivation
- Extraer la lógica de búsqueda de partidos generales a una función dedicada siguiendo `logicaSpin.md` para mantener la resolución de Spin General consistente y desacoplarla del callback del botón.

### Description
- Se crea `resolver_partido_spin_general(session, usuario_db)` que centraliza la búsqueda en `Calendario`, `PlayOffsOro`, `PlayOffsPlata`, `PlayOffsBronce`, `Ticket` y `SuizoEmparejamiento` conservando los filtros actuales y normalizando la salida como `SpinMatchResult`.
- La selección entre varios partidos sigue usando `min(resultados, key=_clave_orden_spin)`, priorizando la fecha más cercana cuando existe, y devuelve `None` si no hay coincidencias.
- Se mantiene `buscar_partido_spin_general` como alias heredado que delega en el nuevo `resolver_partido_spin_general` y se actualiza `buscar_partido_spin` para llamar al resolver fuera del callback del botón.

### Testing
- Se compiló el módulo con `python -m py_compile UtilesDiscord.py` y la compilación finalizó correctamente.
- Se ejecutó `git diff --check` y no se encontraron problemas de espacio en blanco ni conflictos en el diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34435b5664832aa5fc8b8e276cb2b0)