### PR TITLE
Protege descripción de Spin Comunidades incompleta

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, replace
 from typing import Optional
 from threading import Thread
 import threading
+import logging
 import Imagenes
 
 from sqlalchemy.sql.functions import now
@@ -35,6 +36,7 @@ import asyncio
 from datetime import datetime
 
 
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -533,13 +535,30 @@ def mensaje_spin_reservado(partido: SpinMatchResult):
 
     menciones = f"<@{partido.jugador1_discord_id}> y <@{partido.jugador2_discord_id}>"
     if partido.ambito == AMBITO_SPIN_COMUNIDADES:
-        if partido.indice_partido and partido.equipo_a_nombre and partido.equipo_b_nombre:
+        datos_descriptivos_completos = (
+            partido.indice_partido is not None
+            and bool(partido.equipo_a_nombre)
+            and bool(partido.equipo_b_nombre)
+        )
+        if datos_descriptivos_completos:
             return (
                 f"Spin de comunidades reservado para el partido individual {partido.indice_partido} "
                 f"del enfrentamiento {partido.equipo_a_nombre} vs {partido.equipo_b_nombre}: "
                 f"{menciones} pueden buscar partido."
             )
-        return f"Spin de comunidades reservado: {menciones} pueden buscar partido."
+
+        LOGGER.warning(
+            "Spin Comunidades reservado con datos descriptivos incompletos",
+            extra={
+                "spin_torneo_id": partido.torneo_id,
+                "spin_partido_id": partido.partido_id,
+                "spin_enfrentamiento_id": partido.enfrentamiento_id,
+                "spin_indice_partido": partido.indice_partido,
+                "spin_equipo_a_nombre": partido.equipo_a_nombre,
+                "spin_equipo_b_nombre": partido.equipo_b_nombre,
+            },
+        )
+        return f"Spin Comunidades reservado: {menciones} pueden buscar partido."
     return f"Spin General reservado: {menciones} pueden buscar partido."
 
 

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -17,7 +17,7 @@ from GestorSQL import (
     Usuario,
 )
 from SpinConstantes import AMBITO_SPIN_COMUNIDADES
-from UtilesDiscord import resolver_partido_spin_comunidades
+from UtilesDiscord import SpinMatchResult, mensaje_spin_reservado, resolver_partido_spin_comunidades
 
 
 def _session():
@@ -92,6 +92,48 @@ def _partido(torneo, enfrentamiento, equipo_a, equipo_b, local, visitante, *, in
         estado=estado,
         partido_bloodbowl_id=partido_bloodbowl_id,
     )
+
+
+def test_mensaje_spin_comunidades_usa_texto_simple_si_faltan_datos_descriptivos(caplog):
+    resultado = SpinMatchResult(
+        ambito=AMBITO_SPIN_COMUNIDADES,
+        canal_partido_id=902,
+        jugador1_discord_id=101,
+        jugador2_discord_id=202,
+        fecha=None,
+        torneo_id=1,
+        partido_id=2,
+        enfrentamiento_id=3,
+        indice_partido=None,
+        equipo_a_nombre="Equipo A",
+        equipo_b_nombre="Equipo B",
+    )
+
+    mensaje = mensaje_spin_reservado(resultado)
+
+    assert mensaje == "Spin Comunidades reservado: <@101> y <@202> pueden buscar partido."
+    assert "datos descriptivos incompletos" in caplog.text
+
+
+def test_mensaje_spin_comunidades_usa_texto_simple_si_falta_nombre_equipo(caplog):
+    resultado = SpinMatchResult(
+        ambito=AMBITO_SPIN_COMUNIDADES,
+        canal_partido_id=902,
+        jugador1_discord_id=101,
+        jugador2_discord_id=202,
+        fecha=None,
+        torneo_id=1,
+        partido_id=2,
+        enfrentamiento_id=3,
+        indice_partido=1,
+        equipo_a_nombre="",
+        equipo_b_nombre="Equipo B",
+    )
+
+    mensaje = mensaje_spin_reservado(resultado)
+
+    assert mensaje == "Spin Comunidades reservado: <@101> y <@202> pueden buscar partido."
+    assert "datos descriptivos incompletos" in caplog.text
 
 
 def test_resolver_partido_spin_comunidades_devuelve_spin_match_result_con_datos_necesarios():
@@ -965,7 +1007,7 @@ def test_mensaje_spin_reservado_comunidades_usa_contexto_o_fallback():
         "Spin de comunidades reservado para el partido individual 2 "
         "del enfrentamiento Equipo A vs Equipo B: <@102> y <@101> pueden buscar partido."
     )
-    assert mensaje_spin_reservado(incompleto) == "Spin de comunidades reservado: <@102> y <@101> pueden buscar partido."
+    assert mensaje_spin_reservado(incompleto) == "Spin Comunidades reservado: <@102> y <@101> pueden buscar partido."
     assert "None" not in mensaje_spin_reservado(incompleto)
 
 


### PR DESCRIPTION
### Motivation

- Evitar que faltas en los datos descriptivos (índice de partido o nombre de equipos) hagan aparecer `None` en los mensajes públicos o bloqueen la reserva de Spin Comunidades.

### Description

- Añade `logging` y un `LOGGER.warning` en `UtilesDiscord.py` cuando una reserva de Spin Comunidades tiene datos descriptivos incompletos y registra los campos relevantes (`torneo_id`, `partido_id`, `enfrentamiento_id`, `indice_partido`, `equipo_a_nombre`, `equipo_b_nombre`).
- Cambia la lógica de `mensaje_spin_reservado` para comprobar explícitamente que `indice_partido`, `equipo_a_nombre` y `equipo_b_nombre` existan; si faltan, usa el texto simple `Spin Comunidades reservado: <@jugador1> y <@jugador2> pueden buscar partido.` sin impedir la reserva funcional.
- Actualiza/añade pruebas en `tests/test_spin_comunidades.py` para cubrir los fallbacks y la emisión del warning cuando faltan datos descriptivos.

### Testing

- Ejecutado: `PYTHONPATH=. pytest tests/test_spin_comunidades.py -q` and result: all tests passed (`32 passed`).
- Añadidas pruebas que verifican que el texto de fallback se usa cuando falta el índice o el nombre de un equipo y que se registra la advertencia en los logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3483b43a14832a9885f7615f734794)