### PR TITLE
Diferenciar botones persistentes de Spin por ámbito

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -221,8 +221,8 @@ async def reloj_de_cuco():
 
 @bot.event
 async def on_ready():
-    # Registramos una misma vista parametrizada por ámbito. Los custom_id heredados
-    # siguen apuntando a GENERAL y Comunidades usa identificadores propios.
+    # Registramos vistas persistentes separadas por ámbito. Cada una usa custom_id
+    # propio para evitar conflictos entre Spin General y Spin Comunidades.
     bot.add_view(UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL))
     bot.add_view(UtilesDiscord.SpinButtonsView(AMBITO_SPIN_COMUNIDADES))
     await bot.tree.sync()
@@ -1818,13 +1818,17 @@ async def actualizar_configuracion(ctx):
 
 @bot.command(name="AgregarVista")
 @commands.has_any_role('Moderadores', 'Administrador', 'Comisario')
-async def agregar_vista(ctx, message_id: int):
+async def agregar_vista(ctx, message_id: int, ambito: str = "General"):
     # Intenta obtener el mensaje objetivo y añadirle la vista
     try:
+        ambito_normalizado = normalizar_ambito_spin(ambito)
+        if not ambito_normalizado:
+            await ctx.send("Ámbito de Spin no válido. Usa General o Comunidades.", delete_after=20)
+            return
         # Obten el canal y luego el mensaje usando el ID proporcionado
         message = await ctx.channel.fetch_message(message_id)
-        # Edita el mensaje para añadir la vista
-        await message.edit(view=UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL))
+        # Edita el mensaje para añadir la vista del ámbito indicado
+        await message.edit(view=UtilesDiscord.SpinButtonsView(ambito_normalizado))
         # Borra el mensaje que invocó el comando
         await ctx.message.delete()
         # Envía confirmación y luego borra ese mensaje después de 20 segundos

--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -589,9 +589,6 @@ def buscar_partido_spin(session, usuario_db, ambito):
 
 
 class SpinButtonsView(discord.ui.View):
-    CUSTOM_ID_SPIN_LEGACY = 'your_bot:spin'
-    CUSTOM_ID_ENCONTRADO_LEGACY = 'your_bot:encontrado'
-
     def __init__(self, ambito=AMBITO_SPIN_GENERAL):
         super().__init__(timeout=None)
         self.ambito = normalizar_ambito_spin(ambito) or AMBITO_SPIN_GENERAL
@@ -604,13 +601,9 @@ class SpinButtonsView(discord.ui.View):
         return self.ambito.casefold()
 
     def custom_id_spin(self):
-        if self.ambito == AMBITO_SPIN_GENERAL:
-            return self.CUSTOM_ID_SPIN_LEGACY
         return f"lombardbot:spin:{self.sufijo_custom_id()}"
 
     def custom_id_encontrado(self):
-        if self.ambito == AMBITO_SPIN_GENERAL:
-            return self.CUSTOM_ID_ENCONTRADO_LEGACY
         return f"lombardbot:encontrado:{self.sufijo_custom_id()}"
 
     def _aplicar_ambito_a_botones(self):
@@ -620,6 +613,7 @@ class SpinButtonsView(discord.ui.View):
                     child.custom_id = self.custom_id_spin()
                 elif child.label == "Encontrado":
                     child.custom_id = self.custom_id_encontrado()
+                    child.disabled = True
 
     async def auto_release_spin(self, ambito, user, mensaje_botones=None):
         await asyncio.sleep(300)  # Espera 5 minutos
@@ -660,7 +654,7 @@ class SpinButtonsView(discord.ui.View):
             return mensaje  #primer mensaje encontrado
         return None  #None si no hay mensajes
 
-    @discord.ui.button(label="Spin", style=discord.ButtonStyle.green, custom_id='your_bot:spin')
+    @discord.ui.button(label="Spin", style=discord.ButtonStyle.green, custom_id='lombardbot:spin:general')
     async def spin_callback(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.defer()
         ambito = self.ambito
@@ -717,7 +711,7 @@ class SpinButtonsView(discord.ui.View):
         finally:
             session.close()
 
-    @discord.ui.button(label="Encontrado", style=discord.ButtonStyle.blurple, custom_id='your_bot:encontrado')
+    @discord.ui.button(label="Encontrado", style=discord.ButtonStyle.blurple, custom_id='lombardbot:encontrado:general', disabled=True)
     async def encontrado_callback(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.defer()
         user = interaction.user

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -205,10 +205,33 @@ def test_spin_buttons_view_parametriza_custom_ids_por_ambito():
     assert vista_general.ambito == AMBITO_SPIN_GENERAL
     assert vista_comunidades.ambito == AMBITO_SPIN_COMUNIDADES
     assert ids_general == {
-        "Spin": "your_bot:spin",
-        "Encontrado": "your_bot:encontrado",
+        "Spin": "lombardbot:spin:general",
+        "Encontrado": "lombardbot:encontrado:general",
     }
     assert ids_comunidades == {
         "Spin": "lombardbot:spin:comunidades",
         "Encontrado": "lombardbot:encontrado:comunidades",
+    }
+
+
+def test_spin_buttons_view_no_usa_custom_ids_heredados():
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL, AMBITO_SPIN_COMUNIDADES
+
+    ids = {
+        boton.custom_id
+        for vista in (
+            UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL),
+            UtilesDiscord.SpinButtonsView(AMBITO_SPIN_COMUNIDADES),
+        )
+        for boton in vista.children
+    }
+
+    assert "your_bot:spin" not in ids
+    assert "your_bot:encontrado" not in ids
+    assert ids == {
+        "lombardbot:spin:general",
+        "lombardbot:encontrado:general",
+        "lombardbot:spin:comunidades",
+        "lombardbot:encontrado:comunidades",
     }


### PR DESCRIPTION
### Motivation
- Cumplir `logicaSpin.md` para que Discord distinga botones persistentes por ámbito (`GENERAL` vs `COMUNIDADES`) y evitar colisiones entre vistas.
- Usar `custom_id` que incluyan el ámbito para permitir registrar vistas persistentes independientes y facilitar la republicación operativa de mensajes de Spin.

### Description
- `SpinButtonsView` ahora genera `custom_id` basados en ámbito (`lombardbot:spin:general`, `lombardbot:encontrado:general`, `lombardbot:spin:comunidades`, `lombardbot:encontrado:comunidades`) y ya no usa los IDs heredados `your_bot:*`.
- Se actualizó el decorador de botones persistentes para el caso por defecto a `lombardbot:spin:general` y `lombardbot:encontrado:general` y el botón `Encontrado` queda deshabilitado inicialmente.
- `agregar_vista` acepta ahora un parámetro `ambito`, valida con `normalizar_ambito_spin` y aplica la `SpinButtonsView(ambito_normalizado)` al mensaje indicado; `AgregaMensajeSpin` publica el mensaje de Spin con la vista del ámbito correspondiente para facilitar republicación.
- Tests: se ajustaron expectativas en `tests/test_spin_comunidades.py` para los nuevos `custom_id` y se añadió `test_spin_buttons_view_no_usa_custom_ids_heredados` que asegura que los `your_bot:*` ya no aparecen.

### Testing
- Ejecuté `PYTHONDONTWRITEBYTECODE=1 python -m pytest tests/test_spin_comunidades.py -q` y los tests específicos de Spin pasaron (`7 passed`, incluyendo la nueva comprobación).
- Ejecuté la batería completa `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q`; el conjunto global mostró 5 fallos en tests de integración de comunidades no relacionados con estos cambios (errores tipo `ENFRENTAMIENTO_NO_ADMITE_RESULTADOS` y problemas de regeneración/nivel_fallback), mientras que el resto del suite pasó (`470 passed, 5 failed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3446b6cdfc832aae528de9b105c4bc)