### PR TITLE
Separar resolución de Spin por ámbito

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -565,10 +565,27 @@ def buscar_partido_spin_comunidades(session, usuario_db):
     return resolver_partido_spin_comunidades(session, usuario_db)
 
 
-def buscar_partido_spin(session, usuario_db, ambito):
-    if ambito == AMBITO_SPIN_COMUNIDADES:
+def resolver_partido_spin(session, usuario_db, ambito):
+    """Resuelve el partido de Spin delegando exclusivamente por ámbito.
+
+    ``logicaSpin.md`` exige que cada cola busque solo en su proveedor: General
+    en competiciones generales y Comunidades en ``ComunidadesPartido``. Un
+    ámbito no reconocido se considera error controlado para evitar caer por
+    defecto en General y mezclar fuentes.
+    """
+
+    ambito_normalizado = normalizar_ambito_spin(ambito)
+    if ambito_normalizado == AMBITO_SPIN_GENERAL:
+        return resolver_partido_spin_general(session, usuario_db)
+    if ambito_normalizado == AMBITO_SPIN_COMUNIDADES:
         return resolver_partido_spin_comunidades(session, usuario_db)
-    return resolver_partido_spin_general(session, usuario_db)
+    raise ValueError(f"Ámbito de Spin no válido: {ambito!r}")
+
+
+def buscar_partido_spin(session, usuario_db, ambito):
+    """Alias heredado para resolver el partido de Spin por ámbito."""
+
+    return resolver_partido_spin(session, usuario_db, ambito)
 
 
 class SpinButtonsView(discord.ui.View):
@@ -637,7 +654,11 @@ class SpinButtonsView(discord.ui.View):
                 await interaction.followup.send("No se encontró tu usuario en la base de datos.", ephemeral=True)
                 return
 
-            partido_spin = buscar_partido_spin(session, usuario_db, ambito)
+            try:
+                partido_spin = buscar_partido_spin(session, usuario_db, ambito)
+            except ValueError:
+                await interaction.followup.send("El ámbito de Spin no es válido. Avise a un administrador.", ephemeral=True)
+                return
             if not partido_spin:
                 await interaction.followup.send("No tienes ningún partido pendiente en esta cola de Spin.", ephemeral=True)
                 return

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -135,3 +135,58 @@ def test_resolver_partido_spin_comunidades_filtra_no_elegibles():
     finally:
         session.close()
         engine.dispose()
+
+
+def test_resolver_partido_spin_delega_solo_en_general(monkeypatch):
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL
+
+    llamadas = []
+
+    def resolver_general(session, usuario_db):
+        llamadas.append("general")
+        return "partido-general"
+
+    def resolver_comunidades(session, usuario_db):
+        llamadas.append("comunidades")
+        return "partido-comunidades"
+
+    monkeypatch.setattr(UtilesDiscord, "resolver_partido_spin_general", resolver_general)
+    monkeypatch.setattr(UtilesDiscord, "resolver_partido_spin_comunidades", resolver_comunidades)
+
+    assert UtilesDiscord.resolver_partido_spin(object(), object(), AMBITO_SPIN_GENERAL) == "partido-general"
+    assert llamadas == ["general"]
+
+
+def test_resolver_partido_spin_delega_solo_en_comunidades(monkeypatch):
+    import UtilesDiscord
+
+    llamadas = []
+
+    def resolver_general(session, usuario_db):
+        llamadas.append("general")
+        return "partido-general"
+
+    def resolver_comunidades(session, usuario_db):
+        llamadas.append("comunidades")
+        return "partido-comunidades"
+
+    monkeypatch.setattr(UtilesDiscord, "resolver_partido_spin_general", resolver_general)
+    monkeypatch.setattr(UtilesDiscord, "resolver_partido_spin_comunidades", resolver_comunidades)
+
+    assert UtilesDiscord.resolver_partido_spin(object(), object(), "Comunidades") == "partido-comunidades"
+    assert llamadas == ["comunidades"]
+
+
+def test_resolver_partido_spin_rechaza_ambito_no_valido(monkeypatch):
+    import pytest
+    import UtilesDiscord
+
+    def resolver_no_debe_llamarse(session, usuario_db):
+        raise AssertionError("No debe consultar proveedores con un ámbito no válido")
+
+    monkeypatch.setattr(UtilesDiscord, "resolver_partido_spin_general", resolver_no_debe_llamarse)
+    monkeypatch.setattr(UtilesDiscord, "resolver_partido_spin_comunidades", resolver_no_debe_llamarse)
+
+    with pytest.raises(ValueError, match="Ámbito de Spin no válido"):
+        UtilesDiscord.resolver_partido_spin(object(), object(), "Ticket")


### PR DESCRIPTION
### Motivation
- Implementar la lógica de `logicaSpin.md` que exige que cada cola de Spin busque únicamente en su proveedor correspondiente (GENERAL vs COMUNIDADES). 
- Evitar que ámbitos inválidos caigan por defecto en la búsqueda general y prevenir mezclas de proveedores. 
- Preparar la interfaz para comportarse de forma controlada si la configuración de ámbito es incorrecta. 

### Description
- Añadida la función `resolver_partido_spin(session, usuario_db, ambito)` que normaliza `ambito` y delega exclusivamente en `resolver_partido_spin_general` o `resolver_partido_spin_comunidades`, y lanza `ValueError` para ámbitos no válidos. 
- Conservado `buscar_partido_spin` como alias heredado que llama a `resolver_partido_spin` para compatibilidad. 
- Modificado el callback del botón `Spin` para capturar `ValueError` y devolver un mensaje efímero indicando que el ámbito no es válido en lugar de mezclar proveedores. 
- Añadidos tests en `tests/test_spin_comunidades.py` que verifican la delegación exclusiva por ámbito y que un ámbito no válido no consulta otros proveedores. 

### Testing
- Ejecutado `PYTHONPATH=. pytest -q tests/test_spin_comunidades.py` y todos los tests nuevos y relacionados pasaron (`5 passed`, `4 warnings`). 
- Ejecutado `PYTHONPATH=. pytest -q` sobre la suite completa; la mayoría de tests pasaron pero hay 5 fallos en pruebas de flujo/estados de Comunidades (`test_zombificacion_y_kill_se_resuelven_con_la_fotografia_inicial`, `test_ciclo_de_dos_rondas_desde_inscripcion_hasta_final_con_snapshots`, `test_bye_y_regeneracion_revierten_todo_el_estado_de_la_ronda`, `test_transferencia_tras_cerrar_ambos_enfrentamientos_es_idempotente`, `test_api_mockeada_registra_los_dos_resultados_sin_red`), los cuales parecen no estar relacionados con esta modificación de resolución por ámbito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3444c52dfc832abab1fae63061097c)