### PR TITLE
Registra ámbito en pulsaciones Spin heredadas

### DIFF
--- a/ComandosAntiguos.py
+++ b/ComandosAntiguos.py
@@ -377,7 +377,7 @@ class SpinButtonsView(discord.ui.View):
             if mensaje:
                 await mensaje.edit(content=f'**{UsuarioSpin} puede buscar partido**')
             
-            thread = Thread(target=GestorSQL.insertar_spin, args=(UsuarioSpin, now, 'Spin'))
+            thread = Thread(target=GestorSQL.insertar_spin, args=(UsuarioSpin, now, 'Spin', 'GENERAL'))
             thread.start()
 
     @discord.ui.button(label="Encontrado",style=discord.ButtonStyle.blurple, custom_id='your_bot:encontrado')


### PR DESCRIPTION
### Motivation
- `logicaSpin.md` exige que el historial de Spin distinga el `ambito` (`GENERAL`/`COMUNIDADES`) y la inserción heredada no incluía ese campo, por lo que las pulsaciones antiguas quedaban sin ámbito auditado.

### Description
- Se actualiza `ComandosAntiguos.py` para llamar a `GestorSQL.insertar_spin(..., 'GENERAL')` cuando registra `tipo = 'Spin'`, preservando el papel actual de `tipo` y delegando en `GestorSQL.insertar_spin` la normalización y persistencia del campo `ambito`.

### Testing
- Se ejecutaron compilaciones estáticas con `python -m py_compile GestorSQL.py UtilesDiscord.py SpinConstantes.py ComandosAntiguos.py` y todas terminaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347a380f58832ab2b5e0487ab773bb)