### PR TITLE
Registrar vistas persistentes de Spin por ámbito

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -156,6 +156,21 @@ intents.reactions = True
 # Crear e inicializar el bot
 bot = DiscordClientSingleton.initialize(discord_bot_token, intents)
 
+
+def registrar_vistas_persistentes_spin(bot_discord):
+    """Registra una vista persistente de Spin por cada ámbito soportado.
+
+    Las reservas activas no se restauran aquí deliberadamente: viven solo en
+    memoria, así que tras reiniciar el proceso ambas colas vuelven a estar
+    libres.
+    """
+
+    # Cada vista se instancia con su ámbito para que Discord pueda enrutar las
+    # interacciones persistentes usando custom_id distintos por mensaje.
+    bot_discord.add_view(UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL))
+    bot_discord.add_view(UtilesDiscord.SpinButtonsView(AMBITO_SPIN_COMUNIDADES))
+
+
 #Lista de usuarios con permisos
 maestros = ["208239645014753280","681577610010296372","1297346191130103859"]
 
@@ -221,10 +236,7 @@ async def reloj_de_cuco():
 
 @bot.event
 async def on_ready():
-    # Registramos vistas persistentes separadas por ámbito. Cada una usa custom_id
-    # propio para evitar conflictos entre Spin General y Spin Comunidades.
-    bot.add_view(UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL))
-    bot.add_view(UtilesDiscord.SpinButtonsView(AMBITO_SPIN_COMUNIDADES))
+    registrar_vistas_persistentes_spin(bot)
     await bot.tree.sync()
     #await GestionExcel.ActualizarExcels()
     if not programador_tareas.is_running():

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -235,3 +235,17 @@ def test_spin_buttons_view_no_usa_custom_ids_heredados():
         "lombardbot:spin:comunidades",
         "lombardbot:encontrado:comunidades",
     }
+
+
+def test_reservas_spin_arrancan_liberadas_tras_cargar_modulo():
+    import importlib
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL, AMBITO_SPIN_COMUNIDADES
+
+    UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = object()
+    UtilesDiscord.reservas_spin[AMBITO_SPIN_COMUNIDADES] = object()
+
+    UtilesDiscord = importlib.reload(UtilesDiscord)
+
+    assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_GENERAL) is None
+    assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_COMUNIDADES) is None


### PR DESCRIPTION
### Motivation
- Asegurar que ambos mensajes con botones (GENERAL y COMUNIDADES) sigan funcionando tras reiniciar el proceso registrando las vistas persistentes con `bot.add_view` por cada ámbito.
- Dejar claro que las reservas viven solo en memoria y por tanto se consideran liberadas tras un reinicio del proceso.

### Description
- Añade la función helper `registrar_vistas_persistentes_spin(bot_discord)` que instancia y registra `SpinButtonsView` para `AMBITO_SPIN_GENERAL` y `AMBITO_SPIN_COMUNIDADES` en `LombardBot.py`.
- Reemplaza las llamadas directas a `bot.add_view(...)` en `on_ready` por una llamada a `registrar_vistas_persistentes_spin(bot)` para centralizar el registro.
- Añade la prueba `test_reservas_spin_arrancan_liberadas_tras_cargar_modulo` en `tests/test_spin_comunidades.py` que comprueba que las reservas en `UtilesDiscord.reservas_spin` quedan `None` tras recargar el módulo.
- Documenta en el helper que las reservas activas no se restauran y por tanto ambas colas arrancan libres tras reinicio.

### Testing
- Ejecutado `PYTHONPATH=. pytest tests/test_spin_comunidades.py` y la suite específica de spin pasó localmente (`8 passed`).
- Ejecutado `PYTHONPATH=. pytest` sobre todo el repositorio y la ejecución informó que 471 pruebas pasaron, 1 se saltó y hubo 5 fallos en tests de `comunidades` que son preexistentes y no están relacionados con este cambio; el resto de la suite pasó.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3447f77f20832a8b696d33a5ea8217)