### PR TITLE
Aislar reservas de Spin por ámbito

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -76,11 +76,19 @@ reservas_spin = {
     AMBITO_SPIN_GENERAL: None,
     AMBITO_SPIN_COMUNIDADES: None,
 }
+bloqueos_reservas_spin = {
+    AMBITO_SPIN_GENERAL: asyncio.Lock(),
+    AMBITO_SPIN_COMUNIDADES: asyncio.Lock(),
+}
 UsuarioSpin = None
 
 
 def obtener_reserva_spin(ambito):
     return reservas_spin.get(ambito)
+
+
+def obtener_bloqueo_reserva_spin(ambito):
+    return bloqueos_reservas_spin[ambito]
 
 
 def guardar_reserva_spin(reserva):
@@ -660,56 +668,57 @@ class SpinButtonsView(discord.ui.View):
         ambito = self.ambito
         user = interaction.user
 
-        if obtener_reserva_spin(ambito) is not None:
-            await interaction.followup.send(f'{user.mention}, ya hay un partido reservado en esta cola de Spin.', ephemeral=True)
-            return
-
-        Session = GestorSQL.sessionmaker(bind=GestorSQL.conexionEngine())
-        session = Session()
-        timeout_task = None
-        try:
-            usuario_db = session.query(GestorSQL.Usuario).filter(GestorSQL.Usuario.id_discord == user.id).first()
-            if not usuario_db:
-                await interaction.followup.send("No se encontró tu usuario en la base de datos.", ephemeral=True)
+        async with obtener_bloqueo_reserva_spin(ambito):
+            if obtener_reserva_spin(ambito) is not None:
+                await interaction.followup.send('Ya hay un usuario buscando partido en esta cola.', ephemeral=True)
                 return
 
+            Session = GestorSQL.sessionmaker(bind=GestorSQL.conexionEngine())
+            session = Session()
+            timeout_task = None
             try:
-                partido_spin = buscar_partido_spin(session, usuario_db, ambito)
-            except ValueError:
-                await interaction.followup.send("El ámbito de Spin no es válido. Avise a un administrador.", ephemeral=True)
-                return
-            if not partido_spin:
-                await interaction.followup.send("No tienes ningún partido pendiente en esta cola de Spin.", ephemeral=True)
-                return
+                usuario_db = session.query(GestorSQL.Usuario).filter(GestorSQL.Usuario.id_discord == user.id).first()
+                if not usuario_db:
+                    await interaction.followup.send("No se encontró tu usuario en la base de datos.", ephemeral=True)
+                    return
 
-            canal_partido_id = partido_spin.canal_partido_id
-            coach1_id_discord = partido_spin.jugador1_discord_id
-            coach2_id_discord = partido_spin.jugador2_discord_id
+                try:
+                    partido_spin = buscar_partido_spin(session, usuario_db, ambito)
+                except ValueError:
+                    await interaction.followup.send("El ámbito de Spin no es válido. Avise a un administrador.", ephemeral=True)
+                    return
+                if not partido_spin:
+                    await interaction.followup.send("No tienes ningún partido pendiente en esta cola de Spin.", ephemeral=True)
+                    return
 
-            canal_partido = interaction.guild.get_channel(canal_partido_id) if canal_partido_id else None
-            descripcion_partido = partido_spin.descripcion_corta
-            timeout_task = asyncio.create_task(self.auto_release_spin(ambito, user, interaction.message))
-            reserva = SpinReservation(ambito, user, coach1_id_discord, coach2_id_discord, interaction.channel, canal_partido, descripcion_partido, timeout_task, partido_spin)
-            guardar_reserva_spin(reserva)
+                canal_partido_id = partido_spin.canal_partido_id
+                coach1_id_discord = partido_spin.jugador1_discord_id
+                coach2_id_discord = partido_spin.jugador2_discord_id
 
-            if canal_partido:
-                if ambito == AMBITO_SPIN_COMUNIDADES:
-                    await canal_partido.send(f'<@{coach1_id_discord}> y <@{coach2_id_discord}> podéis spinear vuestro partido de comunidades.')
-                else:
-                    await canal_partido.send(f'<@{coach1_id_discord}> y <@{coach2_id_discord}> podéis spinear')
+                canal_partido = interaction.guild.get_channel(canal_partido_id) if canal_partido_id else None
+                descripcion_partido = partido_spin.descripcion_corta
+                timeout_task = asyncio.create_task(self.auto_release_spin(ambito, user, interaction.message))
+                reserva = SpinReservation(ambito, user, coach1_id_discord, coach2_id_discord, interaction.channel, canal_partido, descripcion_partido, timeout_task, partido_spin)
+                guardar_reserva_spin(reserva)
 
-            self.actualizar_botones(spin_habilitado=False)
-            await interaction.message.edit(view=self)
+                if canal_partido:
+                    if ambito == AMBITO_SPIN_COMUNIDADES:
+                        await canal_partido.send(f'<@{coach1_id_discord}> y <@{coach2_id_discord}> podéis spinear vuestro partido de comunidades.')
+                    else:
+                        await canal_partido.send(f'<@{coach1_id_discord}> y <@{coach2_id_discord}> podéis spinear')
 
-            primer_mensaje = await self.obtener_primer_mensaje(interaction.channel)
-            if primer_mensaje:
-                await primer_mensaje.edit(content=descripcion_partido)
+                self.actualizar_botones(spin_habilitado=False)
+                await interaction.message.edit(view=self)
 
-            await interaction.followup.send(f"Ahora puedes buscar partido en {self.nombre_ambito()}.", ephemeral=True)
-            thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Spin', ambito))
-            thread.start()
-        finally:
-            session.close()
+                primer_mensaje = await self.obtener_primer_mensaje(interaction.channel)
+                if primer_mensaje:
+                    await primer_mensaje.edit(content=descripcion_partido)
+
+                await interaction.followup.send(f"Ahora puedes buscar partido en {self.nombre_ambito()}.", ephemeral=True)
+                thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Spin', ambito))
+                thread.start()
+            finally:
+                session.close()
 
     @discord.ui.button(label="Encontrado", style=discord.ButtonStyle.blurple, custom_id='lombardbot:encontrado:general', disabled=True)
     async def encontrado_callback(self, interaction: discord.Interaction, button: discord.ui.Button):

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
+import pytest
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session
 
@@ -248,4 +249,47 @@ def test_reservas_spin_arrancan_liberadas_tras_cargar_modulo():
     UtilesDiscord = importlib.reload(UtilesDiscord)
 
     assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_GENERAL) is None
+    assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_COMUNIDADES) is None
+
+
+def test_reservas_spin_tienen_bloqueos_independientes_por_ambito():
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL, AMBITO_SPIN_COMUNIDADES
+
+    assert UtilesDiscord.obtener_bloqueo_reserva_spin(AMBITO_SPIN_GENERAL) is not UtilesDiscord.obtener_bloqueo_reserva_spin(AMBITO_SPIN_COMUNIDADES)
+
+
+@pytest.mark.asyncio
+async def test_spin_callback_con_reserva_activa_solo_responde_en_esa_cola(monkeypatch):
+    from types import SimpleNamespace
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL, AMBITO_SPIN_COMUNIDADES
+
+    mensajes = []
+
+    class Response:
+        async def defer(self):
+            pass
+
+    class Followup:
+        async def send(self, mensaje, *, ephemeral=False):
+            mensajes.append((mensaje, ephemeral))
+
+    UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = object()
+    UtilesDiscord.reservas_spin[AMBITO_SPIN_COMUNIDADES] = None
+    monkeypatch.setattr(UtilesDiscord.GestorSQL, "conexionEngine", lambda: (_ for _ in ()).throw(AssertionError("No debe consultar la base de datos si la cola está reservada")))
+
+    vista = UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL)
+    interaction = SimpleNamespace(
+        response=Response(),
+        followup=Followup(),
+        user=SimpleNamespace(id=123, mention="<@123>", name="Usuario"),
+    )
+
+    try:
+        await vista.spin_callback(interaction, None)
+    finally:
+        UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = None
+
+    assert mensajes == [("Ya hay un usuario buscando partido en esta cola.", True)]
     assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_COMUNIDADES) is None


### PR DESCRIPTION
### Motivation
- Alinear la implementación con `logicaSpin.md` para que las colas `GENERAL` y `COMUNIDADES` sean independientes y no se bloqueen entre sí.
- Evitar que una pulsación concurrente de `Spin` en una cola haga consultas a la base de datos o afecte a la otra cola cuando ya existe una reserva activa.

### Description
- Añadido un diccionario de locks `bloqueos_reservas_spin` con `asyncio.Lock()` por ámbito y la función `obtener_bloqueo_reserva_spin(ambito)` para obtener el lock correspondiente.
- Envuelto el flujo de `spin_callback` en `async with obtener_bloqueo_reserva_spin(ambito):` para serializar solo las pulsaciones dentro del mismo ámbito y devolver la respuesta efímera exacta `Ya hay un usuario buscando partido en esta cola.` cuando la cola ya está reservada.
- Mantiene la búsqueda de `usuario` y la resolución de `partido` exclusivamente para el ámbito de la vista y crea la `SpinReservation` solo para ese ámbito.
- Añadidas pruebas en `tests/test_spin_comunidades.py`: `test_reservas_spin_tienen_bloqueos_independientes_por_ambito` y `test_spin_callback_con_reserva_activa_solo_responde_en_esa_cola`, y se importó `pytest` para el test async.

### Testing
- Se compiló el código con `python -m py_compile UtilesDiscord.py tests/test_spin_comunidades.py` satisfactoriamente.
- Se ejecutó la verificación de diferencias con `git diff --check` sin problemas.
- Intenté ejecutar `pytest -q tests/test_spin_comunidades.py` pero la ejecución quedó bloqueada por dependencias ausentes en el entorno (`ModuleNotFoundError: No module named 'sqlalchemy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a344946889c832ab681e683ac1d28c4)