### PR TITLE
Evita retener sesiones SQL en Spin

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -2365,34 +2365,38 @@ async def PruebaBD(ctx):
 async def obtener_spins_recientes(interaction: discord.Interaction, minutos: int, ambito: str = "Todos"):
     Session = sessionmaker(bind=GestorSQL.conexionEngine())
     session = Session()
-    
+
     # Calcular el momento de tiempo desde el cual queremos obtener los registros
     tiempo_desde = datetime.utcnow() - timedelta(minutes=minutos)
-    
+    respuesta = None
+    ephemeral = False
+
     try:
         filtro_ambito = normalizar_filtro_historial_spin(ambito)
         if filtro_ambito is None and normalizar_ambito_spin(ambito, permitir_todos=True) != AMBITO_SPIN_TODOS:
-            await interaction.response.send_message("```Ámbito no válido. Usa General, Comunidades o Todos.```", ephemeral=True)
-            return
+            respuesta = "```Ámbito no válido. Usa General, Comunidades o Todos.```"
+            ephemeral = True
+        else:
+            # Realizar la consulta filtrando por fecha y, si procede, por ámbito.
+            # La rutina idempotente añade `Spin.ambito` si falta y marca como GENERAL
+            # los registros heredados antes de consultar el historial.
+            GestorSQL.asegurar_columnas_historial_spin(GestorSQL.conexionEngine())
+            consulta = session.query(GestorSQL.Spin.fecha, GestorSQL.Spin.user, GestorSQL.Spin.tipo, GestorSQL.Spin.ambito).\
+                filter(GestorSQL.Spin.fecha >= tiempo_desde)
+            if filtro_ambito:
+                consulta = consulta.filter(GestorSQL.Spin.ambito == filtro_ambito)
+            resultados = consulta.order_by(GestorSQL.Spin.fecha.asc(), GestorSQL.Spin.idSpin.asc()).all()
 
-        # Realizar la consulta filtrando por fecha y, si procede, por ámbito.
-        # La rutina idempotente añade `Spin.ambito` si falta y marca como GENERAL
-        # los registros heredados antes de consultar el historial.
-        GestorSQL.asegurar_columnas_historial_spin(GestorSQL.conexionEngine())
-        consulta = session.query(GestorSQL.Spin.fecha, GestorSQL.Spin.user, GestorSQL.Spin.tipo, GestorSQL.Spin.ambito).\
-            filter(GestorSQL.Spin.fecha >= tiempo_desde)
-        if filtro_ambito:
-            consulta = consulta.filter(GestorSQL.Spin.ambito == filtro_ambito)
-        resultados = consulta.order_by(GestorSQL.Spin.fecha.asc(), GestorSQL.Spin.idSpin.asc()).all()
-        
-        # Formatear los resultados como líneas compactas con ámbito explícito en
-        # cada registro, incluso cuando `/ultimosspins` se filtra por ámbito.
-        await interaction.response.send_message(formatear_historial_spins(resultados))
+            # Formatear los resultados dentro del scope SQL y responder después
+            # de cerrar la sesión para no retener conexiones durante Discord I/O.
+            respuesta = formatear_historial_spins(resultados)
     except Exception as e:
         print(f"Error al consultar la tabla Spin: {e}")
-        await interaction.response.send_message("```Error al realizar la consulta.```")
+        respuesta = "```Error al realizar la consulta.```"
     finally:
         session.close()
+
+    await interaction.response.send_message(respuesta, ephemeral=ephemeral)
         
 
 @bot.command(name="crearGrupos")

--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -821,65 +821,70 @@ class SpinButtonsView(discord.ui.View):
 
             Session = GestorSQL.sessionmaker(bind=GestorSQL.conexionEngine())
             session = Session()
-            timeout_task = None
             try:
                 usuario_db = session.query(GestorSQL.Usuario).filter(GestorSQL.Usuario.id_discord == user.id).first()
                 if not usuario_db:
-                    await interaction.followup.send("No se encontró tu usuario en la base de datos.", ephemeral=True)
-                    return
-
-                try:
-                    partido_spin = buscar_partido_spin(session, usuario_db, ambito)
-                except ValueError:
-                    await interaction.followup.send("El ámbito de Spin no es válido. Avise a un administrador.", ephemeral=True)
-                    return
-                if not partido_spin:
-                    await interaction.followup.send("No tienes ningún partido pendiente en esta cola de Spin.", ephemeral=True)
-                    return
-
-                canal_partido_id = partido_spin.canal_partido_id
-                coach1_id_discord = partido_spin.jugador1_discord_id
-                coach2_id_discord = partido_spin.jugador2_discord_id
-
-                canal_partido = interaction.guild.get_channel(canal_partido_id) if canal_partido_id else None
-                descripcion_partido = partido_spin.descripcion_corta
-                reserva = SpinReservation(ambito, user, coach1_id_discord, coach2_id_discord, interaction.channel, canal_partido, descripcion_partido, None, partido_spin)
-                timeout_task = asyncio.create_task(self.auto_release_spin(reserva))
-                reserva.timeout_task = timeout_task
-                guardar_reserva_spin(reserva)
-
-                self.actualizar_botones(spin_habilitado=False)
-                try:
-                    await editar_primer_mensaje_spin(
-                        interaction.channel,
-                        content=descripcion_partido,
-                        view=self,
-                    )
-                except Exception as exc:
-                    limpiar_reserva_spin(ambito)
-                    if timeout_task:
-                        timeout_task.cancel()
-                    self.actualizar_botones(spin_habilitado=True)
-                    await interaction.followup.send(
-                        "No se pudo localizar o editar el mensaje principal de Spin. "
-                        "La reserva interna ha quedado liberada; recrea el mensaje con "
-                        f"`!AgregarMensajeSpin {ambito.title()}` si es necesario.",
-                        ephemeral=True,
-                    )
-                    print(f"No se pudo reservar {self.nombre_ambito()} al editar el primer mensaje: {exc}")
-                    return
-
-                if canal_partido:
-                    if ambito == AMBITO_SPIN_COMUNIDADES:
-                        await canal_partido.send(f'<@{coach1_id_discord}> y <@{coach2_id_discord}> podéis spinear vuestro partido de comunidades.')
-                    else:
-                        await canal_partido.send(f'<@{coach1_id_discord}> y <@{coach2_id_discord}> podéis spinear')
-
-                await interaction.followup.send(f"Ahora puedes buscar partido en {self.nombre_ambito()}.", ephemeral=True)
-                thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), TIPO_SPIN, ambito, user.id))
-                thread.start()
+                    partido_spin = None
+                    mensaje_error = "No se encontró tu usuario en la base de datos."
+                else:
+                    try:
+                        partido_spin = buscar_partido_spin(session, usuario_db, ambito)
+                        mensaje_error = None if partido_spin else "No tienes ningún partido pendiente en esta cola de Spin."
+                    except ValueError:
+                        partido_spin = None
+                        mensaje_error = "El ámbito de Spin no es válido. Avise a un administrador."
             finally:
                 session.close()
+
+            if mensaje_error:
+                await interaction.followup.send(mensaje_error, ephemeral=True)
+                return
+
+            # A partir de aquí solo se usan datos escalares copiados en
+            # SpinMatchResult; la sesión SQL ya está cerrada antes de tocar
+            # Discord para evitar fugas o conexiones retenidas durante awaits.
+            timeout_task = None
+            canal_partido_id = partido_spin.canal_partido_id
+            coach1_id_discord = partido_spin.jugador1_discord_id
+            coach2_id_discord = partido_spin.jugador2_discord_id
+
+            canal_partido = interaction.guild.get_channel(canal_partido_id) if canal_partido_id else None
+            descripcion_partido = partido_spin.descripcion_corta
+            reserva = SpinReservation(ambito, user, coach1_id_discord, coach2_id_discord, interaction.channel, canal_partido, descripcion_partido, None, partido_spin)
+            timeout_task = asyncio.create_task(self.auto_release_spin(reserva))
+            reserva.timeout_task = timeout_task
+            guardar_reserva_spin(reserva)
+
+            self.actualizar_botones(spin_habilitado=False)
+            try:
+                await editar_primer_mensaje_spin(
+                    interaction.channel,
+                    content=descripcion_partido,
+                    view=self,
+                )
+            except Exception as exc:
+                limpiar_reserva_spin(ambito)
+                if timeout_task:
+                    timeout_task.cancel()
+                self.actualizar_botones(spin_habilitado=True)
+                await interaction.followup.send(
+                    "No se pudo localizar o editar el mensaje principal de Spin. "
+                    "La reserva interna ha quedado liberada; recrea el mensaje con "
+                    f"`!AgregarMensajeSpin {ambito.title()}` si es necesario.",
+                    ephemeral=True,
+                )
+                print(f"No se pudo reservar {self.nombre_ambito()} al editar el primer mensaje: {exc}")
+                return
+
+            if canal_partido:
+                if ambito == AMBITO_SPIN_COMUNIDADES:
+                    await canal_partido.send(f'<@{coach1_id_discord}> y <@{coach2_id_discord}> podéis spinear vuestro partido de comunidades.')
+                else:
+                    await canal_partido.send(f'<@{coach1_id_discord}> y <@{coach2_id_discord}> podéis spinear')
+
+            await interaction.followup.send(f"Ahora puedes buscar partido en {self.nombre_ambito()}.", ephemeral=True)
+            thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), TIPO_SPIN, ambito, user.id))
+            thread.start()
 
     @discord.ui.button(label="Encontrado", style=discord.ButtonStyle.blurple, custom_id='lombardbot:encontrado:general', disabled=True)
     async def encontrado_callback(self, interaction: discord.Interaction, button: discord.ui.Button):


### PR DESCRIPTION
### Motivation
- Evitar fugas de conexión y sesiones SQL retenidas por operaciones `await` o retornos tempranos en la lógica de Spin según `logicaSpin.md`.
- Garantizar que los callbacks de Spin y las consultas de historial cierren la sesión antes de hacer I/O con Discord y que los datos necesarios se copien antes del cierre.

### Description
- Refactoriza `SpinButtonsView.spin_callback` para abrir la sesión, resolver el partido y siempre ejecutar `session.close()` en un `finally`, cerrando la sesión antes de cualquier `await` con Discord y preservando solo datos escalares desde `SpinMatchResult` para uso posterior. (archivo modificado: `UtilesDiscord.py`).
- Reestructura la lógica de `/ultimosspins` para construir la respuesta dentro del ámbito SQL, cerrar la sesión en `finally` y enviar el mensaje a Discord después del cierre para no retener conexiones durante I/O. (archivo modificado: `LombardBot.py`).
- Mantiene la creación de la `SpinReservation`, la creación de la tarea de timeout y la inserción en historial (`GestorSQL.insertar_spin`) sin acceso a la sesión tras los `await` garantizando que no queden conexiones abiertas.

### Testing
- Se ejecutó `python -m compileall UtilesDiscord.py LombardBot.py` y la compilación de ambos módulos fue satisfactoria. (OK)
- Se intentó `pytest tests/test_spin_comunidades.py -q` pero las pruebas no pudieron ejecutarse en el entorno por falta de la dependencia `sqlalchemy` (`ModuleNotFoundError: No module named 'sqlalchemy'`). (no ejecutadas)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347f0ecbf0832a92bcc9d1b06711df)