### PR TITLE
Añade ámbito al historial de Spin

### DIFF
--- a/BD/spin_ambito_migration.sql
+++ b/BD/spin_ambito_migration.sql
@@ -1,0 +1,25 @@
+-- Migración idempotente para distinguir el historial de Spin por ámbito.
+-- logicaSpin.md define los valores internos soportados: GENERAL y COMUNIDADES.
+-- Los registros anteriores a esta columna pertenecen al Spin General.
+
+SET @spin_ambito_columna := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'Spin'
+    AND COLUMN_NAME = 'ambito'
+);
+
+SET @spin_ambito_sql := IF(
+  @spin_ambito_columna = 0,
+  'ALTER TABLE Spin ADD COLUMN ambito VARCHAR(32) NOT NULL DEFAULT ''GENERAL''',
+  'SELECT 1'
+);
+
+PREPARE spin_ambito_stmt FROM @spin_ambito_sql;
+EXECUTE spin_ambito_stmt;
+DEALLOCATE PREPARE spin_ambito_stmt;
+
+UPDATE Spin
+SET ambito = 'GENERAL'
+WHERE ambito IS NULL OR ambito = '';

--- a/GestorSQL.py
+++ b/GestorSQL.py
@@ -137,7 +137,34 @@ class Spin(Base):
     user = Column('user', String)
     fecha = Column('fecha', DateTime)
     tipo = Column('tipo', String)
-    ambito = Column('ambito', String, default=AMBITO_SPIN_GENERAL)
+    ambito = Column('ambito', String(32), nullable=False, default=AMBITO_SPIN_GENERAL, server_default=AMBITO_SPIN_GENERAL)
+
+
+def asegurar_columna_ambito_spin(engine=None):
+    """Garantiza la columna de ámbito en el historial de Spin.
+
+    Según ``logicaSpin.md``, el historial debe distinguir el ámbito con los
+    valores internos ``GENERAL`` y ``COMUNIDADES``. Los registros previos a esta
+    columna pertenecen al Spin General, por lo que se rellenan como ``GENERAL``.
+    """
+    engine = engine or conexionEngine()
+    inspector = inspect(engine)
+    columnas_spin = {columna["name"] for columna in inspector.get_columns(Spin.__tablename__)}
+
+    with engine.begin() as conexion:
+        if "ambito" not in columnas_spin:
+            conexion.execute(
+                text(
+                    "ALTER TABLE Spin ADD COLUMN ambito VARCHAR(32) NOT NULL DEFAULT 'GENERAL'"
+                )
+            )
+        conexion.execute(
+            text(
+                "UPDATE Spin SET ambito = :ambito_general "
+                "WHERE ambito IS NULL OR ambito = ''"
+            ),
+            {"ambito_general": AMBITO_SPIN_GENERAL},
+        )
 
 
 def insertar_spin(usuario, fecha, tipo, ambito=AMBITO_SPIN_GENERAL):
@@ -149,19 +176,12 @@ def insertar_spin(usuario, fecha, tipo, ambito=AMBITO_SPIN_GENERAL):
     Session = sessionmaker(bind=engine)
     session = Session()
     try:
-        columnas_spin = {columna["name"] for columna in inspect(engine).get_columns(Spin.__tablename__)}
-        valores = {"usuario": usuario, "fecha": fecha, "tipo": tipo}
-        if "ambito" in columnas_spin:
-            valores["ambito"] = ambito_normalizado
-            session.execute(
-                text("INSERT INTO Spin (`user`, fecha, tipo, ambito) VALUES (:usuario, :fecha, :tipo, :ambito)"),
-                valores,
-            )
-        else:
-            session.execute(
-                text("INSERT INTO Spin (`user`, fecha, tipo) VALUES (:usuario, :fecha, :tipo)"),
-                valores,
-            )
+        asegurar_columna_ambito_spin(engine)
+        valores = {"usuario": usuario, "fecha": fecha, "tipo": tipo, "ambito": ambito_normalizado}
+        session.execute(
+            text("INSERT INTO Spin (`user`, fecha, tipo, ambito) VALUES (:usuario, :fecha, :tipo, :ambito)"),
+            valores,
+        )
         session.commit()
     except Exception as e:
         session.rollback()

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -2342,23 +2342,14 @@ async def obtener_spins_recientes(interaction: discord.Interaction, minutos: int
             return
 
         # Realizar la consulta filtrando por fecha y, si procede, por ámbito.
-        # Si la base de datos aún no tiene `Spin.ambito`, los registros heredados
-        # se muestran como GENERAL para mantener la compatibilidad del Spin actual.
-        columnas_spin = {columna["name"] for columna in GestorSQL.inspect(GestorSQL.conexionEngine()).get_columns(GestorSQL.Spin.__tablename__)}
-        if "ambito" in columnas_spin:
-            consulta = session.query(GestorSQL.Spin.fecha, GestorSQL.Spin.user, GestorSQL.Spin.tipo, GestorSQL.Spin.ambito).\
-                filter(GestorSQL.Spin.fecha >= tiempo_desde)
-            if ambito_normalizado != AMBITO_SPIN_TODOS:
-                consulta = consulta.filter(GestorSQL.Spin.ambito == ambito_normalizado)
-            resultados = consulta.all()
-        else:
-            if ambito_normalizado == AMBITO_SPIN_COMUNIDADES:
-                resultados = []
-            else:
-                resultados = [
-                    (fecha, usuario, tipo, AMBITO_SPIN_GENERAL)
-                    for fecha, usuario, tipo in session.query(GestorSQL.Spin.fecha, GestorSQL.Spin.user, GestorSQL.Spin.tipo).filter(GestorSQL.Spin.fecha >= tiempo_desde).all()
-                ]
+        # La rutina idempotente añade `Spin.ambito` si falta y marca como GENERAL
+        # los registros heredados antes de consultar el historial.
+        GestorSQL.asegurar_columna_ambito_spin(GestorSQL.conexionEngine())
+        consulta = session.query(GestorSQL.Spin.fecha, GestorSQL.Spin.user, GestorSQL.Spin.tipo, GestorSQL.Spin.ambito).\
+            filter(GestorSQL.Spin.fecha >= tiempo_desde)
+        if ambito_normalizado != AMBITO_SPIN_TODOS:
+            consulta = consulta.filter(GestorSQL.Spin.ambito == ambito_normalizado)
+        resultados = consulta.all()
         
         # Formatear los resultados en Markdown
         tabla_markdown = "```| Fecha (Europe/Madrid) | Usuario | Acción | Ámbito |\n|----------------------|---------|--------|--------|"

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -767,3 +767,33 @@ def test_mensaje_spin_reservado_comunidades_usa_contexto_o_fallback():
     )
     assert mensaje_spin_reservado(incompleto) == "Spin de comunidades reservado: <@102> y <@101> pueden buscar partido."
     assert "None" not in mensaje_spin_reservado(incompleto)
+
+
+def test_asegurar_columna_ambito_spin_migra_registros_heredados():
+    from sqlalchemy import create_engine, inspect, text
+    from SpinConstantes import AMBITO_SPIN_GENERAL
+    from GestorSQL import asegurar_columna_ambito_spin
+
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conexion:
+        conexion.execute(
+            text(
+                "CREATE TABLE Spin ("
+                "idCalendario INTEGER PRIMARY KEY, "
+                "`user` VARCHAR, "
+                "fecha DATETIME, "
+                "tipo VARCHAR"
+                ")"
+            )
+        )
+        conexion.execute(
+            text("INSERT INTO Spin (idCalendario, `user`, fecha, tipo) VALUES (1, 'Coach', '2026-06-18 10:00:00', 'Spin')")
+        )
+
+    asegurar_columna_ambito_spin(engine)
+
+    columnas = {columna["name"] for columna in inspect(engine).get_columns("Spin")}
+    assert "ambito" in columnas
+    with engine.connect() as conexion:
+        ambitos = conexion.execute(text("SELECT ambito FROM Spin")).scalars().all()
+    assert ambitos == [AMBITO_SPIN_GENERAL]


### PR DESCRIPTION
### Motivation
- Diferenciar el historial de `Spin` por ámbito para poder filtrar `/ultimosspins` entre `GENERAL` y `COMUNIDADES` según lo definido en `logicaSpin.md`.
- Mantener compatibilidad con bases de datos antiguas asignando `GENERAL` a los registros previos y asegurando una migración idempotente.

### Description
- Se añade la columna `ambito` al modelo `Spin` como `VARCHAR(32) NOT NULL` con `default` y `server_default` `AMBITO_SPIN_GENERAL` en `GestorSQL.py`.
- Se implementa la rutina idempotente `asegurar_columna_ambito_spin(engine=None)` que crea la columna si falta y rellena registros antiguos vacíos/NULL con `GENERAL`.
- Se actualiza `insertar_spin` para normalizar el ámbito y ejecutar `asegurar_columna_ambito_spin` antes de insertar siempre la columna `ambito`.
- Se modifica el comando `/ultimosspins` en `LombardBot.py` para ejecutar la rutina de asegurado antes de consultar y filtrar por `Spin.ambito`, y se añade una migración SQL en `BD/spin_ambito_migration.sql` para despliegue manual.
- Se añade una prueba `test_asegurar_columna_ambito_spin_migra_registros_heredados` en `tests/test_spin_comunidades.py` que valida la migración sobre una tabla `Spin` heredada.

### Testing
- Se ejecutó `PYTHONPATH=. pytest -q tests/test_spin_comunidades.py` y todos los tests del fichero pasaron (`22 passed`).
- Se compiló el código con `python3 -m py_compile GestorSQL.py LombardBot.py` sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a345763e000832a81669d5493852ae5)