### PR TITLE
Centraliza mensajes de liberación de Spin por ámbito

### DIFF
--- a/SpinConstantes.py
+++ b/SpinConstantes.py
@@ -32,6 +32,22 @@ MENSAJES_SPIN_LIBRE = {
     AMBITO_SPIN_COMUNIDADES: "El Spin Comunidades está **LIBRE**",
 }
 
+MENSAJES_CANAL_PARTIDO_LIBERACION_MANUAL = {
+    AMBITO_SPIN_GENERAL: "El Spin General ha sido liberado.",
+    AMBITO_SPIN_COMUNIDADES: "El Spin Comunidades ha sido liberado.",
+}
+
+MENSAJES_CANAL_PARTIDO_LIBERACION_AUTOMATICA = {
+    AMBITO_SPIN_GENERAL: (
+        "El Spin General ha sido liberado automáticamente. 😡 Afortunadamente "
+        "las máquinas somos superiores y cuidamos de los esmirriados humanos."
+    ),
+    AMBITO_SPIN_COMUNIDADES: (
+        "El Spin Comunidades ha sido liberado automáticamente. 😡 La comunidad "
+        "ha sobrevivido a otro intento fallido de coordinación humana."
+    ),
+}
+
 
 AYUDA_AGREGAR_MENSAJE_SPIN = (
     "Uso: `!AgregarMensajeSpin <ámbito>`\n"
@@ -65,6 +81,29 @@ def mensaje_spin_libre(ambito):
     if not ambito_normalizado:
         raise ValueError(f"Ámbito de Spin no válido: {ambito!r}")
     return MENSAJES_SPIN_LIBRE[ambito_normalizado]
+
+
+def mensaje_canal_partido_liberacion_manual(ambito):
+    """Devuelve el texto canónico al liberar manualmente una reserva.
+
+    En Spin General este texto no menciona comunidades porque ``logicaSpin.md``
+    separa los ámbitos y define un mensaje claro para el canal del partido
+    general.
+    """
+
+    ambito_normalizado = normalizar_ambito_spin(ambito)
+    if not ambito_normalizado:
+        raise ValueError(f"Ámbito de Spin no válido: {ambito!r}")
+    return MENSAJES_CANAL_PARTIDO_LIBERACION_MANUAL[ambito_normalizado]
+
+
+def mensaje_canal_partido_liberacion_automatica(ambito):
+    """Devuelve el texto humorístico canónico al liberar por timeout."""
+
+    ambito_normalizado = normalizar_ambito_spin(ambito)
+    if not ambito_normalizado:
+        raise ValueError(f"Ámbito de Spin no válido: {ambito!r}")
+    return MENSAJES_CANAL_PARTIDO_LIBERACION_AUTOMATICA[ambito_normalizado]
 
 # Canal actual de Spin General; se conserva para compatibilidad operativa.
 CANAL_SPIN_GENERAL_ID = 1224128423929315468

--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -25,6 +25,8 @@ from SpinConstantes import (
     TIPO_SPIN_ENCONTRADO,
     CANAL_SPIN_COMUNIDADES_ID,
     CANAL_SPIN_GENERAL_ID,
+    mensaje_canal_partido_liberacion_automatica,
+    mensaje_canal_partido_liberacion_manual,
     mensaje_spin_libre,
     normalizar_ambito_spin,
 )
@@ -792,7 +794,7 @@ async def liberar_reserva_spin_administrativa(ambito, usuario_admin):
 
     if reserva.canal_partido:
         try:
-            await reserva.canal_partido.send(f"El {nombre_ambito} ha sido liberado.")
+            await reserva.canal_partido.send(mensaje_canal_partido_liberacion_manual(ambito_normalizado))
         except Exception as exc:
             print(f"No se pudo enviar el mensaje de liberación administrativa de {nombre_ambito}: {exc}")
 
@@ -865,10 +867,7 @@ class SpinButtonsView(discord.ui.View):
         nombre_ambito = self.nombre_ambito()
         if reserva.canal_partido:
             try:
-                if ambito == AMBITO_SPIN_COMUNIDADES:
-                    await reserva.canal_partido.send("El Spin Comunidades ha sido liberado automáticamente. 😡 La comunidad ha sobrevivido a otro intento fallido de coordinación humana.")
-                else:
-                    await reserva.canal_partido.send("El Spin General ha sido liberado automáticamente. 😡 Afortunadamente las máquinas somos superiores y cuidamos de los esmirriados humanos.")
+                await reserva.canal_partido.send(mensaje_canal_partido_liberacion_automatica(ambito))
             except Exception as exc:
                 print(f"No se pudo enviar el mensaje de timeout de {nombre_ambito} al canal del partido: {exc}")
 
@@ -1016,7 +1015,7 @@ class SpinButtonsView(discord.ui.View):
 
         if reserva.canal_partido:
             try:
-                await reserva.canal_partido.send(f"El {self.nombre_ambito()} ha sido liberado.")
+                await reserva.canal_partido.send(mensaje_canal_partido_liberacion_manual(ambito))
             except Exception as exc:
                 print(f"No se pudo enviar el mensaje de liberación de {self.nombre_ambito()}: {exc}")
 

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -1022,3 +1022,19 @@ def test_formatear_historial_spins_asume_general_para_registros_heredados():
     )
 
     assert "[GENERAL] UsuarioX - Spin - 2026-06-18 20:15:00" in salida
+
+
+def test_mensajes_liberacion_canal_partido_respetan_ambito_general():
+    from SpinConstantes import (
+        AMBITO_SPIN_GENERAL,
+        mensaje_canal_partido_liberacion_automatica,
+        mensaje_canal_partido_liberacion_manual,
+    )
+
+    assert mensaje_canal_partido_liberacion_manual(AMBITO_SPIN_GENERAL) == "El Spin General ha sido liberado."
+    automatico = mensaje_canal_partido_liberacion_automatica(AMBITO_SPIN_GENERAL)
+    assert automatico == (
+        "El Spin General ha sido liberado automáticamente. 😡 Afortunadamente "
+        "las máquinas somos superiores y cuidamos de los esmirriados humanos."
+    )
+    assert "comunidad" not in automatico.casefold()


### PR DESCRIPTION
### Motivation
- Alinear la salida en canales con lo documentado en `logicaSpin.md` y evitar que el mensaje de liberación del ámbito GENERAL mencione comunidades. 
- Evitar duplicación de literales y garantizar que las liberaciones manuales, administrativas y por timeout usen textos canónicos por ámbito.

### Description
- Se añaden constantes y funciones en `SpinConstantes.py`: `MENSAJES_CANAL_PARTIDO_LIBERACION_MANUAL`, `MENSAJES_CANAL_PARTIDO_LIBERACION_AUTOMATICA`, `mensaje_canal_partido_liberacion_manual` y `mensaje_canal_partido_liberacion_automatica` para centralizar los textos por ámbito. 
- `UtilesDiscord.py` pasa a usar las nuevas funciones canónicas al enviar avisos al canal del partido durante liberación administrativa, liberación por timeout y liberación manual vía `Encontrado`. 
- Se añade la prueba `test_mensajes_liberacion_canal_partido_respetan_ambito_general` en `tests/test_spin_comunidades.py` que fija el texto manual y automático de Spin General y comprueba que el mensaje automático no contiene la palabra "comunidad".

### Testing
- Ejecutado: `PYTHONPATH=. pytest tests/test_spin_comunidades.py`.
- Resultado: la suite de `tests/test_spin_comunidades.py` pasó completamente (`30 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3482c37fe4832abe170834e593ff02)