### PR TITLE
Fix independent spin reservation timeouts

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -66,7 +66,7 @@ class SpinReservation:
     canal_spin: object
     canal_partido: object
     descripcion_partido: str
-    timeout_task: asyncio.Task
+    timeout_task: Optional[asyncio.Task]
     partido: SpinMatchResult
 
 
@@ -641,28 +641,53 @@ class SpinButtonsView(discord.ui.View):
                     child.custom_id = self.custom_id_encontrado()
                     child.disabled = True
 
-    async def auto_release_spin(self, ambito, user, mensaje_botones=None):
+    async def auto_release_spin(self, reserva_esperada, mensaje_botones=None):
+        """Libera por timeout únicamente la reserva concreta que creó la tarea.
+
+        Cada cola mantiene su propia tarea de timeout. Tras esperar los 5
+        minutos exigidos por ``logicaSpin.md``, la tarea comprueba que la
+        reserva activa del ámbito sigue siendo exactamente la misma instancia.
+        Así una tarea antigua no puede liberar una reserva posterior del mismo
+        ámbito ni tocar la otra cola.
+        """
+
         await asyncio.sleep(300)  # Espera 5 minutos
-        reserva = obtener_reserva_spin(ambito)
-        if not reserva or reserva.usuario_spin != user:
-            return
+        ambito = reserva_esperada.ambito
 
-        limpiar_reserva_spin(ambito)
+        async with obtener_bloqueo_reserva_spin(ambito):
+            reserva = obtener_reserva_spin(ambito)
+            if reserva is not reserva_esperada:
+                return
+            limpiar_reserva_spin(ambito)
+
+        nombre_ambito = self.nombre_ambito()
         if reserva.canal_partido:
-            if ambito == AMBITO_SPIN_COMUNIDADES:
-                await reserva.canal_partido.send("El Spin Comunidades ha sido liberado automáticamente. 😡 La comunidad ha sobrevivido a otro intento fallido de coordinación humana.")
-            else:
-                await reserva.canal_partido.send("El Spin General ha sido liberado automáticamente. 😡 Afortunadamente las máquinas somos superiores y cuidamos de los esmirriados humanos.")
+            try:
+                if ambito == AMBITO_SPIN_COMUNIDADES:
+                    await reserva.canal_partido.send("El Spin Comunidades ha sido liberado automáticamente. 😡 La comunidad ha sobrevivido a otro intento fallido de coordinación humana.")
+                else:
+                    await reserva.canal_partido.send("El Spin General ha sido liberado automáticamente. 😡 Afortunadamente las máquinas somos superiores y cuidamos de los esmirriados humanos.")
+            except Exception as exc:
+                print(f"No se pudo enviar el mensaje de timeout de {nombre_ambito} al canal del partido: {exc}")
 
-        await user.send('Tu spin ha sido liberado automáticamente debido a la inactividad.')
+        try:
+            await reserva.usuario_spin.send('Tu spin ha sido liberado automáticamente debido a la inactividad.')
+        except Exception as exc:
+            print(f"No se pudo enviar DM de timeout de {nombre_ambito}: {exc}")
 
         if mensaje_botones:
-            self.actualizar_botones(spin_habilitado=True)
-            await mensaje_botones.edit(view=self)
+            try:
+                self.actualizar_botones(spin_habilitado=True)
+                await mensaje_botones.edit(view=self)
+            except Exception as exc:
+                print(f"No se pudo editar la vista de botones de {nombre_ambito} tras timeout: {exc}")
 
-        primer_mensaje = await self.obtener_primer_mensaje(reserva.canal_spin) if reserva.canal_spin else None
-        if primer_mensaje:
-            await primer_mensaje.edit(content=f'El {self.nombre_ambito()} está **LIBRE**')
+        try:
+            primer_mensaje = await self.obtener_primer_mensaje(reserva.canal_spin) if reserva.canal_spin else None
+            if primer_mensaje:
+                await primer_mensaje.edit(content=f'El {nombre_ambito} está **LIBRE**')
+        except Exception as exc:
+            print(f"No se pudo editar el primer mensaje de {nombre_ambito} tras timeout: {exc}")
 
         thread = Thread(target=GestorSQL.insertar_spin, args=('LOMBARDBOT', datetime.utcnow(), 'Encontrado', ambito))
         thread.start()
@@ -715,8 +740,9 @@ class SpinButtonsView(discord.ui.View):
 
                 canal_partido = interaction.guild.get_channel(canal_partido_id) if canal_partido_id else None
                 descripcion_partido = partido_spin.descripcion_corta
-                timeout_task = asyncio.create_task(self.auto_release_spin(ambito, user, interaction.message))
-                reserva = SpinReservation(ambito, user, coach1_id_discord, coach2_id_discord, interaction.channel, canal_partido, descripcion_partido, timeout_task, partido_spin)
+                reserva = SpinReservation(ambito, user, coach1_id_discord, coach2_id_discord, interaction.channel, canal_partido, descripcion_partido, None, partido_spin)
+                timeout_task = asyncio.create_task(self.auto_release_spin(reserva, interaction.message))
+                reserva.timeout_task = timeout_task
                 guardar_reserva_spin(reserva)
 
                 if canal_partido:

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -522,3 +522,114 @@ async def test_encontrado_callback_no_hace_excepcion_por_admin_ni_comisario(monk
         assert mensajes == [("Solo uno de los jugadores del partido reservado puede liberar este Spin.", True)]
     finally:
         UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = None
+
+@pytest.mark.asyncio
+async def test_timeout_libera_solo_la_reserva_exacta_de_su_ambito(monkeypatch):
+    from types import SimpleNamespace
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL, AMBITO_SPIN_COMUNIDADES
+
+    mensajes_canal = []
+    dms = []
+    edits = []
+
+    async def sleep_inmediato(segundos):
+        assert segundos == 300
+
+    class CanalPartido:
+        async def send(self, mensaje):
+            mensajes_canal.append(mensaje)
+
+    class User:
+        def __init__(self, id):
+            self.id = id
+
+        async def send(self, mensaje):
+            dms.append((self.id, mensaje))
+
+    class Message:
+        async def edit(self, **kwargs):
+            edits.append(kwargs)
+
+    class Channel:
+        def history(self, *, oldest_first=False, limit=1):
+            async def iterator():
+                yield Message()
+            return iterator()
+
+    monkeypatch.setattr(UtilesDiscord.asyncio, "sleep", sleep_inmediato)
+    monkeypatch.setattr(UtilesDiscord.Thread, "start", lambda self: None)
+
+    reserva_general = SimpleNamespace(
+        ambito=AMBITO_SPIN_GENERAL,
+        usuario_spin=User(10),
+        jugador1_discord_id=111,
+        jugador2_discord_id=222,
+        canal_spin=Channel(),
+        canal_partido=CanalPartido(),
+        timeout_task=None,
+    )
+    reserva_comunidades = SimpleNamespace(
+        ambito=AMBITO_SPIN_COMUNIDADES,
+        usuario_spin=User(20),
+        jugador1_discord_id=333,
+        jugador2_discord_id=444,
+        canal_spin=Channel(),
+        canal_partido=CanalPartido(),
+        timeout_task=None,
+    )
+    UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = reserva_general
+    UtilesDiscord.reservas_spin[AMBITO_SPIN_COMUNIDADES] = reserva_comunidades
+
+    try:
+        await UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL).auto_release_spin(reserva_general, Message())
+
+        assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_GENERAL) is None
+        assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_COMUNIDADES) is reserva_comunidades
+        assert mensajes_canal == ["El Spin General ha sido liberado automáticamente. 😡 Afortunadamente las máquinas somos superiores y cuidamos de los esmirriados humanos."]
+        assert dms == [(10, 'Tu spin ha sido liberado automáticamente debido a la inactividad.')]
+        assert any(edit.get("content") == "El Spin General está **LIBRE**" for edit in edits)
+    finally:
+        UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = None
+        UtilesDiscord.reservas_spin[AMBITO_SPIN_COMUNIDADES] = None
+
+
+@pytest.mark.asyncio
+async def test_timeout_antiguo_no_libera_reserva_nueva_del_mismo_ambito(monkeypatch):
+    from types import SimpleNamespace
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL
+
+    mensajes_canal = []
+
+    async def sleep_inmediato(segundos):
+        assert segundos == 300
+
+    class CanalPartido:
+        async def send(self, mensaje):
+            mensajes_canal.append(mensaje)
+
+    monkeypatch.setattr(UtilesDiscord.asyncio, "sleep", sleep_inmediato)
+    monkeypatch.setattr(UtilesDiscord.Thread, "start", lambda self: None)
+
+    reserva_antigua = SimpleNamespace(
+        ambito=AMBITO_SPIN_GENERAL,
+        usuario_spin=SimpleNamespace(id=10),
+        canal_spin=None,
+        canal_partido=CanalPartido(),
+    )
+    reserva_nueva = SimpleNamespace(
+        ambito=AMBITO_SPIN_GENERAL,
+        usuario_spin=SimpleNamespace(id=10),
+        canal_spin=None,
+        canal_partido=CanalPartido(),
+    )
+    UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = reserva_nueva
+
+    try:
+        await UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL).auto_release_spin(reserva_antigua)
+
+        assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_GENERAL) is reserva_nueva
+        assert mensajes_canal == []
+    finally:
+        UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = None


### PR DESCRIPTION
### Motivation
- Implementar la regla de `logicaSpin.md` que exige que cada cola de Spin tenga su propio timeout asociado a la reserva concreta y que una tarea de timeout no libere reservas de otro momento ni de la otra cola.
- Evitar condiciones de carrera donde una tarea de timeout antigua pudiera liberar una reserva posterior del mismo ámbito o afectar la otra cola.

### Description
- Cambiada la estructura de `SpinReservation` para permitir que `timeout_task` se asigne opcionalmente después de crear la reserva (`timeout_task: Optional[asyncio.Task]`).
- `auto_release_spin` ahora recibe la instancia de reserva esperada, espera 5 minutos y, bajo el `Lock` del ámbito, comprueba que la reserva activa es exactamente la misma instancia antes de liberarla; si no lo es, no hace nada.
- Al liberar por timeout se limpia solo la reserva del ámbito correspondiente y se toleran fallos al enviar DM o editar la vista/mensaje (se registran errores en stdout en vez de romper el flujo).
- Al crear una reserva se crea primero la instancia `SpinReservation`, luego se arranca la tarea `auto_release_spin(reserva, ...)` y se almacena la `timeout_task` en la propia reserva; se añadieron tests que verifican el comportamiento esperado ante timeouts y tareas obsoletas.

### Testing
- Ejecutado `PYTHONPATH=. pytest -q tests/test_spin_comunidades.py` y las pruebas relacionadas con Spin pasaron correctamente (`16 passed`).
- Ejecutado `PYTHONPATH=. pytest -q` contra toda la suite y la modificación no introdujo fallos en las pruebas de Spin, pero la ejecución completa mostró 5 fallos de integración en módulos de comunidades existentes que son preexistentes y no están relacionados con este cambio (estado `ELECCIONES_COMPLETAS` y expectativas de regeneración de rondas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a344f9ed520832a82d13c093405c700)