### PR TITLE
Usar el primer mensaje del canal como fuente de Spin

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -630,6 +630,44 @@ def buscar_partido_spin(session, usuario_db, ambito):
     return resolver_partido_spin(session, usuario_db, ambito)
 
 
+async def obtener_primer_mensaje_canal(channel):
+    """Devuelve el primer mensaje del canal de Spin, o ``None`` si no existe.
+
+    La decisión operativa de ``logicaSpin.md`` es no persistir ni usar como
+    fuente de verdad el ID del mensaje de Spin: el mensaje editable es siempre
+    el primer mensaje visible del canal.
+    """
+
+    if channel is None:
+        return None
+
+    async for mensaje in channel.history(oldest_first=True, limit=1):
+        return mensaje
+    return None
+
+
+async def editar_primer_mensaje_spin(channel, *, content=None, view=None):
+    """Edita el primer mensaje del canal de Spin sin depender de IDs guardados.
+
+    Lanza ``LookupError`` si no hay mensaje principal para que el flujo que
+    reserva/libera pueda decidir cómo degradar sin dejar estado interno
+    atascado.
+    """
+
+    primer_mensaje = await obtener_primer_mensaje_canal(channel)
+    if primer_mensaje is None:
+        raise LookupError("No se encontró el primer mensaje del canal de Spin")
+
+    kwargs = {}
+    if content is not None:
+        kwargs["content"] = content
+    if view is not None:
+        kwargs["view"] = view
+    if kwargs:
+        await primer_mensaje.edit(**kwargs)
+    return primer_mensaje
+
+
 class SpinButtonsView(discord.ui.View):
     def __init__(self, ambito=AMBITO_SPIN_GENERAL):
         super().__init__(timeout=None)
@@ -691,17 +729,13 @@ class SpinButtonsView(discord.ui.View):
         except Exception as exc:
             print(f"No se pudo enviar DM de timeout de {nombre_ambito}: {exc}")
 
-        if mensaje_botones:
-            try:
-                self.actualizar_botones(spin_habilitado=True)
-                await mensaje_botones.edit(view=self)
-            except Exception as exc:
-                print(f"No se pudo editar la vista de botones de {nombre_ambito} tras timeout: {exc}")
-
         try:
-            primer_mensaje = await self.obtener_primer_mensaje(reserva.canal_spin) if reserva.canal_spin else None
-            if primer_mensaje:
-                await primer_mensaje.edit(content=mensaje_spin_libre(ambito))
+            self.actualizar_botones(spin_habilitado=True)
+            await editar_primer_mensaje_spin(
+                reserva.canal_spin,
+                content=mensaje_spin_libre(ambito),
+                view=self,
+            )
         except Exception as exc:
             print(f"No se pudo editar el primer mensaje de {nombre_ambito} tras timeout: {exc}")
 
@@ -717,9 +751,7 @@ class SpinButtonsView(discord.ui.View):
                     child.disabled = spin_habilitado
 
     async def obtener_primer_mensaje(self, channel):
-        async for mensaje in channel.history(oldest_first=True, limit=1):
-            return mensaje  #primer mensaje encontrado
-        return None  #None si no hay mensajes
+        return await obtener_primer_mensaje_canal(channel)
 
     @discord.ui.button(label="Spin", style=discord.ButtonStyle.green, custom_id='lombardbot:spin:general')
     async def spin_callback(self, interaction: discord.Interaction, button: discord.ui.Button):
@@ -757,22 +789,36 @@ class SpinButtonsView(discord.ui.View):
                 canal_partido = interaction.guild.get_channel(canal_partido_id) if canal_partido_id else None
                 descripcion_partido = partido_spin.descripcion_corta
                 reserva = SpinReservation(ambito, user, coach1_id_discord, coach2_id_discord, interaction.channel, canal_partido, descripcion_partido, None, partido_spin)
-                timeout_task = asyncio.create_task(self.auto_release_spin(reserva, interaction.message))
+                timeout_task = asyncio.create_task(self.auto_release_spin(reserva))
                 reserva.timeout_task = timeout_task
                 guardar_reserva_spin(reserva)
+
+                self.actualizar_botones(spin_habilitado=False)
+                try:
+                    await editar_primer_mensaje_spin(
+                        interaction.channel,
+                        content=descripcion_partido,
+                        view=self,
+                    )
+                except Exception as exc:
+                    limpiar_reserva_spin(ambito)
+                    if timeout_task:
+                        timeout_task.cancel()
+                    self.actualizar_botones(spin_habilitado=True)
+                    await interaction.followup.send(
+                        "No se pudo localizar o editar el mensaje principal de Spin. "
+                        "La reserva interna ha quedado liberada; recrea el mensaje con "
+                        f"`!AgregarMensajeSpin {ambito.title()}` si es necesario.",
+                        ephemeral=True,
+                    )
+                    print(f"No se pudo reservar {self.nombre_ambito()} al editar el primer mensaje: {exc}")
+                    return
 
                 if canal_partido:
                     if ambito == AMBITO_SPIN_COMUNIDADES:
                         await canal_partido.send(f'<@{coach1_id_discord}> y <@{coach2_id_discord}> podéis spinear vuestro partido de comunidades.')
                     else:
                         await canal_partido.send(f'<@{coach1_id_discord}> y <@{coach2_id_discord}> podéis spinear')
-
-                self.actualizar_botones(spin_habilitado=False)
-                await interaction.message.edit(view=self)
-
-                primer_mensaje = await self.obtener_primer_mensaje(interaction.channel)
-                if primer_mensaje:
-                    await primer_mensaje.edit(content=descripcion_partido)
 
                 await interaction.followup.send(f"Ahora puedes buscar partido en {self.nombre_ambito()}.", ephemeral=True)
                 thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Spin', ambito))
@@ -807,11 +853,14 @@ class SpinButtonsView(discord.ui.View):
             await reserva.canal_partido.send(f"El {self.nombre_ambito()} ha sido liberado.")
 
         self.actualizar_botones(spin_habilitado=True)
-        await interaction.message.edit(view=self)
-
-        primer_mensaje = await self.obtener_primer_mensaje(interaction.channel)
-        if primer_mensaje:
-            await primer_mensaje.edit(content=mensaje_spin_libre(ambito))
+        try:
+            await editar_primer_mensaje_spin(
+                interaction.channel,
+                content=mensaje_spin_libre(ambito),
+                view=self,
+            )
+        except Exception as exc:
+            print(f"No se pudo editar el primer mensaje de {self.nombre_ambito()} al liberar: {exc}")
 
         await interaction.followup.send(f"Has liberado el {self.nombre_ambito()}.", ephemeral=True)
         thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Encontrado', ambito))

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -515,6 +515,66 @@ async def test_encontrado_callback_permita_liberar_al_rival_que_no_inicio_el_spi
     finally:
         UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = None
 
+@pytest.mark.asyncio
+async def test_encontrado_callback_libera_estado_aunque_no_exista_mensaje_principal(monkeypatch):
+    from types import SimpleNamespace
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL
+
+    mensajes = []
+
+    class Response:
+        async def defer(self):
+            pass
+
+    class Followup:
+        async def send(self, mensaje, *, ephemeral=False):
+            mensajes.append((mensaje, ephemeral))
+
+    class ChannelSinMensajes:
+        def history(self, *, oldest_first=False, limit=1):
+            async def iterator():
+                if False:
+                    yield None
+            return iterator()
+
+    class TimeoutTask:
+        def __init__(self):
+            self.cancelled = False
+
+        def cancel(self):
+            self.cancelled = True
+
+    monkeypatch.setattr(UtilesDiscord.Thread, "start", lambda self: None)
+    timeout = TimeoutTask()
+    reserva = SimpleNamespace(
+        ambito=AMBITO_SPIN_GENERAL,
+        usuario_spin=SimpleNamespace(id=111),
+        jugador1_discord_id=111,
+        jugador2_discord_id=222,
+        canal_spin=ChannelSinMensajes(),
+        canal_partido=None,
+        descripcion_partido="General",
+        timeout_task=timeout,
+        partido=None,
+    )
+    UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = reserva
+
+    interaction = SimpleNamespace(
+        response=Response(),
+        followup=Followup(),
+        user=SimpleNamespace(id=111, name="Jugador"),
+        channel=ChannelSinMensajes(),
+    )
+
+    try:
+        await UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL).encontrado_callback.callback(interaction)
+        assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_GENERAL) is None
+        assert timeout.cancelled is True
+        assert mensajes == [("Has liberado el Spin General.", True)]
+    finally:
+        UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = None
+
 
 @pytest.mark.asyncio
 async def test_encontrado_callback_no_hace_excepcion_por_admin_ni_comisario(monkeypatch):


### PR DESCRIPTION
### Motivation
- Aplicar la decisión operativa de `logicaSpin.md` de no persistir el ID del mensaje de Spin y siempre localizar/editar el primer mensaje del canal como fuente de verdad. 
- Garantizar que la reserva interna se libera aun cuando no sea posible localizar o editar el mensaje público, permitiendo la recreación operativa con `!AgregarMensajeSpin <ambito>`.

### Description
- Añadido helper `obtener_primer_mensaje_canal(channel)` para obtener el primer mensaje del canal y `editar_primer_mensaje_spin(channel, *, content=None, view=None)` para editarlo sin depender de IDs persistidos (archivo `UtilesDiscord.py`).
- Actualizado `SpinButtonsView` para usar los helpers en `spin_callback`, `encontrado_callback` y `auto_release_spin`, de modo que la vista/botones y el mensaje principal se actualizan vía el primer mensaje del canal.
- Al reservar, si no se puede localizar/editar el primer mensaje se cancela el timeout, se libera el estado interno y se informa al usuario para recrear el mensaje con `!AgregarMensajeSpin <ambito>`; al liberar, se intenta editar pero la liberación interna no depende del éxito de la edición.
- Añadida una prueba que valida que `Encontrado` libera el estado aunque el canal no tenga mensaje principal y se actualizaron tests relevantes (`tests/test_spin_comunidades.py`).

### Testing
- Se compiló el código con `python3 -m py_compile UtilesDiscord.py SpinConstantes.py LombardBot.py` y la compilación completó sin errores.
- Se ejecutaron las pruebas unitarias relevantes con `PYTHONPATH=. pytest -q tests/test_spin_comunidades.py` y todas pasaron: `21 passed` (con warnings menores).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34563f5340832ab70a0494c7591002)