### PR TITLE
Add resolver for Spin Comunidades matches and unit tests

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -12,7 +12,7 @@ from sqlalchemy import BIGINT, create_engine, Column, Integer, String, ForeignKe
 from sqlalchemy import and_, or_ ,null
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
-from sqlalchemy.orm import aliased
+from sqlalchemy.orm import aliased, joinedload
 from sqlalchemy.sql import case,func
 
 import GestorSQL
@@ -499,10 +499,20 @@ def buscar_partido_spin_general(session, usuario_db):
     return resolver_partido_spin_general(session, usuario_db)
 
 
-def buscar_partido_spin_comunidades(session, usuario_db):
-    """Devuelve el partido de Spin Comunidades normalizado o ``None``."""
+def resolver_partido_spin_comunidades(session, usuario_db):
+    """Resuelve el partido elegible de Spin Comunidades o ``None``.
 
-    partidos = session.query(GestorSQL.ComunidadesPartido).join(
+    ``logicaSpin.md`` establece que Spin Comunidades debe buscar únicamente en
+    ``ComunidadesPartido`` y devolver un ``SpinMatchResult`` con los datos
+    necesarios del canal, jugadores, partido individual y enfrentamiento.
+    """
+
+    partidos = session.query(GestorSQL.ComunidadesPartido).options(
+        joinedload(GestorSQL.ComunidadesPartido.usuario_local),
+        joinedload(GestorSQL.ComunidadesPartido.usuario_visitante),
+        joinedload(GestorSQL.ComunidadesPartido.enfrentamiento).joinedload(GestorSQL.ComunidadesEnfrentamiento.equipo_a),
+        joinedload(GestorSQL.ComunidadesPartido.enfrentamiento).joinedload(GestorSQL.ComunidadesEnfrentamiento.equipo_b),
+    ).join(
         GestorSQL.ComunidadesEnfrentamiento,
         and_(
             GestorSQL.ComunidadesPartido.enfrentamiento_id == GestorSQL.ComunidadesEnfrentamiento.id,
@@ -515,6 +525,7 @@ def buscar_partido_spin_comunidades(session, usuario_db):
         ),
         GestorSQL.ComunidadesPartido.canal_discord_id != None,
         GestorSQL.ComunidadesPartido.estado.in_(("PENDIENTE", "EN_CURSO")),
+        ~GestorSQL.ComunidadesPartido.estado.in_(("FINALIZADO", "ADMINISTRADO")),
         GestorSQL.ComunidadesPartido.partido_bloodbowl_id == None,
     ).all()
 
@@ -548,9 +559,15 @@ def buscar_partido_spin_comunidades(session, usuario_db):
     return min(resultados, key=_clave_orden_spin) if resultados else None
 
 
+def buscar_partido_spin_comunidades(session, usuario_db):
+    """Alias heredado para resolver el partido de Spin Comunidades."""
+
+    return resolver_partido_spin_comunidades(session, usuario_db)
+
+
 def buscar_partido_spin(session, usuario_db, ambito):
     if ambito == AMBITO_SPIN_COMUNIDADES:
-        return buscar_partido_spin_comunidades(session, usuario_db)
+        return resolver_partido_spin_comunidades(session, usuario_db)
     return resolver_partido_spin_general(session, usuario_db)
 
 

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session
+
+from GestorSQL import (
+    Base,
+    ComunidadesComunidad,
+    ComunidadesEnfrentamiento,
+    ComunidadesEquipo,
+    ComunidadesPartido,
+    ComunidadesRonda,
+    ComunidadesTorneo,
+    Usuario,
+)
+from SpinConstantes import AMBITO_SPIN_COMUNIDADES
+from UtilesDiscord import resolver_partido_spin_comunidades
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+
+    @event.listens_for(engine, "connect")
+    def _activar_foreign_keys(dbapi_connection, _):
+        dbapi_connection.execute("PRAGMA foreign_keys=ON")
+
+    Base.metadata.create_all(engine)
+    return Session(engine), engine
+
+
+def _crear_contexto(session: Session):
+    ahora = datetime(2026, 7, 1, 20, 0)
+    usuarios = [
+        Usuario(idUsuarios=11, id_discord=101, nombre_discord="Local"),
+        Usuario(idUsuarios=12, id_discord=102, nombre_discord="Local 2"),
+        Usuario(idUsuarios=21, id_discord=201, nombre_discord="Visitante"),
+        Usuario(idUsuarios=22, id_discord=202, nombre_discord="Visitante 2"),
+    ]
+    torneo = ComunidadesTorneo(
+        nombre="Copa Spin",
+        rondas_totales=3,
+        fecha_fin_ronda1=ahora + timedelta(days=7),
+        plantilla_mensaje_ronda1="Ronda 1",
+        plantilla_mensaje_rondas_siguientes="Ronda {ronda}",
+        creado_por_discord_id=999,
+    )
+    comunidad_a = ComunidadesComunidad(nombre="Comunidad A")
+    comunidad_b = ComunidadesComunidad(nombre="Comunidad B")
+    equipo_a = ComunidadesEquipo(nombre="Equipo A")
+    equipo_b = ComunidadesEquipo(nombre="Equipo B")
+    comunidad_a.equipos.append(equipo_a)
+    comunidad_b.equipos.append(equipo_b)
+    torneo.comunidades.extend([comunidad_a, comunidad_b])
+    torneo.equipos.extend([equipo_a, equipo_b])
+    ronda = ComunidadesRonda(
+        numero=1,
+        fecha_inicio=ahora,
+        fecha_fin=ahora + timedelta(days=7),
+        generada_por_discord_id=999,
+    )
+    torneo.rondas.append(ronda)
+    session.add_all([*usuarios, torneo])
+    session.flush()
+    enfrentamiento = ComunidadesEnfrentamiento(
+        torneo_id=torneo.id,
+        ronda=ronda,
+        mesa_numero=1,
+        equipo_a=equipo_a,
+        equipo_b=equipo_b,
+    )
+    session.add(enfrentamiento)
+    session.flush()
+    return usuarios, torneo, enfrentamiento, equipo_a, equipo_b, ahora
+
+
+def _partido(torneo, enfrentamiento, equipo_a, equipo_b, local, visitante, *, indice, canal, fecha, estado="PENDIENTE", partido_bloodbowl_id=None):
+    return ComunidadesPartido(
+        torneo_id=torneo.id,
+        enfrentamiento=enfrentamiento,
+        indice=indice,
+        equipo_local=equipo_a,
+        equipo_visitante=equipo_b,
+        usuario_local=local,
+        usuario_visitante=visitante,
+        atacante_usuario=local,
+        defensor_usuario=visitante,
+        canal_discord_id=canal,
+        fecha=fecha,
+        estado=estado,
+        partido_bloodbowl_id=partido_bloodbowl_id,
+    )
+
+
+def test_resolver_partido_spin_comunidades_devuelve_spin_match_result_con_datos_necesarios():
+    session, engine = _session()
+    try:
+        usuarios, torneo, enfrentamiento, equipo_a, equipo_b, ahora = _crear_contexto(session)
+        lejano = _partido(torneo, enfrentamiento, equipo_a, equipo_b, usuarios[0], usuarios[2], indice=1, canal=901, fecha=ahora + timedelta(days=4))
+        cercano = _partido(torneo, enfrentamiento, equipo_a, equipo_b, usuarios[1], usuarios[0], indice=2, canal=902, fecha=ahora + timedelta(days=1), estado="EN_CURSO")
+        session.add_all([lejano, cercano])
+        session.commit()
+
+        resultado = resolver_partido_spin_comunidades(session, usuarios[0])
+
+        assert resultado.ambito == AMBITO_SPIN_COMUNIDADES
+        assert resultado.partido_id == cercano.id
+        assert resultado.canal_partido_id == 902
+        assert resultado.jugador1_discord_id == 102
+        assert resultado.jugador2_discord_id == 101
+        assert resultado.indice_partido == 2
+        assert resultado.enfrentamiento_id == enfrentamiento.id
+        assert resultado.torneo_id == torneo.id
+        assert resultado.equipo_a_nombre == "Equipo A"
+        assert resultado.equipo_b_nombre == "Equipo B"
+        assert "partido individual 2" in resultado.descripcion_corta
+        assert "Equipo A vs Equipo B" in resultado.descripcion_corta
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def test_resolver_partido_spin_comunidades_filtra_no_elegibles():
+    session, engine = _session()
+    try:
+        usuarios, torneo, enfrentamiento, equipo_a, equipo_b, ahora = _crear_contexto(session)
+        session.add_all([
+            _partido(torneo, enfrentamiento, equipo_a, equipo_b, usuarios[0], usuarios[2], indice=1, canal=None, fecha=ahora),
+            _partido(torneo, enfrentamiento, equipo_a, equipo_b, usuarios[1], usuarios[3], indice=2, canal=902, fecha=ahora),
+        ])
+        session.commit()
+
+        assert resolver_partido_spin_comunidades(session, usuarios[0]) is None
+    finally:
+        session.close()
+        engine.dispose()


### PR DESCRIPTION
### Motivation
- Implement Spin Comunidades lookup according to `logicaSpin.md` so the Spin flow can find eligible `ComunidadesPartido` records and return a stable `SpinMatchResult` structure. 
- Ensure the resolver loads all data needed by the Spin UI (Discord IDs, partido index, equipo names, enfrentamiento and channel) and applies the exact eligibility filters defined in the spec.

### Description
- Added `resolver_partido_spin_comunidades(session, usuario_db)` in `UtilesDiscord.py` which queries `GestorSQL.ComunidadesPartido`, eager-loads related users and enfrentamiento teams with `joinedload`, applies filters for participation, non-null `canal_discord_id`, allowed `estado` (`PENDIENTE` or `EN_CURSO`) while explicitly excluding `FINALIZADO`/`ADMINISTRADO`, and requires `partido_bloodbowl_id` to be `NULL`. 
- Normalizes each match into a `SpinMatchResult` populated with `canal_partido_id`, both players' Discord IDs, `indice_partido`, `equipo_a_nombre`/`equipo_b_nombre`, `enfrentamiento_id`, `torneo_id`, `partido_id` and descriptive text. 
- Uses the existing `_clave_orden_spin` ordering when multiple candidates exist so the closest-date match is chosen when dates are present. 
- Keeps `buscar_partido_spin_comunidades` as a legacy alias and routes the COMUNIDADES branch in `buscar_partido_spin` to the new resolver. 
- Adds unit tests in `tests/test_spin_comunidades.py` that cover correct `SpinMatchResult` contents, nearest-date selection, and filtering of non-eligible matches.

### Testing
- Successfully type-checked/compiled with `python3 -m py_compile UtilesDiscord.py tests/test_spin_comunidades.py` which passed without syntax errors. 
- Attempted to run `pytest -q tests/test_spin_comunidades.py` but the run could not complete in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'sqlalchemy'`).
- The new tests exercise selection and filtering logic and are designed to pass in an environment with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3443dbec5c832ab915fdf0ac64510c)