### PR TITLE
Mostrar ámbito en cada entrada de /ultimosspins

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -37,6 +37,7 @@ from SpinConstantes import (
     AMBITO_SPIN_TODOS,
     ayuda_agregar_mensaje_spin,
     mensaje_spin_libre,
+    formatear_historial_spins,
     normalizar_filtro_historial_spin,
     normalizar_ambito_spin,
 )
@@ -2352,15 +2353,9 @@ async def obtener_spins_recientes(interaction: discord.Interaction, minutos: int
             consulta = consulta.filter(GestorSQL.Spin.ambito == filtro_ambito)
         resultados = consulta.order_by(GestorSQL.Spin.fecha.asc(), GestorSQL.Spin.idSpin.asc()).all()
         
-        # Formatear los resultados en Markdown
-        tabla_markdown = "```| Fecha (Europe/Madrid) | Usuario | Acción | Ámbito |\n|----------------------|---------|--------|--------|"
-        for fecha, usuario, tipo, ambito_registro in resultados:
-            fecha_madrid = fecha.replace(tzinfo=ZoneInfo('UTC')).astimezone(ZoneInfo('Europe/Madrid')) if fecha.tzinfo is None else fecha.astimezone(ZoneInfo('Europe/Madrid'))
-            tabla_markdown += f"\n| {fecha_madrid.strftime('%Y-%m-%d %H:%M:%S')} | {usuario} | {tipo} | {ambito_registro or AMBITO_SPIN_GENERAL} |"
-        
-        tabla_markdown += "```"
-        
-        await interaction.response.send_message(tabla_markdown)
+        # Formatear los resultados como líneas compactas con ámbito explícito en
+        # cada registro, incluso cuando `/ultimosspins` se filtra por ámbito.
+        await interaction.response.send_message(formatear_historial_spins(resultados))
     except Exception as e:
         print(f"Error al consultar la tabla Spin: {e}")
         await interaction.response.send_message("```Error al realizar la consulta.```")

--- a/SpinConstantes.py
+++ b/SpinConstantes.py
@@ -7,6 +7,8 @@ antes de usarse en la lógica o persistirse.
 
 from enum import Enum
 import unicodedata
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 
 class AmbitoSpin(str, Enum):
@@ -96,6 +98,37 @@ def normalizar_ambito_spin(texto, *, permitir_todos=False):
 
     opciones = _TEXTOS_AMBITO_SPIN_TODOS if permitir_todos else _TEXTOS_AMBITO_SPIN
     return opciones.get(_normalizar_texto_ambito(texto))
+
+
+def formatear_linea_historial_spin(fecha, usuario, tipo, ambito):
+    """Devuelve una línea no ambigua para el historial de ``/ultimosspins``.
+
+    ``logicaSpin.md`` recomienda que cada registro visible incluya el ámbito
+    incluso cuando la consulta ya esté filtrada por ``General`` o
+    ``Comunidades``. El formato mantiene la lectura compacta heredada:
+    ``[GENERAL] Usuario - Spin - fecha``.
+    """
+
+    ambito_normalizado = normalizar_ambito_spin(ambito) or AMBITO_SPIN_GENERAL
+    if isinstance(fecha, datetime):
+        fecha_madrid = (
+            fecha.replace(tzinfo=ZoneInfo("UTC")).astimezone(ZoneInfo("Europe/Madrid"))
+            if fecha.tzinfo is None
+            else fecha.astimezone(ZoneInfo("Europe/Madrid"))
+        )
+        fecha_texto = fecha_madrid.strftime("%Y-%m-%d %H:%M:%S")
+    else:
+        fecha_texto = str(fecha)
+    return f"[{ambito_normalizado}] {usuario} - {tipo} - {fecha_texto}"
+
+
+def formatear_historial_spins(registros):
+    """Formatea registros de Spin como bloque de líneas con ámbito explícito."""
+
+    lineas = ["Historial de Spin (Europe/Madrid)"]
+    for fecha, usuario, tipo, ambito in registros:
+        lineas.append(formatear_linea_historial_spin(fecha, usuario, tipo, ambito))
+    return "```" + "\n".join(lineas) + "```"
 
 
 def normalizar_filtro_historial_spin(texto):

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -846,3 +846,28 @@ def test_asegurar_columna_ambito_spin_migra_registros_heredados():
     with engine.connect() as conexion:
         ambitos = conexion.execute(text("SELECT ambito FROM Spin")).scalars().all()
     assert ambitos == [AMBITO_SPIN_GENERAL]
+
+
+def test_formatear_historial_spins_muestra_ambito_en_cada_linea():
+    from SpinConstantes import AMBITO_SPIN_GENERAL, formatear_historial_spins
+
+    salida = formatear_historial_spins(
+        [
+            (datetime(2026, 6, 18, 18, 15), "UsuarioX", "Spin", AMBITO_SPIN_GENERAL),
+            (datetime(2026, 6, 18, 18, 20), "UsuarioY", "Encontrado", AMBITO_SPIN_COMUNIDADES),
+        ]
+    )
+
+    assert "[GENERAL] UsuarioX - Spin - 2026-06-18 20:15:00" in salida
+    assert "[COMUNIDADES] UsuarioY - Encontrado - 2026-06-18 20:20:00" in salida
+    assert "| Ámbito |" not in salida
+
+
+def test_formatear_historial_spins_asume_general_para_registros_heredados():
+    from SpinConstantes import formatear_historial_spins
+
+    salida = formatear_historial_spins(
+        [(datetime(2026, 6, 18, 18, 15), "UsuarioX", "Spin", None)]
+    )
+
+    assert "[GENERAL] UsuarioX - Spin - 2026-06-18 20:15:00" in salida


### PR DESCRIPTION
### Motivation

- Evitar ambigüedad al consultar el historial de Spin mostrando explícitamente el ámbito en cada registro como especifica `logicaSpin.md`.

### Description

- Se centraliza el formateo del historial en `SpinConstantes.py` con `formatear_linea_historial_spin` y `formatear_historial_spins` que producen líneas del tipo `[ÁMBITO] Usuario - Acción - fecha` y convierten fechas a `Europe/Madrid`.
- `obtener_spins_recientes` en `LombardBot.py` pasa a usar `formatear_historial_spins` en lugar de la tabla Markdown previa para asegurar que cada línea incluye el ámbito aun cuando se aplique un filtro.
- La implementación trata registros heredados sin `ambito` asignado como `GENERAL` y mantiene el formato compacto recomendado por la especificación.
- Se añadieron tests en `tests/test_spin_comunidades.py` que verifican la presentación del ámbito por línea y el comportamiento con registros heredados.

### Testing

- `python -m py_compile SpinConstantes.py LombardBot.py` se ejecutó correctamente y no reportó errores.
- `git diff --check` se ejecutó correctamente y no reportó problemas de formato.
- `pytest tests/test_spin_comunidades.py -q` no pudo ejecutarse en este entorno debido a la falta de la dependencia `sqlalchemy` (`ModuleNotFoundError: No module named 'sqlalchemy'`), por lo que los tests añadidos no se corrieron aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347e0416a8832a9ed050bef82977c3)