### PR TITLE
Filtra Spin Comunidades con partido Blood Bowl asociado

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -604,7 +604,7 @@ def resolver_partido_spin_comunidades(session, usuario_db):
         GestorSQL.ComunidadesPartido.canal_discord_id != None,
         GestorSQL.ComunidadesPartido.estado.in_(("PENDIENTE", "EN_CURSO")),
         ~GestorSQL.ComunidadesPartido.estado.in_(("FINALIZADO", "ADMINISTRADO")),
-        GestorSQL.ComunidadesPartido.partido_bloodbowl_id == None,
+        GestorSQL.ComunidadesPartido.partido_bloodbowl_id.is_(None),
     ).all()
 
     resultados = []

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -138,6 +138,34 @@ def test_resolver_partido_spin_comunidades_filtra_no_elegibles():
         engine.dispose()
 
 
+@pytest.mark.parametrize("estado", ["PENDIENTE", "EN_CURSO"])
+def test_resolver_partido_spin_comunidades_excluye_partidos_con_bloodbowl_id(estado):
+    session, engine = _session()
+    try:
+        usuarios, torneo, enfrentamiento, equipo_a, equipo_b, ahora = _crear_contexto(session)
+        session.add(
+            _partido(
+                torneo,
+                enfrentamiento,
+                equipo_a,
+                equipo_b,
+                usuarios[0],
+                usuarios[2],
+                indice=1,
+                canal=901,
+                fecha=ahora,
+                estado=estado,
+                partido_bloodbowl_id=f"bb-{estado.lower()}",
+            )
+        )
+        session.commit()
+
+        assert resolver_partido_spin_comunidades(session, usuarios[0]) is None
+    finally:
+        session.close()
+        engine.dispose()
+
+
 def test_resolver_partido_spin_delega_solo_en_general(monkeypatch):
     import UtilesDiscord
     from SpinConstantes import AMBITO_SPIN_GENERAL


### PR DESCRIPTION
### Motivation
- Evitar que la cola `COMUNIDADES` permita hacer Spin sobre partidos que ya fueron encontrados o iniciados, siguiendo la especificación de `logicaSpin.md` (excluir partidos con `partido_bloodbowl_id`).

### Description
- Cambiado el filtro en `resolver_partido_spin_comunidades` para usar el comparador SQLAlchemy explícito `partido_bloodbowl_id.is_(None)` en lugar de `== None` en `UtilesDiscord.py`.
- Añadido test parametrizado `test_resolver_partido_spin_comunidades_excluye_partidos_con_bloodbowl_id` en `tests/test_spin_comunidades.py` que verifica que partidos en estado `PENDIENTE` y `EN_CURSO` con `partido_bloodbowl_id` no se devuelven.

### Testing
- Ejecutado `PYTHONPATH=. pytest tests/test_spin_comunidades.py` y la suite de tests del módulo pasó correctamente (`28 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34803a54f4832a8dadcf25a0229e75)