### PR TITLE
Centraliza mensajes de Spin libre

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -35,6 +35,7 @@ from SpinConstantes import (
     AMBITO_SPIN_COMUNIDADES,
     AMBITO_SPIN_GENERAL,
     AMBITO_SPIN_TODOS,
+    mensaje_spin_libre,
     normalizar_ambito_spin,
 )
 import GestionExcel
@@ -1859,8 +1860,7 @@ async def AgregaMensajeSpin(ctx, ambito: str = "General"):
         await ctx.send("Ámbito de Spin no válido. Usa General o Comunidades.", delete_after=20)
         return
 
-    nombre_ambito = "Spin Comunidades" if ambito_normalizado == AMBITO_SPIN_COMUNIDADES else "Spin General"
-    await ctx.send(f"El {nombre_ambito} está **LIBRE**")
+    await ctx.send(mensaje_spin_libre(ambito_normalizado))
     await ctx.send("¡Úsame para Spinear!", view=UtilesDiscord.SpinButtonsView(ambito_normalizado))
     UtilesDiscord.limpiar_reserva_spin(ambito_normalizado)
     await ctx.message.delete()

--- a/SpinConstantes.py
+++ b/SpinConstantes.py
@@ -21,6 +21,25 @@ AMBITO_SPIN_COMUNIDADES = AmbitoSpin.COMUNIDADES.value
 AMBITOS_SPIN = frozenset(ambito.value for ambito in AmbitoSpin)
 AMBITO_SPIN_TODOS = "TODOS"
 
+MENSAJES_SPIN_LIBRE = {
+    AMBITO_SPIN_GENERAL: "El Spin General está **LIBRE**",
+    AMBITO_SPIN_COMUNIDADES: "El Spin Comunidades está **LIBRE**",
+}
+
+
+def mensaje_spin_libre(ambito):
+    """Devuelve el texto canónico de cola libre para el ámbito indicado.
+
+    ``logicaSpin.md`` define estos textos como fuente de verdad para crear
+    mensajes de Spin y para actualizar el mensaje principal al liberar
+    reservas.
+    """
+
+    ambito_normalizado = normalizar_ambito_spin(ambito)
+    if not ambito_normalizado:
+        raise ValueError(f"Ámbito de Spin no válido: {ambito!r}")
+    return MENSAJES_SPIN_LIBRE[ambito_normalizado]
+
 # Canal actual de Spin General; se conserva para compatibilidad operativa.
 CANAL_SPIN_GENERAL_ID = 1224128423929315468
 # Canal independiente para Spin Comunidades. Configurar el ID real al activarlo.

--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -21,6 +21,7 @@ from SpinConstantes import (
     AMBITO_SPIN_GENERAL,
     CANAL_SPIN_COMUNIDADES_ID,
     CANAL_SPIN_GENERAL_ID,
+    mensaje_spin_libre,
     normalizar_ambito_spin,
 )
 
@@ -685,7 +686,7 @@ class SpinButtonsView(discord.ui.View):
         try:
             primer_mensaje = await self.obtener_primer_mensaje(reserva.canal_spin) if reserva.canal_spin else None
             if primer_mensaje:
-                await primer_mensaje.edit(content=f'El {nombre_ambito} está **LIBRE**')
+                await primer_mensaje.edit(content=mensaje_spin_libre(ambito))
         except Exception as exc:
             print(f"No se pudo editar el primer mensaje de {nombre_ambito} tras timeout: {exc}")
 
@@ -795,7 +796,7 @@ class SpinButtonsView(discord.ui.View):
 
         primer_mensaje = await self.obtener_primer_mensaje(interaction.channel)
         if primer_mensaje:
-            await primer_mensaje.edit(content=f'El {self.nombre_ambito()} está **LIBRE**')
+            await primer_mensaje.edit(content=mensaje_spin_libre(ambito))
 
         await interaction.followup.send(f"Has liberado el {self.nombre_ambito()}.", ephemeral=True)
         thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Encontrado', ambito))

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -193,6 +193,22 @@ def test_resolver_partido_spin_rechaza_ambito_no_valido(monkeypatch):
         UtilesDiscord.resolver_partido_spin(object(), object(), "Ticket")
 
 
+def test_mensaje_spin_libre_centraliza_textos_por_ambito():
+    from SpinConstantes import (
+        AMBITO_SPIN_COMUNIDADES,
+        AMBITO_SPIN_GENERAL,
+        MENSAJES_SPIN_LIBRE,
+        mensaje_spin_libre,
+    )
+
+    assert MENSAJES_SPIN_LIBRE == {
+        AMBITO_SPIN_GENERAL: "El Spin General está **LIBRE**",
+        AMBITO_SPIN_COMUNIDADES: "El Spin Comunidades está **LIBRE**",
+    }
+    assert mensaje_spin_libre("General") == MENSAJES_SPIN_LIBRE[AMBITO_SPIN_GENERAL]
+    assert mensaje_spin_libre("COMUNIDADES") == MENSAJES_SPIN_LIBRE[AMBITO_SPIN_COMUNIDADES]
+
+
 def test_spin_buttons_view_parametriza_custom_ids_por_ambito():
     import UtilesDiscord
     from SpinConstantes import AMBITO_SPIN_GENERAL, AMBITO_SPIN_COMUNIDADES


### PR DESCRIPTION
### Motivation
- Evitar duplicación de la cadena de estado "LIBRE" para las colas de Spin y asegurar que los textos visibles sigan lo definido en `logicaSpin.md` para los ámbitos `GENERAL` y `COMUNIDADES`.
- Usar un único punto de verdad al crear mensajes de Spin y al liberar reservas (manual o automática) para facilitar futuros cambios y traducciones.

### Description
- Añadido `MENSAJES_SPIN_LIBRE` y la función `mensaje_spin_libre(ambito)` en `SpinConstantes.py` que centralizan los textos canónicos para `GENERAL` y `COMUNIDADES`.
- Reemplazados los textos inline al crear el mensaje de Spin en `AgregaMensajeSpin` (`LombardBot.py`) para usar `mensaje_spin_libre(ambito)`.
- Reemplazados los textos inline usados al liberar reservas (tanto en la liberación automática por timeout como en el flujo `Encontrado`) en `UtilesDiscord.py` para usar `mensaje_spin_libre(ambito)`.
- Añadida la prueba unitaria `test_mensaje_spin_libre_centraliza_textos_por_ambito` en `tests/test_spin_comunidades.py` que verifica el mapa `MENSAJES_SPIN_LIBRE` y que `mensaje_spin_libre` normaliza/acepta entradas como `"General"` o `"COMUNIDADES"`.

### Testing
- Ejecutado `python -m compileall SpinConstantes.py UtilesDiscord.py LombardBot.py`, la compilación de los módulos modificados fue satisfactoria.
- Ejecutado `pytest -q tests/test_spin_comunidades.py`, la ejecución de tests quedó bloqueada por una dependencia ausente: `ModuleNotFoundError: No module named 'sqlalchemy'`, por lo que la prueba unitaria añadida no pudo completarse en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3450ae1248832abeee991e8a7cbf95)