### PR TITLE
Dirige administradores al comando liberarspin

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -124,6 +124,33 @@ def discord_ids_jugadores_reserva(reserva):
     }
 
 
+def usuario_tiene_rol_administrativo_spin(usuario):
+    """Indica si un usuario debe ser dirigido al comando administrativo.
+
+    Esto no autoriza el botón `Encontrado`: solo permite mostrar una respuesta
+    más útil a administradores/comisarios que no sean jugadores del partido.
+    """
+
+    permisos = getattr(usuario, "guild_permissions", None)
+    if getattr(permisos, "administrator", False):
+        return True
+
+    roles_administrativos = {"Comisario", "Administrador", "Moderadores"}
+    return any(
+        getattr(rol, "name", "") in roles_administrativos
+        for rol in getattr(usuario, "roles", [])
+    )
+
+
+def mensaje_encontrado_no_autorizado(usuario):
+    if usuario_tiene_rol_administrativo_spin(usuario):
+        return (
+            "Solo uno de los jugadores del partido reservado puede liberar este Spin. "
+            "Si necesitas liberarlo como administración, usa `/liberarspin`."
+        )
+    return "Solo uno de los jugadores del partido reservado puede liberar este Spin."
+
+
 def get_int_value(dictionary, key):
     value = dictionary.get(key)
     return 0 if value is None else value
@@ -897,7 +924,7 @@ class SpinButtonsView(discord.ui.View):
                 return
 
             if user.id not in discord_ids_jugadores_reserva(reserva):
-                await interaction.followup.send("Solo uno de los jugadores del partido reservado puede liberar este Spin.", ephemeral=True)
+                await interaction.followup.send(mensaje_encontrado_no_autorizado(user), ephemeral=True)
                 return
 
             limpiar_reserva_spin(ambito)

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -606,7 +606,11 @@ async def test_encontrado_callback_no_hace_excepcion_por_admin_ni_comisario(monk
     try:
         await UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL).encontrado_callback.callback(interaction)
         assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_GENERAL) is reserva
-        assert mensajes == [("Solo uno de los jugadores del partido reservado puede liberar este Spin.", True)]
+        assert mensajes == [(
+            "Solo uno de los jugadores del partido reservado puede liberar este Spin. "
+            "Si necesitas liberarlo como administración, usa `/liberarspin`.",
+            True,
+        )]
     finally:
         UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = None
 


### PR DESCRIPTION
### Motivation
- Cumplir la especificación de `logicaSpin.md` para que solo `jugador1` o `jugador2` puedan liberar una reserva pulsando el botón `Encontrado` y evitar excepciones por roles administrativos.
- Mejorar la UX cuando un administrador o comisario pulsa el botón mostrando una indicación de usar el comando administrativo en lugar de concederle permiso desde el botón.

### Description
- Añadidas las funciones `usuario_tiene_rol_administrativo_spin` y `mensaje_encontrado_no_autorizado` en `UtilesDiscord.py` para detectar roles administrativos y construir un mensaje que redirija a `/liberarspin` sin cambiar permisos del botón.
- Modificado el callback `encontrado_callback` de `SpinButtonsView` para usar `mensaje_encontrado_no_autorizado(user)` cuando quien pulsa no es uno de los dos jugadores de la reserva, manteniendo la reserva intacta.
- Actualizada la prueba `tests/test_spin_comunidades.py` que valida el comportamiento de administradores/comisarios para esperar la nueva indicación de usar `/liberarspin`.

### Testing
- Ejecutado `PYTHONPATH=. pytest tests/test_spin_comunidades.py -q` y todos los tests del archivo pasaron; final: `25 passed, 9 warnings`.
- Los cambios afectan solo a `UtilesDiscord.py` y a la expectativa de la prueba de integración de `Encontrado`, y las pruebas relevantes fueron verdes tras la modificación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347f035198832aa5d34a8e51f08b61)