### PR TITLE
Registrar liberación por timeout como AutoRelease y añadir trazabilidad de ámbito

### DIFF
--- a/SpinConstantes.py
+++ b/SpinConstantes.py
@@ -20,6 +20,9 @@ AMBITO_SPIN_GENERAL = AmbitoSpin.GENERAL.value
 AMBITO_SPIN_COMUNIDADES = AmbitoSpin.COMUNIDADES.value
 AMBITOS_SPIN = frozenset(ambito.value for ambito in AmbitoSpin)
 AMBITO_SPIN_TODOS = "TODOS"
+TIPO_SPIN = "Spin"
+TIPO_SPIN_ENCONTRADO = "Encontrado"
+TIPO_SPIN_AUTO_RELEASE = "AutoRelease"
 
 MENSAJES_SPIN_LIBRE = {
     AMBITO_SPIN_GENERAL: "El Spin General está **LIBRE**",

--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -19,6 +19,9 @@ import GestorSQL
 from SpinConstantes import (
     AMBITO_SPIN_COMUNIDADES,
     AMBITO_SPIN_GENERAL,
+    TIPO_SPIN,
+    TIPO_SPIN_AUTO_RELEASE,
+    TIPO_SPIN_ENCONTRADO,
     CANAL_SPIN_COMUNIDADES_ID,
     CANAL_SPIN_GENERAL_ID,
     mensaje_spin_libre,
@@ -739,7 +742,7 @@ class SpinButtonsView(discord.ui.View):
         except Exception as exc:
             print(f"No se pudo editar el primer mensaje de {nombre_ambito} tras timeout: {exc}")
 
-        thread = Thread(target=GestorSQL.insertar_spin, args=('LOMBARDBOT', datetime.utcnow(), 'Encontrado', ambito))
+        thread = Thread(target=GestorSQL.insertar_spin, args=('LOMBARDBOT', datetime.utcnow(), TIPO_SPIN_AUTO_RELEASE, ambito))
         thread.start()
 
     def actualizar_botones(self, spin_habilitado):
@@ -821,7 +824,7 @@ class SpinButtonsView(discord.ui.View):
                         await canal_partido.send(f'<@{coach1_id_discord}> y <@{coach2_id_discord}> podéis spinear')
 
                 await interaction.followup.send(f"Ahora puedes buscar partido en {self.nombre_ambito()}.", ephemeral=True)
-                thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Spin', ambito, user.id))
+                thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), TIPO_SPIN, ambito, user.id))
                 thread.start()
             finally:
                 session.close()
@@ -863,7 +866,7 @@ class SpinButtonsView(discord.ui.View):
             print(f"No se pudo editar el primer mensaje de {self.nombre_ambito()} al liberar: {exc}")
 
         await interaction.followup.send(f"Has liberado el {self.nombre_ambito()}.", ephemeral=True)
-        thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), 'Encontrado', ambito, user.id))
+        thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), TIPO_SPIN_ENCONTRADO, ambito, user.id))
         thread.start()
 
             

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -619,6 +619,7 @@ async def test_timeout_libera_solo_la_reserva_exacta_de_su_ambito(monkeypatch):
     mensajes_canal = []
     dms = []
     edits = []
+    inserciones_historial = []
 
     async def sleep_inmediato(segundos):
         assert segundos == 300
@@ -644,8 +645,17 @@ async def test_timeout_libera_solo_la_reserva_exacta_de_su_ambito(monkeypatch):
                 yield Message()
             return iterator()
 
+    class ThreadFake:
+        def __init__(self, target=None, args=(), kwargs=None):
+            self.target = target
+            self.args = args
+            self.kwargs = kwargs or {}
+
+        def start(self):
+            inserciones_historial.append((self.target, self.args, self.kwargs))
+
     monkeypatch.setattr(UtilesDiscord.asyncio, "sleep", sleep_inmediato)
-    monkeypatch.setattr(UtilesDiscord.Thread, "start", lambda self: None)
+    monkeypatch.setattr(UtilesDiscord, "Thread", ThreadFake)
 
     reserva_general = SimpleNamespace(
         ambito=AMBITO_SPIN_GENERAL,
@@ -676,6 +686,13 @@ async def test_timeout_libera_solo_la_reserva_exacta_de_su_ambito(monkeypatch):
         assert mensajes_canal == ["El Spin General ha sido liberado automáticamente. 😡 Afortunadamente las máquinas somos superiores y cuidamos de los esmirriados humanos."]
         assert dms == [(10, 'Tu spin ha sido liberado automáticamente debido a la inactividad.')]
         assert any(edit.get("content") == "El Spin General está **LIBRE**" for edit in edits)
+        assert len(inserciones_historial) == 1
+        target, args, kwargs = inserciones_historial[0]
+        assert target is UtilesDiscord.GestorSQL.insertar_spin
+        assert args[0] == "LOMBARDBOT"
+        assert args[2] == "AutoRelease"
+        assert args[3] == AMBITO_SPIN_GENERAL
+        assert kwargs == {}
     finally:
         UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = None
         UtilesDiscord.reservas_spin[AMBITO_SPIN_COMUNIDADES] = None
@@ -720,6 +737,38 @@ async def test_timeout_antiguo_no_libera_reserva_nueva_del_mismo_ambito(monkeypa
         assert mensajes_canal == []
     finally:
         UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = None
+
+
+
+def test_insertar_spin_mantiene_compatibilidad_timeout_heredado_encontrado(monkeypatch):
+    from sqlalchemy import create_engine, text
+    import GestorSQL
+    from SpinConstantes import AMBITO_SPIN_GENERAL
+
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conexion:
+        conexion.execute(
+            text(
+                "CREATE TABLE Spin ("
+                "idCalendario INTEGER PRIMARY KEY, "
+                "`user` VARCHAR, "
+                "fecha DATETIME, "
+                "tipo VARCHAR"
+                ")"
+            )
+        )
+
+    monkeypatch.setattr(GestorSQL, "conexionEngine", lambda: engine)
+
+    fecha = datetime(2026, 6, 18, 20, 17)
+    GestorSQL.insertar_spin("LOMBARDBOT", fecha, "Encontrado", AMBITO_SPIN_GENERAL)
+
+    with engine.connect() as conexion:
+        fila = conexion.execute(
+            text("SELECT `user`, tipo, ambito, usuario_discord_id FROM Spin")
+        ).one()
+
+    assert fila == ("LOMBARDBOT", "Encontrado", AMBITO_SPIN_GENERAL, None)
 
 
 def test_mensaje_spin_reservado_se_construye_desde_spin_match_result():


### PR DESCRIPTION
### Motivation
- Hacer que las liberaciones automáticas por timeout queden claramente trazadas en el historial siguiendo `logicaSpin.md` (usar el tipo recomendado `AutoRelease`).
- Mantener la compatibilidad con los registros actuales que pueden mostrar `Encontrado` por `LOMBARDBOT` y preservar el campo `ambito` en el historial.
- Evitar romper la funcionalidad de consulta de historial `/ultimosspins` al añadir la nueva trazabilidad.

### Description
- Se añaden constantes centralizadas de tipos de evento en `SpinConstantes.py`: `TIPO_SPIN`, `TIPO_SPIN_ENCONTRADO` y `TIPO_SPIN_AUTO_RELEASE`.
- Se modifica `UtilesDiscord.py` para registrar las inserciones en historial usando las nuevas constantes; específicamente la liberación por timeout usa ahora `TIPO_SPIN_AUTO_RELEASE` con usuario `LOMBARDBOT` y se sigue pasando `ambito`.
- Se actualizan las llamadas existentes a `GestorSQL.insertar_spin` para usar `TIPO_SPIN` y `TIPO_SPIN_ENCONTRADO` donde procedía, manteniendo la normalización de `ambito` dentro de `insertar_spin`.
- Se añaden/ajustan tests en `tests/test_spin_comunidades.py` para verificar que el timeout genera una inserción `AutoRelease` con `ambito` y que persiste la compatibilidad con registros heredados que usan `LOMBARDBOT`/`Encontrado`.

### Testing
- Se ejecutó `PYTHONPATH=. pytest -q tests/test_spin_comunidades.py` y todos los tests del módulo pasaron (`23 passed`, `9 warnings`).
- Las pruebas incluyen comprobaciones unitarias de `SpinButtonsView.auto_release_spin` que verifican la edición del mensaje, envío de DM, y la llamada a `GestorSQL.insertar_spin` con `AutoRelease` y `ambito`.
- Se añadió un test que valida que `GestorSQL.insertar_spin` mantiene compatibilidad con tablas heredadas sin columna `ambito` y rellena `GENERAL` cuando procede.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347c3223b4832a8a4af6fbdd0d91b4)