### PR TITLE
Filtra /ultimosspins por ámbito

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -37,6 +37,7 @@ from SpinConstantes import (
     AMBITO_SPIN_TODOS,
     ayuda_agregar_mensaje_spin,
     mensaje_spin_libre,
+    normalizar_filtro_historial_spin,
     normalizar_ambito_spin,
 )
 import GestionExcel
@@ -2336,8 +2337,8 @@ async def obtener_spins_recientes(interaction: discord.Interaction, minutos: int
     tiempo_desde = datetime.utcnow() - timedelta(minutes=minutos)
     
     try:
-        ambito_normalizado = normalizar_ambito_spin(ambito, permitir_todos=True)
-        if ambito_normalizado is None:
+        filtro_ambito = normalizar_filtro_historial_spin(ambito)
+        if filtro_ambito is None and normalizar_ambito_spin(ambito, permitir_todos=True) != AMBITO_SPIN_TODOS:
             await interaction.response.send_message("```Ámbito no válido. Usa General, Comunidades o Todos.```", ephemeral=True)
             return
 
@@ -2347,8 +2348,8 @@ async def obtener_spins_recientes(interaction: discord.Interaction, minutos: int
         GestorSQL.asegurar_columnas_historial_spin(GestorSQL.conexionEngine())
         consulta = session.query(GestorSQL.Spin.fecha, GestorSQL.Spin.user, GestorSQL.Spin.tipo, GestorSQL.Spin.ambito).\
             filter(GestorSQL.Spin.fecha >= tiempo_desde)
-        if ambito_normalizado != AMBITO_SPIN_TODOS:
-            consulta = consulta.filter(GestorSQL.Spin.ambito == ambito_normalizado)
+        if filtro_ambito:
+            consulta = consulta.filter(GestorSQL.Spin.ambito == filtro_ambito)
         resultados = consulta.order_by(GestorSQL.Spin.fecha.asc(), GestorSQL.Spin.idSpin.asc()).all()
         
         # Formatear los resultados en Markdown

--- a/SpinConstantes.py
+++ b/SpinConstantes.py
@@ -96,3 +96,17 @@ def normalizar_ambito_spin(texto, *, permitir_todos=False):
 
     opciones = _TEXTOS_AMBITO_SPIN_TODOS if permitir_todos else _TEXTOS_AMBITO_SPIN
     return opciones.get(_normalizar_texto_ambito(texto))
+
+
+def normalizar_filtro_historial_spin(texto):
+    """Normaliza el filtro de ámbito de ``/ultimosspins``.
+
+    ``logicaSpin.md`` define que el valor de usuario ``Todos`` no debe aplicar
+    filtro de ámbito, mientras que ``General`` y ``Comunidades`` deben
+    convertirse a los valores canónicos persistidos en el historial.
+    """
+
+    ambito = normalizar_ambito_spin(texto, permitir_todos=True)
+    if ambito == AMBITO_SPIN_TODOS:
+        return None
+    return ambito


### PR DESCRIPTION
### Motivation
- `logicaSpin.md` requiere que el comando `/ultimosspins` acepte un argumento `ambito` con valores `Todos`, `General` y `Comunidades` y que `Todos` signifique “sin filtro”, mientras que `General`/`Comunidades` se normalicen a los valores canónicos persistidos (`GENERAL`/`COMUNIDADES`).
- El cambio busca aplicar ese comportamiento en la consulta de historial sin romper la compatibilidad con el valor por defecto `Todos`.

### Description
- Añadida la función `normalizar_filtro_historial_spin` en `SpinConstantes.py` para convertir `Todos` en `None` (sin filtro) y mapear `General`/`Comunidades` a `GENERAL`/`COMUNIDADES` internamente. 
- Actualizado `LombardBot.py` para importar `normalizar_filtro_historial_spin` y usarlo en el handler de `/ultimosspins` para validar el argumento y decidir si aplicar el filtro SQL por `Spin.ambito`.
- La consulta SQL ahora aplica la cláusula `WHERE Spin.ambito = ...` solo cuando el filtro normalizado devuelve un ámbito concreto, preservando el comportamiento por defecto sin filtro para `Todos` y manteniendo la columna de ámbito en la presentación.

### Testing
- Se compiló el código con `python -m py_compile SpinConstantes.py LombardBot.py` y la comprobación pasó correctamente. 
- Se ejecutó un pequeño script `python - <<'PY' ...` para comprobar `normalizar_filtro_historial_spin('Todos')`, `normalizar_filtro_historial_spin('General')` y `normalizar_filtro_historial_spin('Comunidades')`, que devolvieron `None`, `GENERAL` y `COMUNIDADES` respectivamente. 
- Se intentó correr `pytest -q tests/test_spin_comunidades.py`, pero la ejecución quedó bloqueada por la falta de la dependencia `sqlalchemy` en el entorno de pruebas (no se pudieron ejecutar los tests de integración que requieren DB en este entorno).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347d54a774832a8e7d44743b25ddba)