### PR TITLE
Centraliza y ajusta aviso de reserva de Spin General

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -468,6 +468,10 @@ def _clave_orden_spin(partido: SpinMatchResult):
     )
 
 
+def _menciones_jugadores_spin(partido: SpinMatchResult):
+    return f"<@{partido.jugador1_discord_id}> y <@{partido.jugador2_discord_id}>"
+
+
 def mensaje_spin_reservado(partido: SpinMatchResult):
     """Construye el mensaje principal reservado desde ``SpinMatchResult``.
 
@@ -477,7 +481,7 @@ def mensaje_spin_reservado(partido: SpinMatchResult):
     un mensaje seguro sin mostrar ``None``.
     """
 
-    menciones = f"<@{partido.jugador1_discord_id}> y <@{partido.jugador2_discord_id}>"
+    menciones = _menciones_jugadores_spin(partido)
     if partido.ambito == AMBITO_SPIN_COMUNIDADES:
         if partido.indice_partido and partido.equipo_a_nombre and partido.equipo_b_nombre:
             return (
@@ -487,6 +491,19 @@ def mensaje_spin_reservado(partido: SpinMatchResult):
             )
         return f"Spin de comunidades reservado: {menciones} pueden buscar partido."
     return f"Spin General reservado: {menciones} pueden buscar partido."
+
+
+def mensaje_canal_partido_spin_reservado(partido: SpinMatchResult):
+    """Construye el aviso de reserva para el canal del partido.
+
+    En Spin General el aviso debe limitarse a los jugadores y al permiso para
+    spinear, sin mencionar comunidades ni contexto de otros ámbitos.
+    """
+
+    menciones = _menciones_jugadores_spin(partido)
+    if partido.ambito == AMBITO_SPIN_COMUNIDADES:
+        return f"{menciones} podéis spinear vuestro partido de comunidades."
+    return f"{menciones}, podéis spinear."
 
 
 def _spin_match_desde_partido_general(partido):
@@ -904,10 +921,7 @@ class SpinButtonsView(discord.ui.View):
                 return
 
             if canal_partido:
-                if ambito == AMBITO_SPIN_COMUNIDADES:
-                    await canal_partido.send(f'<@{coach1_id_discord}> y <@{coach2_id_discord}> podéis spinear vuestro partido de comunidades.')
-                else:
-                    await canal_partido.send(f'<@{coach1_id_discord}> y <@{coach2_id_discord}> podéis spinear')
+                await canal_partido.send(mensaje_canal_partido_spin_reservado(partido_spin))
 
             await interaction.followup.send(f"Ahora puedes buscar partido en {self.nombre_ambito()}.", ephemeral=True)
             thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), TIPO_SPIN, ambito, user.id))

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -854,6 +854,44 @@ async def test_liberacion_administrativa_inserta_historial_con_ambito_y_admin(mo
     assert ambito == AMBITO_SPIN_GENERAL
     assert usuario_discord_id == 987654321
 
+
+def test_mensaje_canal_partido_spin_general_es_exactamente_el_definido():
+    from SpinConstantes import AMBITO_SPIN_GENERAL
+    from UtilesDiscord import SpinMatchResult, mensaje_canal_partido_spin_reservado
+
+    resultado = SpinMatchResult(
+        ambito=AMBITO_SPIN_GENERAL,
+        canal_partido_id=900,
+        jugador1_discord_id=101,
+        jugador2_discord_id=201,
+        fecha=None,
+    )
+
+    mensaje = mensaje_canal_partido_spin_reservado(resultado)
+
+    assert mensaje == "<@101> y <@201>, podéis spinear."
+    assert "comunidad" not in mensaje.casefold()
+    assert "comunidades" not in mensaje.casefold()
+
+
+def test_mensaje_canal_partido_spin_comunidades_mantiene_texto_especifico():
+    from SpinConstantes import AMBITO_SPIN_COMUNIDADES
+    from UtilesDiscord import SpinMatchResult, mensaje_canal_partido_spin_reservado
+
+    resultado = SpinMatchResult(
+        ambito=AMBITO_SPIN_COMUNIDADES,
+        canal_partido_id=902,
+        jugador1_discord_id=102,
+        jugador2_discord_id=101,
+        fecha=None,
+    )
+
+    assert (
+        mensaje_canal_partido_spin_reservado(resultado)
+        == "<@102> y <@101> podéis spinear vuestro partido de comunidades."
+    )
+
+
 def test_mensaje_spin_reservado_se_construye_desde_spin_match_result():
     from SpinConstantes import AMBITO_SPIN_GENERAL
     from UtilesDiscord import SpinMatchResult, mensaje_spin_reservado


### PR DESCRIPTION
### Motivation
- Evitar variaciones en el texto enviado al canal del partido al reservar un Spin y asegurar que el aviso de Spin General no mencione comunidades, siguiendo lo definido en `logicaSpin.md`.

### Description
- Extrae las menciones de jugadores en `_menciones_jugadores_spin` y centraliza la lógica de texto de canal en `mensaje_canal_partido_spin_reservado` para separar el aviso de canal del `mensaje_spin_reservado` ya existente.
- Sustituye los envíos directos de texto en `SpinButtonsView.spin_callback` por una llamada a `mensaje_canal_partido_spin_reservado(partido_spin)` para unificar el formato.
- Mantiene el texto explícito para `Spin Comunidades` y ajusta el texto de `Spin General` al formato exacto: `<@jugador1> y <@jugador2>, podéis spinear.`
- Añade pruebas en `tests/test_spin_comunidades.py` que verifican el mensaje enviado al canal para ambos ámbitos y garantizan que el aviso de General no contiene "comunidad"/"comunidades".

### Testing
- Ejecutado `PYTHONPATH=. pytest tests/test_spin_comunidades.py -q` — OK (todas las pruebas del archivo pasaron).
- Ejecutado `python -m py_compile UtilesDiscord.py tests/test_spin_comunidades.py` — OK (sin errores de compilación).
- Ejecutado `PYTHONPATH=. pytest -q` (suite completa) — Fallaron 5 pruebas de integración de comunidades que no están relacionadas con este cambio: `test_zombificacion_y_kill_se_resuelven_con_la_fotografia_inicial`, `test_ciclo_de_dos_rondas_desde_inscripcion_hasta_final_con_snapshots`, `test_bye_y_regeneracion_revierten_todo_el_estado_de_la_ronda`, `test_transferencia_tras_cerrar_ambos_enfrentamientos_es_idempotente`, `test_api_mockeada_registra_los_dos_resultados_sin_red`. Estas fallas ya existían durante la verificación y no fueron introducidas por esta modificación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3480303acc832abcde39c1bb7618e5)