### PR TITLE
Parametrizar SpinButtonsView por ámbito y registrar vistas para GENERAL/COMUNIDADES

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -221,9 +221,10 @@ async def reloj_de_cuco():
 
 @bot.event
 async def on_ready():
-    # Los botones persistentes existentes (`your_bot:spin` / `your_bot:encontrado`)
-    # pertenecen al Spin heredado, que debe seguir operando como GENERAL.
+    # Registramos una misma vista parametrizada por ámbito. Los custom_id heredados
+    # siguen apuntando a GENERAL y Comunidades usa identificadores propios.
     bot.add_view(UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL))
+    bot.add_view(UtilesDiscord.SpinButtonsView(AMBITO_SPIN_COMUNIDADES))
     await bot.tree.sync()
     #await GestionExcel.ActualizarExcels()
     if not programador_tareas.is_running():

--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -589,12 +589,37 @@ def buscar_partido_spin(session, usuario_db, ambito):
 
 
 class SpinButtonsView(discord.ui.View):
+    CUSTOM_ID_SPIN_LEGACY = 'your_bot:spin'
+    CUSTOM_ID_ENCONTRADO_LEGACY = 'your_bot:encontrado'
+
     def __init__(self, ambito=AMBITO_SPIN_GENERAL):
         super().__init__(timeout=None)
         self.ambito = normalizar_ambito_spin(ambito) or AMBITO_SPIN_GENERAL
+        self._aplicar_ambito_a_botones()
 
     def nombre_ambito(self):
         return "Spin Comunidades" if self.ambito == AMBITO_SPIN_COMUNIDADES else "Spin General"
+
+    def sufijo_custom_id(self):
+        return self.ambito.casefold()
+
+    def custom_id_spin(self):
+        if self.ambito == AMBITO_SPIN_GENERAL:
+            return self.CUSTOM_ID_SPIN_LEGACY
+        return f"lombardbot:spin:{self.sufijo_custom_id()}"
+
+    def custom_id_encontrado(self):
+        if self.ambito == AMBITO_SPIN_GENERAL:
+            return self.CUSTOM_ID_ENCONTRADO_LEGACY
+        return f"lombardbot:encontrado:{self.sufijo_custom_id()}"
+
+    def _aplicar_ambito_a_botones(self):
+        for child in self.children:
+            if isinstance(child, discord.ui.Button):
+                if child.label == "Spin":
+                    child.custom_id = self.custom_id_spin()
+                elif child.label == "Encontrado":
+                    child.custom_id = self.custom_id_encontrado()
 
     async def auto_release_spin(self, ambito, user, mensaje_botones=None):
         await asyncio.sleep(300)  # Espera 5 minutos

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -190,3 +190,25 @@ def test_resolver_partido_spin_rechaza_ambito_no_valido(monkeypatch):
 
     with pytest.raises(ValueError, match="Ámbito de Spin no válido"):
         UtilesDiscord.resolver_partido_spin(object(), object(), "Ticket")
+
+
+def test_spin_buttons_view_parametriza_custom_ids_por_ambito():
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL, AMBITO_SPIN_COMUNIDADES
+
+    vista_general = UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL)
+    vista_comunidades = UtilesDiscord.SpinButtonsView(AMBITO_SPIN_COMUNIDADES)
+
+    ids_general = {boton.label: boton.custom_id for boton in vista_general.children}
+    ids_comunidades = {boton.label: boton.custom_id for boton in vista_comunidades.children}
+
+    assert vista_general.ambito == AMBITO_SPIN_GENERAL
+    assert vista_comunidades.ambito == AMBITO_SPIN_COMUNIDADES
+    assert ids_general == {
+        "Spin": "your_bot:spin",
+        "Encontrado": "your_bot:encontrado",
+    }
+    assert ids_comunidades == {
+        "Spin": "lombardbot:spin:comunidades",
+        "Encontrado": "lombardbot:encontrado:comunidades",
+    }


### PR DESCRIPTION
### Motivation
- Reutilizar una única vista de botones para `Spin General` y `Spin Comunidades` según lo definido en `logicaSpin.md`, evitando duplicar la clase para comunidades.
- Garantizar que la UI y la lógica usan el `ambito` de la instancia para botones, reserva, mensajes, historial y timeout.

### Description
- `SpinButtonsView` ahora aplica el `ambito` almacenado a los `custom_id` de los botones y conserva compatibilidad con los `custom_id` legacy de `GENERAL` mediante `custom_id_spin()` y `custom_id_encontrado()`; la lógica se centraliza en `_aplicar_ambito_a_botones()` (modificaciones en `UtilesDiscord.py`).
- La instancia guarda el `ambito` en `self.ambito` y la vista usa ese `ambito` para las operaciones de `Spin`, `Encontrado`, reserva y timeout (sin crear una clase duplicada para Comunidades). 
- En el arranque del bot se registran vistas persistentes para ambos ámbitos llamando a `bot.add_view(UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL))` y `bot.add_view(UtilesDiscord.SpinButtonsView(AMBITO_SPIN_COMUNIDADES))` (cambio en `LombardBot.py`).
- Añadida prueba `test_spin_buttons_view_parametriza_custom_ids_por_ambito` que verifica que las vistas `GENERAL` y `COMUNIDADES` mantienen su `ambito` y generan los `custom_id` esperados (nuevo código en `tests/test_spin_comunidades.py`).

### Testing
- Se ejecutó la comprobación de sintaxis con `python -m py_compile SpinConstantes.py UtilesDiscord.py LombardBot.py`, que pasó correctamente. 
- Se intentó lanzar `pytest -q tests/test_spin_comunidades.py`, pero la ejecución falló en este entorno por falta de la dependencia `sqlalchemy` (error reproducible: `ModuleNotFoundError: No module named 'sqlalchemy'`).
- Se añadió y commitó el cambio en el repositorio (`Parametrize spin view by scope`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3445d69c08832a8872f4692e27b410)