### PR TITLE
Limita Encontrado al ámbito reservado

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -724,22 +724,27 @@ class SpinButtonsView(discord.ui.View):
     async def encontrado_callback(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.defer()
         user = interaction.user
+        # El ámbito de la vista identifica de forma inequívoca la cola a liberar.
+        # No se consulta ni se modifica ninguna reserva fuera de esta clave.
         ambito = self.ambito
-        reserva = obtener_reserva_spin(ambito)
 
-        if not reserva:
-            await interaction.followup.send("No hay ningún Spin reservado en esta cola.", ephemeral=True)
-            return
+        async with obtener_bloqueo_reserva_spin(ambito):
+            reserva = obtener_reserva_spin(ambito)
 
-        if user.id not in (reserva.jugador1_discord_id, reserva.jugador2_discord_id):
-            await interaction.followup.send("Solo uno de los jugadores del partido reservado puede liberar este Spin.", ephemeral=True)
-            return
+            if not reserva:
+                await interaction.followup.send("No hay ningún Spin reservado en esta cola.", ephemeral=True)
+                return
 
-        limpiar_reserva_spin(ambito)
+            if user.id not in (reserva.jugador1_discord_id, reserva.jugador2_discord_id):
+                await interaction.followup.send("Solo uno de los jugadores del partido reservado puede liberar este Spin.", ephemeral=True)
+                return
+
+            limpiar_reserva_spin(ambito)
+            if reserva.timeout_task:
+                reserva.timeout_task.cancel()
+
         if reserva.canal_partido:
             await reserva.canal_partido.send(f"El {self.nombre_ambito()} ha sido liberado.")
-        if reserva.timeout_task:
-            reserva.timeout_task.cancel()
 
         self.actualizar_botones(spin_habilitado=True)
         await interaction.message.edit(view=self)
@@ -747,6 +752,8 @@ class SpinButtonsView(discord.ui.View):
         primer_mensaje = await self.obtener_primer_mensaje(interaction.channel)
         if primer_mensaje:
             await primer_mensaje.edit(content=f'El {self.nombre_ambito()} está **LIBRE**')
+
+        await interaction.followup.send(f"Has liberado el {self.nombre_ambito()}.", ephemeral=True)
         thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Encontrado', ambito))
         thread.start()
 

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -287,9 +287,133 @@ async def test_spin_callback_con_reserva_activa_solo_responde_en_esa_cola(monkey
     )
 
     try:
-        await vista.spin_callback(interaction, None)
+        await vista.spin_callback.callback(interaction)
     finally:
         UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = None
 
     assert mensajes == [("Ya hay un usuario buscando partido en esta cola.", True)]
     assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_COMUNIDADES) is None
+
+@pytest.mark.asyncio
+async def test_encontrado_callback_libera_solo_reserva_del_ambito_de_la_vista(monkeypatch):
+    from types import SimpleNamespace
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL, AMBITO_SPIN_COMUNIDADES
+
+    mensajes = []
+    edits = []
+    canales = []
+
+    class Response:
+        async def defer(self):
+            pass
+
+    class Followup:
+        async def send(self, mensaje, *, ephemeral=False):
+            mensajes.append((mensaje, ephemeral))
+
+    class Message:
+        async def edit(self, **kwargs):
+            edits.append(kwargs)
+
+    class Channel:
+        def history(self, *, oldest_first=False, limit=1):
+            async def iterator():
+                yield Message()
+            return iterator()
+
+    class CanalPartido:
+        async def send(self, mensaje):
+            canales.append(mensaje)
+
+    class TimeoutTask:
+        def __init__(self):
+            self.cancelled = False
+
+        def cancel(self):
+            self.cancelled = True
+
+    monkeypatch.setattr(UtilesDiscord.Thread, "start", lambda self: None)
+    timeout_general = TimeoutTask()
+    timeout_comunidades = TimeoutTask()
+    reserva_general = SimpleNamespace(
+        ambito=AMBITO_SPIN_GENERAL,
+        usuario_spin=SimpleNamespace(id=10),
+        jugador1_discord_id=111,
+        jugador2_discord_id=222,
+        canal_spin=Channel(),
+        canal_partido=CanalPartido(),
+        descripcion_partido="General",
+        timeout_task=timeout_general,
+        partido=None,
+    )
+    reserva_comunidades = SimpleNamespace(
+        ambito=AMBITO_SPIN_COMUNIDADES,
+        usuario_spin=SimpleNamespace(id=30),
+        jugador1_discord_id=333,
+        jugador2_discord_id=444,
+        canal_spin=Channel(),
+        canal_partido=CanalPartido(),
+        descripcion_partido="Comunidades",
+        timeout_task=timeout_comunidades,
+        partido=None,
+    )
+    UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = reserva_general
+    UtilesDiscord.reservas_spin[AMBITO_SPIN_COMUNIDADES] = reserva_comunidades
+
+    interaction = SimpleNamespace(
+        response=Response(),
+        followup=Followup(),
+        user=SimpleNamespace(id=333, name="JugadorComunidades"),
+        message=Message(),
+        channel=Channel(),
+    )
+
+    try:
+        await UtilesDiscord.SpinButtonsView(AMBITO_SPIN_COMUNIDADES).encontrado_callback.callback(interaction)
+        assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_GENERAL) is reserva_general
+        assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_COMUNIDADES) is None
+        assert timeout_comunidades.cancelled is True
+        assert timeout_general.cancelled is False
+        assert canales == ["El Spin Comunidades ha sido liberado."]
+        assert mensajes == [("Has liberado el Spin Comunidades.", True)]
+    finally:
+        UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = None
+        UtilesDiscord.reservas_spin[AMBITO_SPIN_COMUNIDADES] = None
+
+
+@pytest.mark.asyncio
+async def test_encontrado_callback_rechaza_usuario_ajeno_sin_liberar_ningun_ambito(monkeypatch):
+    from types import SimpleNamespace
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL, AMBITO_SPIN_COMUNIDADES
+
+    mensajes = []
+
+    class Response:
+        async def defer(self):
+            pass
+
+    class Followup:
+        async def send(self, mensaje, *, ephemeral=False):
+            mensajes.append((mensaje, ephemeral))
+
+    reserva_general = SimpleNamespace(jugador1_discord_id=111, jugador2_discord_id=222, timeout_task=None, canal_partido=None)
+    reserva_comunidades = SimpleNamespace(jugador1_discord_id=333, jugador2_discord_id=444, timeout_task=None, canal_partido=None)
+    UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = reserva_general
+    UtilesDiscord.reservas_spin[AMBITO_SPIN_COMUNIDADES] = reserva_comunidades
+
+    interaction = SimpleNamespace(
+        response=Response(),
+        followup=Followup(),
+        user=SimpleNamespace(id=999, name="Intruso"),
+    )
+
+    try:
+        await UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL).encontrado_callback.callback(interaction)
+        assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_GENERAL) is reserva_general
+        assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_COMUNIDADES) is reserva_comunidades
+        assert mensajes == [("Solo uno de los jugadores del partido reservado puede liberar este Spin.", True)]
+    finally:
+        UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = None
+        UtilesDiscord.reservas_spin[AMBITO_SPIN_COMUNIDADES] = None


### PR DESCRIPTION
### Motivation
- Asegurar que la acción `Encontrado` libere únicamente la cola correspondiente al ámbito de la vista, según la especificación en `logicaSpin.md`.
- Evitar modificaciones o lecturas de reservas de otros ámbitos y prevenir liberaciones por usuarios no autorizados.

### Description
- El callback de `Encontrado` ahora obtiene el ámbito desde la instancia de la vista (`self.ambito`) y usa el bloqueo específico de ese ámbito (`obtener_bloqueo_reserva_spin(ambito)`) para leer y modificar solo esa reserva.
- Se comprueba la existencia de la reserva y se rechaza con el mensaje efímero `No hay ningún Spin reservado en esta cola.` si no existe.
- Se valida que quien pulsa sea `jugador1` o `jugador2` del `Spin`, rechazando con `Solo uno de los jugadores del partido reservado puede liberar este Spin.` en caso contrario.
- Al liberar se llama a `limpiar_reserva_spin(ambito)`, se cancela el `timeout_task` asociado, se actualizan botones y mensajes, se envía la confirmación efímera `Has liberado el <ambito>.` y se registra el evento en la base con `GestorSQL.insertar_spin`.
- No se tocan ni se consultan reservas de otros ámbitos durante el proceso.
- Archivos modificados: `UtilesDiscord.py`; tests añadidos/ajustados en `tests/test_spin_comunidades.py`.

### Testing
- Ejecutado: `PYTHONPATH=. pytest -q tests/test_spin_comunidades.py` anduvo correctamente; resultado: `12 passed` (todos los tests del módulo pasan).
- Verificación rápida de formato: `git diff --check` no mostró problemas en el diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a344a766098832a854dcc0cfe06c47e)