### PR TITLE
Require explicit scope for `!AgregarMensajeSpin` and add usage help

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -35,6 +35,7 @@ from SpinConstantes import (
     AMBITO_SPIN_COMUNIDADES,
     AMBITO_SPIN_GENERAL,
     AMBITO_SPIN_TODOS,
+    ayuda_agregar_mensaje_spin,
     mensaje_spin_libre,
     normalizar_ambito_spin,
 )
@@ -1854,10 +1855,17 @@ async def agregar_vista(ctx, message_id: int, ambito: str = "General"):
 
 @bot.command(name="AgregaMensajeSpin", aliases=["AgregarMensajeSpin"])
 @commands.has_any_role('Moderadores', 'Administrador', 'Comisario')
-async def AgregaMensajeSpin(ctx, ambito: str):
+async def AgregaMensajeSpin(ctx, ambito: str = None):
+    if ambito is None:
+        await ctx.send(ayuda_agregar_mensaje_spin(), delete_after=20)
+        return
+
     ambito_normalizado = normalizar_ambito_spin(ambito)
     if not ambito_normalizado:
-        await ctx.send("Ámbito de Spin no válido. Usa General o Comunidades.", delete_after=20)
+        await ctx.send(
+            f"Ámbito de Spin no válido: `{ambito}`.\n{ayuda_agregar_mensaje_spin()}",
+            delete_after=20,
+        )
         return
 
     await ctx.send(
@@ -1871,7 +1879,7 @@ async def AgregaMensajeSpin(ctx, ambito: str):
 @AgregaMensajeSpin.error
 async def AgregaMensajeSpin_error(ctx, error):
     if isinstance(error, commands.MissingRequiredArgument) and error.param.name == "ambito":
-        await ctx.send("Debes indicar el ámbito del Spin: General o Comunidades.", delete_after=20)
+        await ctx.send(ayuda_agregar_mensaje_spin(), delete_after=20)
         return
     raise error
    

--- a/SpinConstantes.py
+++ b/SpinConstantes.py
@@ -27,6 +27,26 @@ MENSAJES_SPIN_LIBRE = {
 }
 
 
+AYUDA_AGREGAR_MENSAJE_SPIN = (
+    "Uso: `!AgregarMensajeSpin <ámbito>`\n"
+    "Ámbitos válidos: `General` y `Comunidades`.\n"
+    "Ejemplos:\n"
+    "`!AgregarMensajeSpin General`\n"
+    "`!AgregarMensajeSpin Comunidades`"
+)
+
+
+def ayuda_agregar_mensaje_spin():
+    """Devuelve la ayuda de uso del comando de creación de mensajes Spin.
+
+    ``logicaSpin.md`` exige que el comando reciba explícitamente el ámbito y
+    valide los valores ``General`` y ``Comunidades`` para evitar mensajes
+    ambiguos. Omitir el ámbito no asume ningún valor por defecto.
+    """
+
+    return AYUDA_AGREGAR_MENSAJE_SPIN
+
+
 def mensaje_spin_libre(ambito):
     """Devuelve el texto canónico de cola libre para el ámbito indicado.
 

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -193,6 +193,17 @@ def test_resolver_partido_spin_rechaza_ambito_no_valido(monkeypatch):
         UtilesDiscord.resolver_partido_spin(object(), object(), "Ticket")
 
 
+def test_ayuda_agregar_mensaje_spin_exige_ambito_explicito():
+    from SpinConstantes import ayuda_agregar_mensaje_spin
+
+    ayuda = ayuda_agregar_mensaje_spin()
+
+    assert "Uso: `!AgregarMensajeSpin <ámbito>`" in ayuda
+    assert "`!AgregarMensajeSpin General`" in ayuda
+    assert "`!AgregarMensajeSpin Comunidades`" in ayuda
+    assert "equivale a `General`" not in ayuda
+
+
 def test_mensaje_spin_libre_centraliza_textos_por_ambito():
     from SpinConstantes import (
         AMBITO_SPIN_COMUNIDADES,


### PR DESCRIPTION
### Motivation
- Evitar la creación de mensajes de Spin ambiguos al exigir un ámbito explícito conforme a `logicaSpin.md`.
- Documentar y centralizar la ayuda de uso para que los moderadores sepan cómo invocar correctamente el comando.

### Description
- Añadida la constante `AYUDA_AGREGAR_MENSAJE_SPIN` y la función `ayuda_agregar_mensaje_spin()` en `SpinConstantes.py` con uso, ámbitos válidos y ejemplos.
- Modificado `AgregaMensajeSpin` en `LombardBot.py` para aceptar `ambito: str = None`, devolver la ayuda cuando falta el argumento y mostrar la ayuda completa cuando el ámbito es inválido.
- Actualizada la validación de ámbito para seguir usando `normalizar_ambito_spin()` y evitar asumir `General` por defecto.
- Añadida la prueba `test_ayuda_agregar_mensaje_spin_exige_ambito_explicito` en `tests/test_spin_comunidades.py` para cubrir la nueva ayuda centralizada.

### Testing
- Compilación estática ejecutada con `python -m py_compile SpinConstantes.py LombardBot.py` (éxito).
- Impresión de la ayuda verificada con `python - <<'PY' from SpinConstantes import ayuda_agregar_mensaje_spin; print(ayuda_agregar_mensaje_spin()) PY` (éxito).
- `pytest tests/test_spin_comunidades.py` intentado pero no ejecutado en este entorno por falta de la dependencia `sqlalchemy` (`ModuleNotFoundError`).
- Comprobación de formato con `git diff --check` (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3453b44ce0832a8f43a04fe347f291)