### PR TITLE
Usar constantes en el filtro de Spin Comunidades

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -17,6 +17,12 @@ from sqlalchemy.orm import aliased, joinedload
 from sqlalchemy.sql import case,func
 
 import GestorSQL
+from ComunidadesConstantes import (
+    PARTIDO_ADMINISTRADO,
+    PARTIDO_EN_CURSO,
+    PARTIDO_FINALIZADO,
+    PARTIDO_PENDIENTE,
+)
 from SpinConstantes import (
     AMBITO_SPIN_COMUNIDADES,
     AMBITO_SPIN_GENERAL,
@@ -695,8 +701,12 @@ def resolver_partido_spin_comunidades(session, usuario_db):
             GestorSQL.ComunidadesPartido.usuario_visitante_id == usuario_db.idUsuarios,
         ),
         GestorSQL.ComunidadesPartido.canal_discord_id != None,
-        GestorSQL.ComunidadesPartido.estado.in_(("PENDIENTE", "EN_CURSO")),
-        ~GestorSQL.ComunidadesPartido.estado.in_(("FINALIZADO", "ADMINISTRADO")),
+        GestorSQL.ComunidadesPartido.estado.in_(
+            (PARTIDO_PENDIENTE, PARTIDO_EN_CURSO)
+        ),
+        ~GestorSQL.ComunidadesPartido.estado.in_(
+            (PARTIDO_FINALIZADO, PARTIDO_ADMINISTRADO)
+        ),
         GestorSQL.ComunidadesPartido.partido_bloodbowl_id.is_(None),
     ).all()
 


### PR DESCRIPTION
### Motivation
- Alinear el proveedor de Spin Comunidades con `logicaSpin.md` evitando duplicar literales de estado y usando las constantes canónicas del módulo de comunidades. 
- Garantizar que Spin Comunidades solo permita partidos pendientes o en curso y excluya los partidos finalizados o administrados, además de no permitir partidos con `partido_bloodbowl_id`.

### Description
- Importa las constantes de estado desde `ComunidadesConstantes` (`PARTIDO_PENDIENTE`, `PARTIDO_EN_CURSO`, `PARTIDO_FINALIZADO`, `PARTIDO_ADMINISTRADO`).
- Actualiza el filtro en `resolver_partido_spin_comunidades` para usar `GestorSQL.ComunidadesPartido.estado.in_((PARTIDO_PENDIENTE, PARTIDO_EN_CURSO))` en lugar de literales; y para excluir con `~GestorSQL.ComunidadesPartido.estado.in_((PARTIDO_FINALIZADO, PARTIDO_ADMINISTRADO))`.
- Conserva las demás condiciones existentes: `canal_discord_id != None` y `partido_bloodbowl_id.is_(None)`, y la proyección a `SpinMatchResult` sin modificar.

### Testing
- Se compiló el módulo con `python -m py_compile UtilesDiscord.py` y la compilación fue exitosa.
- Se intentó ejecutar `pytest tests/test_spin_comunidades.py -q` pero falló por falta de la dependencia `sqlalchemy` en el entorno (`ModuleNotFoundError: No module named 'sqlalchemy'`), por lo que las pruebas unitarias completas no pudieron correrse aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3484b0e3b8832a8f4c21a43eb3555f)