### PR TITLE
Audita ámbito y usuario en historial Spin

### DIFF
--- a/BD/spin_ambito_migration.sql
+++ b/BD/spin_ambito_migration.sql
@@ -23,3 +23,21 @@ DEALLOCATE PREPARE spin_ambito_stmt;
 UPDATE Spin
 SET ambito = 'GENERAL'
 WHERE ambito IS NULL OR ambito = '';
+
+SET @spin_usuario_discord_columna := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'Spin'
+    AND COLUMN_NAME = 'usuario_discord_id'
+);
+
+SET @spin_usuario_discord_sql := IF(
+  @spin_usuario_discord_columna = 0,
+  'ALTER TABLE Spin ADD COLUMN usuario_discord_id BIGINT NULL',
+  'SELECT 1'
+);
+
+PREPARE spin_usuario_discord_stmt FROM @spin_usuario_discord_sql;
+EXECUTE spin_usuario_discord_stmt;
+DEALLOCATE PREPARE spin_usuario_discord_stmt;

--- a/GestorSQL.py
+++ b/GestorSQL.py
@@ -138,14 +138,17 @@ class Spin(Base):
     fecha = Column('fecha', DateTime)
     tipo = Column('tipo', String)
     ambito = Column('ambito', String(32), nullable=False, default=AMBITO_SPIN_GENERAL, server_default=AMBITO_SPIN_GENERAL)
+    usuario_discord_id = Column('usuario_discord_id', BigInteger, nullable=True)
 
 
-def asegurar_columna_ambito_spin(engine=None):
-    """Garantiza la columna de ámbito en el historial de Spin.
+def asegurar_columnas_historial_spin(engine=None):
+    """Garantiza las columnas de auditoría en el historial de Spin.
 
     Según ``logicaSpin.md``, el historial debe distinguir el ámbito con los
-    valores internos ``GENERAL`` y ``COMUNIDADES``. Los registros previos a esta
-    columna pertenecen al Spin General, por lo que se rellenan como ``GENERAL``.
+    valores internos ``GENERAL`` y ``COMUNIDADES``. Además, para las liberaciones
+    manuales debe quedar registrado el usuario de Discord que pulsó
+    ``Encontrado``. Los registros previos a ``ambito`` pertenecen al Spin
+    General, por lo que se rellenan como ``GENERAL``.
     """
     engine = engine or conexionEngine()
     inspector = inspect(engine)
@@ -158,6 +161,12 @@ def asegurar_columna_ambito_spin(engine=None):
                     "ALTER TABLE Spin ADD COLUMN ambito VARCHAR(32) NOT NULL DEFAULT 'GENERAL'"
                 )
             )
+        if "usuario_discord_id" not in columnas_spin:
+            conexion.execute(
+                text(
+                    "ALTER TABLE Spin ADD COLUMN usuario_discord_id BIGINT NULL"
+                )
+            )
         conexion.execute(
             text(
                 "UPDATE Spin SET ambito = :ambito_general "
@@ -167,7 +176,12 @@ def asegurar_columna_ambito_spin(engine=None):
         )
 
 
-def insertar_spin(usuario, fecha, tipo, ambito=AMBITO_SPIN_GENERAL):
+def asegurar_columna_ambito_spin(engine=None):
+    """Compatibilidad: delega en la rutina completa de historial Spin."""
+    asegurar_columnas_historial_spin(engine)
+
+
+def insertar_spin(usuario, fecha, tipo, ambito=AMBITO_SPIN_GENERAL, usuario_discord_id=None):
     # Esta es la función que inserta un nuevo Spin en la base de datos.
     # Los Spins heredados son Spin General, pero el despliegue puede convivir
     # temporalmente con bases de datos donde aún no exista la columna `ambito`.
@@ -176,10 +190,19 @@ def insertar_spin(usuario, fecha, tipo, ambito=AMBITO_SPIN_GENERAL):
     Session = sessionmaker(bind=engine)
     session = Session()
     try:
-        asegurar_columna_ambito_spin(engine)
-        valores = {"usuario": usuario, "fecha": fecha, "tipo": tipo, "ambito": ambito_normalizado}
+        asegurar_columnas_historial_spin(engine)
+        valores = {
+            "usuario": usuario,
+            "fecha": fecha,
+            "tipo": tipo,
+            "ambito": ambito_normalizado,
+            "usuario_discord_id": usuario_discord_id,
+        }
         session.execute(
-            text("INSERT INTO Spin (`user`, fecha, tipo, ambito) VALUES (:usuario, :fecha, :tipo, :ambito)"),
+            text(
+                "INSERT INTO Spin (`user`, fecha, tipo, ambito, usuario_discord_id) "
+                "VALUES (:usuario, :fecha, :tipo, :ambito, :usuario_discord_id)"
+            ),
             valores,
         )
         session.commit()

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -2344,12 +2344,12 @@ async def obtener_spins_recientes(interaction: discord.Interaction, minutos: int
         # Realizar la consulta filtrando por fecha y, si procede, por ámbito.
         # La rutina idempotente añade `Spin.ambito` si falta y marca como GENERAL
         # los registros heredados antes de consultar el historial.
-        GestorSQL.asegurar_columna_ambito_spin(GestorSQL.conexionEngine())
+        GestorSQL.asegurar_columnas_historial_spin(GestorSQL.conexionEngine())
         consulta = session.query(GestorSQL.Spin.fecha, GestorSQL.Spin.user, GestorSQL.Spin.tipo, GestorSQL.Spin.ambito).\
             filter(GestorSQL.Spin.fecha >= tiempo_desde)
         if ambito_normalizado != AMBITO_SPIN_TODOS:
             consulta = consulta.filter(GestorSQL.Spin.ambito == ambito_normalizado)
-        resultados = consulta.all()
+        resultados = consulta.order_by(GestorSQL.Spin.fecha.asc(), GestorSQL.Spin.idSpin.asc()).all()
         
         # Formatear los resultados en Markdown
         tabla_markdown = "```| Fecha (Europe/Madrid) | Usuario | Acción | Ámbito |\n|----------------------|---------|--------|--------|"

--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -821,7 +821,7 @@ class SpinButtonsView(discord.ui.View):
                         await canal_partido.send(f'<@{coach1_id_discord}> y <@{coach2_id_discord}> podéis spinear')
 
                 await interaction.followup.send(f"Ahora puedes buscar partido en {self.nombre_ambito()}.", ephemeral=True)
-                thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Spin', ambito))
+                thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Spin', ambito, user.id))
                 thread.start()
             finally:
                 session.close()
@@ -863,7 +863,7 @@ class SpinButtonsView(discord.ui.View):
             print(f"No se pudo editar el primer mensaje de {self.nombre_ambito()} al liberar: {exc}")
 
         await interaction.followup.send(f"Has liberado el {self.nombre_ambito()}.", ephemeral=True)
-        thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Encontrado', ambito))
+        thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Encontrado', ambito, user.id))
         thread.start()
 
             


### PR DESCRIPTION
### Motivation

- Registrar en el historial no solo el `tipo` y el `ambito` sino también qué usuario de Discord ejecutó la acción para poder auditar liberaciones manuales y el orden intercalado de `Spin`/`Encontrado` según `logicaSpin.md`.

### Description

- Añade la columna `usuario_discord_id` al modelo `Spin` y a la migración idempotente `BD/spin_ambito_migration.sql` para almacenar el Discord ID del usuario que pulsa `Spin`/`Encontrado`.
- Amplía la rutina de preparación de la tabla (`asegurar_columnas_historial_spin`) para garantizar `ambito` y `usuario_discord_id`, y deja un adaptador de compatibilidad `asegurar_columna_ambito_spin` que delega en la nueva rutina.
- Extiende `insertar_spin` para aceptar el nuevo argumento `usuario_discord_id` y guardar `ambito` y `usuario_discord_id` en la inserción; las llamadas desde la vista de botones ahora pasan `user.id` para ambos eventos `Spin` y `Encontrado` (`UtilesDiscord.SpinButtonsView`).
- Mejora la consulta de `/ultimosspins` en `LombardBot.py` para ordenar por `fecha` y por `idSpin` garantizando un orden determinista y auditable de eventos con el mismo timestamp.

### Testing

- `python3 -m compileall GestorSQL.py UtilesDiscord.py LombardBot.py` se ejecutó correctamente y compiló los módulos modificados.
- `pytest -q tests/test_spin_comunidades.py` no pudo ejecutarse en este entorno por falta de la dependencia `sqlalchemy`, por lo que los tests unitarios no se completaron aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347b3df594832abfc6ab6d8b567bd5)