### PR TITLE
Corrige mensaje principal de reserva de Spin

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands
 from discord import app_commands
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Optional
 from threading import Thread
 import threading
@@ -46,8 +46,8 @@ class SpinMatchResult:
     jugador1_discord_id: Optional[int]
     jugador2_discord_id: Optional[int]
     fecha: Optional[datetime]
-    descripcion_corta: Optional[str]
-    descripcion_larga: Optional[str]
+    descripcion_corta: Optional[str] = None
+    descripcion_larga: Optional[str] = None
     torneo_id: Optional[int] = None
     partido_id: Optional[int] = None
     enfrentamiento_id: Optional[int] = None
@@ -437,6 +437,27 @@ def _clave_orden_spin(partido: SpinMatchResult):
     )
 
 
+def mensaje_spin_reservado(partido: SpinMatchResult):
+    """Construye el mensaje principal reservado desde ``SpinMatchResult``.
+
+    ``logicaSpin.md`` define el texto público de reserva por ámbito. Para
+    Comunidades se usa el texto completo solo si el resultado trae partido
+    individual y ambos equipos; si falta algún dato descriptivo, se degrada a
+    un mensaje seguro sin mostrar ``None``.
+    """
+
+    menciones = f"<@{partido.jugador1_discord_id}> y <@{partido.jugador2_discord_id}>"
+    if partido.ambito == AMBITO_SPIN_COMUNIDADES:
+        if partido.indice_partido and partido.equipo_a_nombre and partido.equipo_b_nombre:
+            return (
+                f"Spin de comunidades reservado para el partido individual {partido.indice_partido} "
+                f"del enfrentamiento {partido.equipo_a_nombre} vs {partido.equipo_b_nombre}: "
+                f"{menciones} pueden buscar partido."
+            )
+        return f"Spin de comunidades reservado: {menciones} pueden buscar partido."
+    return f"Spin General reservado: {menciones} pueden buscar partido."
+
+
 def _spin_match_desde_partido_general(partido):
     canal_partido_id = getattr(partido, "canalAsociado", None) or getattr(partido, "canal_id", None)
     fecha = getattr(partido, "fecha", None)
@@ -449,20 +470,19 @@ def _spin_match_desde_partido_general(partido):
         jugador1_discord_id = getattr(partido.coach1_usuario, "id_discord", None)
         jugador2_discord_id = getattr(partido.coach2_usuario, "id_discord", None) if partido.coach2_usuario else jugador1_discord_id
 
-    descripcion = f"Spin General reservado: <@{jugador1_discord_id}> y <@{jugador2_discord_id}> pueden buscar partido."
-    return SpinMatchResult(
+    resultado = SpinMatchResult(
         ambito=AMBITO_SPIN_GENERAL,
         canal_partido_id=canal_partido_id,
         jugador1_discord_id=jugador1_discord_id,
         jugador2_discord_id=jugador2_discord_id,
         fecha=fecha,
-        descripcion_corta=descripcion,
-        descripcion_larga=descripcion,
         torneo_id=getattr(partido, "torneo_id", None),
         partido_id=partido_id,
         enfrentamiento_id=getattr(partido, "ronda_id", None),
         indice_partido=getattr(partido, "mesa_numero", None),
     )
+    descripcion = mensaje_spin_reservado(resultado)
+    return replace(resultado, descripcion_corta=descripcion, descripcion_larga=descripcion)
 
 
 def resolver_partido_spin_general(session, usuario_db):
@@ -563,26 +583,21 @@ def resolver_partido_spin_comunidades(session, usuario_db):
         equipo_b_nombre = getattr(getattr(enfrentamiento, "equipo_b", None), "nombre", None)
         jugador1_discord_id = getattr(partido.usuario_local, "id_discord", None)
         jugador2_discord_id = getattr(partido.usuario_visitante, "id_discord", None)
-        descripcion_corta = (
-            f"Spin de comunidades reservado para el partido individual {partido.indice} "
-            f"del enfrentamiento {equipo_a_nombre} vs {equipo_b_nombre}: "
-            f"<@{jugador1_discord_id}> y <@{jugador2_discord_id}> pueden buscar partido."
-        )
-        resultados.append(SpinMatchResult(
+        resultado = SpinMatchResult(
             ambito=AMBITO_SPIN_COMUNIDADES,
             canal_partido_id=partido.canal_discord_id,
             jugador1_discord_id=jugador1_discord_id,
             jugador2_discord_id=jugador2_discord_id,
             fecha=partido.fecha,
-            descripcion_corta=descripcion_corta,
-            descripcion_larga=descripcion_corta,
             torneo_id=partido.torneo_id,
             partido_id=partido.id,
             enfrentamiento_id=partido.enfrentamiento_id,
             indice_partido=partido.indice,
             equipo_a_nombre=equipo_a_nombre,
             equipo_b_nombre=equipo_b_nombre,
-        ))
+        )
+        descripcion = mensaje_spin_reservado(resultado)
+        resultados.append(replace(resultado, descripcion_corta=descripcion, descripcion_larga=descripcion))
     return min(resultados, key=_clave_orden_spin) if resultados else None
 
 

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -660,3 +660,50 @@ async def test_timeout_antiguo_no_libera_reserva_nueva_del_mismo_ambito(monkeypa
         assert mensajes_canal == []
     finally:
         UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = None
+
+
+def test_mensaje_spin_reservado_se_construye_desde_spin_match_result():
+    from SpinConstantes import AMBITO_SPIN_GENERAL
+    from UtilesDiscord import SpinMatchResult, mensaje_spin_reservado
+
+    resultado = SpinMatchResult(
+        ambito=AMBITO_SPIN_GENERAL,
+        canal_partido_id=900,
+        jugador1_discord_id=101,
+        jugador2_discord_id=201,
+        fecha=None,
+    )
+
+    assert mensaje_spin_reservado(resultado) == "Spin General reservado: <@101> y <@201> pueden buscar partido."
+
+
+def test_mensaje_spin_reservado_comunidades_usa_contexto_o_fallback():
+    from SpinConstantes import AMBITO_SPIN_COMUNIDADES
+    from UtilesDiscord import SpinMatchResult, mensaje_spin_reservado
+
+    completo = SpinMatchResult(
+        ambito=AMBITO_SPIN_COMUNIDADES,
+        canal_partido_id=902,
+        jugador1_discord_id=102,
+        jugador2_discord_id=101,
+        fecha=None,
+        indice_partido=2,
+        equipo_a_nombre="Equipo A",
+        equipo_b_nombre="Equipo B",
+    )
+    incompleto = SpinMatchResult(
+        ambito=AMBITO_SPIN_COMUNIDADES,
+        canal_partido_id=902,
+        jugador1_discord_id=102,
+        jugador2_discord_id=101,
+        fecha=None,
+        indice_partido=2,
+        equipo_a_nombre="Equipo A",
+    )
+
+    assert mensaje_spin_reservado(completo) == (
+        "Spin de comunidades reservado para el partido individual 2 "
+        "del enfrentamiento Equipo A vs Equipo B: <@102> y <@101> pueden buscar partido."
+    )
+    assert mensaje_spin_reservado(incompleto) == "Spin de comunidades reservado: <@102> y <@101> pueden buscar partido."
+    assert "None" not in mensaje_spin_reservado(incompleto)


### PR DESCRIPTION
### Motivation

- Alinear la construcción del texto público de reserva con lo definido en `logicaSpin.md` para que el mensaje principal indique correctamente qué partido está reservado. 
- Evitar que se muestren valores `None` en mensajes de `COMUNIDADES` cuando falten datos descriptivos del enfrentamiento.

### Description

- Añade `mensaje_spin_reservado(partido: SpinMatchResult)` que centraliza la construcción del texto principal reservado y aplica la forma específica para `GENERAL` y `COMUNIDADES` con fallback cuando falte contexto.
- Ajusta `SpinMatchResult` para permitir construir la estructura normalizada primero y rellenar después `descripcion_corta`/`descripcion_larga` generadas por el helper.
- Modifica los resolutores para `GENERAL` y `COMUNIDADES` para crear primero un `SpinMatchResult` y luego derivar la descripción llamando a `mensaje_spin_reservado`, evitando interpolar `None` directamente.
- Añade tests unitarios que verifican la generación del mensaje reservado tanto para Spin General como para Spin Comunidades con datos completos e incompletos; integra la nueva lógica en los casos existentes.

### Testing

- Ejecutado `PYTHONPATH=. pytest -q tests/test_spin_comunidades.py` y todos los tests relevantes pasaron: `20 passed, 7 warnings`.
- Compilado el módulo con `python -m py_compile UtilesDiscord.py` sin errores.
- Verificado que no hay problemas de formato con `git diff --check` (sin errores reportados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3454643358832a9d441fc5df3c97c4)