### PR TITLE
Aplica criterio común de selección de Spin

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -64,6 +64,7 @@ class SpinMatchResult:
     descripcion_larga: Optional[str] = None
     torneo_id: Optional[int] = None
     partido_id: Optional[int] = None
+    ronda_id: Optional[int] = None
     enfrentamiento_id: Optional[int] = None
     indice_partido: Optional[int] = None
     equipo_a_nombre: Optional[str] = None
@@ -512,21 +513,32 @@ Si hubiera cualquier problema mencionad a los comisarios que están para ayudar.
                 
 
 
+def _valor_orden_determinista_spin(valor):
+    """Normaliza identificadores opcionales para desempatar de forma estable."""
+
+    return valor if valor is not None else 0
+
+
 def _clave_orden_spin(partido: SpinMatchResult):
-    """Ordena partidos por fecha cercana y después por identificadores estables."""
+    """Ordena partidos según el criterio común de ``logicaSpin.md``.
+
+    Primero van los partidos con fecha, ordenados por cercanía al momento
+    actual. Los partidos sin fecha quedan detrás y todos los empates se
+    resuelven por identificadores estables: torneo, ronda, enfrentamiento,
+    índice de partido e ID interno.
+    """
 
     ahora = datetime.utcnow()
-    distancia_fecha = (
-        abs((partido.fecha - ahora).total_seconds())
-        if partido.fecha is not None
-        else float("inf")
-    )
+    tiene_fecha = partido.fecha is not None
+    distancia_fecha = abs((partido.fecha - ahora).total_seconds()) if tiene_fecha else float("inf")
     return (
+        0 if tiene_fecha else 1,
         distancia_fecha,
-        partido.torneo_id or 0,
-        partido.enfrentamiento_id or 0,
-        partido.indice_partido or 0,
-        partido.partido_id or 0,
+        _valor_orden_determinista_spin(partido.torneo_id),
+        _valor_orden_determinista_spin(partido.ronda_id),
+        _valor_orden_determinista_spin(partido.enfrentamiento_id),
+        _valor_orden_determinista_spin(partido.indice_partido),
+        _valor_orden_determinista_spin(partido.partido_id),
     )
 
 
@@ -608,7 +620,8 @@ def _spin_match_desde_partido_general(partido):
         fecha=fecha,
         torneo_id=getattr(partido, "torneo_id", None),
         partido_id=partido_id,
-        enfrentamiento_id=getattr(partido, "ronda_id", None),
+        ronda_id=getattr(partido, "ronda_id", None) or getattr(partido, "jornada", None),
+        enfrentamiento_id=getattr(partido, "id", None),
         indice_partido=getattr(partido, "mesa_numero", None),
     )
     descripcion = mensaje_spin_reservado(resultado)
@@ -725,6 +738,7 @@ def resolver_partido_spin_comunidades(session, usuario_db):
             fecha=partido.fecha,
             torneo_id=partido.torneo_id,
             partido_id=partido.id,
+            ronda_id=getattr(enfrentamiento, "ronda_id", None),
             enfrentamiento_id=partido.enfrentamiento_id,
             indice_partido=partido.indice,
             equipo_a_nombre=equipo_a_nombre,

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -1080,3 +1080,81 @@ def test_mensajes_liberacion_canal_partido_respetan_ambito_general():
         "las máquinas somos superiores y cuidamos de los esmirriados humanos."
     )
     assert "comunidad" not in automatico.casefold()
+
+
+def test_clave_orden_spin_prioriza_fecha_sobre_partidos_sin_fecha(monkeypatch):
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL
+
+    class FechaFija(datetime):
+        @classmethod
+        def utcnow(cls):
+            return datetime(2026, 7, 1, 20, 0)
+
+    monkeypatch.setattr(UtilesDiscord, "datetime", FechaFija)
+
+    con_fecha = SpinMatchResult(
+        ambito=AMBITO_SPIN_GENERAL,
+        canal_partido_id=1,
+        jugador1_discord_id=101,
+        jugador2_discord_id=201,
+        fecha=datetime(2026, 7, 20, 20, 0),
+        torneo_id=99,
+        ronda_id=99,
+        enfrentamiento_id=99,
+        indice_partido=99,
+        partido_id=99,
+    )
+    sin_fecha = SpinMatchResult(
+        ambito=AMBITO_SPIN_GENERAL,
+        canal_partido_id=2,
+        jugador1_discord_id=101,
+        jugador2_discord_id=202,
+        fecha=None,
+        torneo_id=1,
+        ronda_id=1,
+        enfrentamiento_id=1,
+        indice_partido=1,
+        partido_id=1,
+    )
+
+    assert min([sin_fecha, con_fecha], key=UtilesDiscord._clave_orden_spin) is con_fecha
+
+
+def test_clave_orden_spin_desempata_sin_fechas_por_ids_deterministas(monkeypatch):
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL
+
+    base = dict(
+        ambito=AMBITO_SPIN_GENERAL,
+        canal_partido_id=1,
+        jugador1_discord_id=101,
+        jugador2_discord_id=201,
+        fecha=None,
+        torneo_id=1,
+        ronda_id=1,
+        enfrentamiento_id=1,
+        indice_partido=1,
+    )
+    mayor_id = SpinMatchResult(**base, partido_id=20)
+    menor_id = SpinMatchResult(**base, partido_id=10)
+
+    assert min([mayor_id, menor_id], key=UtilesDiscord._clave_orden_spin) is menor_id
+
+
+def test_resolver_partido_spin_comunidades_deja_sin_fecha_detras_de_fechados():
+    session, engine = _session()
+    try:
+        usuarios, torneo, enfrentamiento, equipo_a, equipo_b, ahora = _crear_contexto(session)
+        sin_fecha = _partido(torneo, enfrentamiento, equipo_a, equipo_b, usuarios[0], usuarios[2], indice=1, canal=901, fecha=None)
+        con_fecha = _partido(torneo, enfrentamiento, equipo_a, equipo_b, usuarios[1], usuarios[0], indice=2, canal=902, fecha=ahora + timedelta(days=10))
+        session.add_all([sin_fecha, con_fecha])
+        session.commit()
+
+        resultado = resolver_partido_spin_comunidades(session, usuarios[0])
+
+        assert resultado.partido_id == con_fecha.id
+        assert resultado.ronda_id == enfrentamiento.ronda_id
+    finally:
+        session.close()
+        engine.dispose()


### PR DESCRIPTION
### Motivation
- Implementar el criterio de `logicaSpin.md` para elegir el partido cuando un usuario tiene varios pendientes: priorizar partidos con fecha más cercana, dejar los sin fecha detrás y resolver empates de forma determinista por identificadores.
- Aplicar el mismo comportamiento tanto a `Spin General` como a `Spin Comunidades` y conservar una frontera de datos estable para la UI de Spin.

### Description
- Añade `ronda_id` a la estructura normalizada `SpinMatchResult` para permitir desempates por torneo/ronda/enfrentamiento/índice/ID. 
- Introduce la función ` _valor_orden_determinista_spin` y actualiza ` _clave_orden_spin` para priorizar partidos con fecha, ordenar por cercanía y desempatar determinísticamente usando `torneo_id`, `ronda_id`, `enfrentamiento_id`, `indice_partido` y `partido_id`.
- Propaga `ronda_id` desde los convertidores de partidos de `Spin General` y desde los resultados de `Spin Comunidades` para que el desempate tenga la información necesaria.
- Añade pruebas unitarias en `tests/test_spin_comunidades.py` que verifican priorización de partidos con fecha, desempate determinista entre sin-fecha y que `resolver_partido_spin_comunidades` deja partidos sin fecha detrás de los fechados.

### Testing
- Ejecutado `PYTHONPATH=. pytest -q tests/test_spin_comunidades.py -q` y todos los tests del fichero pasaron (tests unitarios de Spin Comunidades). 
- Comprobada la compilación estática con `PYTHONPATH=. python -m py_compile UtilesDiscord.py tests/test_spin_comunidades.py` sin errores. 
- Se verificó que la nueva clave de orden funciona mediante las pruebas añadidas que cubren los escenarios requeridos por `logicaSpin.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a348554eac8832a913ad644272a355e)