### PR TITLE
Parametrizar comando de mensaje Spin por ámbito

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -1852,18 +1852,28 @@ async def agregar_vista(ctx, message_id: int, ambito: str = "General"):
     except Exception as e:
         await ctx.send(f"Error: {e}", delete_after=20)
 
-@bot.command(name="AgregaMensajeSpin")
+@bot.command(name="AgregaMensajeSpin", aliases=["AgregarMensajeSpin"])
 @commands.has_any_role('Moderadores', 'Administrador', 'Comisario')
-async def AgregaMensajeSpin(ctx, ambito: str = "General"):
+async def AgregaMensajeSpin(ctx, ambito: str):
     ambito_normalizado = normalizar_ambito_spin(ambito)
     if not ambito_normalizado:
         await ctx.send("Ámbito de Spin no válido. Usa General o Comunidades.", delete_after=20)
         return
 
-    await ctx.send(mensaje_spin_libre(ambito_normalizado))
-    await ctx.send("¡Úsame para Spinear!", view=UtilesDiscord.SpinButtonsView(ambito_normalizado))
+    await ctx.send(
+        mensaje_spin_libre(ambito_normalizado),
+        view=UtilesDiscord.SpinButtonsView(ambito_normalizado),
+    )
     UtilesDiscord.limpiar_reserva_spin(ambito_normalizado)
     await ctx.message.delete()
+
+
+@AgregaMensajeSpin.error
+async def AgregaMensajeSpin_error(ctx, error):
+    if isinstance(error, commands.MissingRequiredArgument) and error.param.name == "ambito":
+        await ctx.send("Debes indicar el ámbito del Spin: General o Comunidades.", delete_after=20)
+        return
+    raise error
    
 
 @bot.tree.command(name="dado", description="Lanza un dado!")


### PR DESCRIPTION
### Motivation
- Permitir crear el mensaje de `Spin` para `General` o `Comunidades` usando el mismo comando y forzar que se indique el ámbito explícitamente. 

### Description
- El comando prefijado `AgregaMensajeSpin` ahora requiere el argumento `ambito` y acepta el alias `AgregarMensajeSpin` para compatibilidad. 
- Se valida y normaliza el valor de `ambito` mediante la función existente `normalizar_ambito_spin` y se rechazan valores no válidos con un mensaje claro. 
- El mensaje inicial se publica usando el texto canónico `mensaje_spin_libre(ambito_normalizado)` y la vista parametrizada `UtilesDiscord.SpinButtonsView(ambito_normalizado)` en un único `ctx.send`. 
- Se añadió un manejador de errores `@AgregaMensajeSpin.error` que muestra un mensaje cuando falta el argumento obligatorio `ambito`.

### Testing
- Se comprobó la compilación estática ejecutando `python -m py_compile LombardBot.py SpinConstantes.py UtilesDiscord.py` y finalizó sin errores. 
- Se intentó ejecutar `pytest -q tests/test_spin_comunidades.py` pero la ejecución quedó bloqueada por falta de la dependencia `sqlalchemy` en el entorno, por lo que los tests automatizados no pudieron completarse.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34528e4330832a92c1948c4d30e596)