### PR TITLE
Corregir liberación de Spin y estados visuales

### DIFF
--- a/SpinConstantes.py
+++ b/SpinConstantes.py
@@ -37,6 +37,11 @@ MENSAJES_CANAL_PARTIDO_LIBERACION_MANUAL = {
     AMBITO_SPIN_COMUNIDADES: "El Spin Comunidades ha sido liberado.",
 }
 
+MENSAJES_CANAL_PARTIDO_LIBERACION_ADMINISTRATIVA = {
+    AMBITO_SPIN_GENERAL: "El Spin General ha sido liberado por administración.",
+    AMBITO_SPIN_COMUNIDADES: "El Spin Comunidades ha sido liberado por administración.",
+}
+
 MENSAJES_CANAL_PARTIDO_LIBERACION_AUTOMATICA = {
     AMBITO_SPIN_GENERAL: (
         "El Spin General ha sido liberado automáticamente. 😡 Afortunadamente "
@@ -95,6 +100,15 @@ def mensaje_canal_partido_liberacion_manual(ambito):
     if not ambito_normalizado:
         raise ValueError(f"Ámbito de Spin no válido: {ambito!r}")
     return MENSAJES_CANAL_PARTIDO_LIBERACION_MANUAL[ambito_normalizado]
+
+
+def mensaje_canal_partido_liberacion_administrativa(ambito):
+    """Devuelve el texto canónico al liberar una reserva por administración."""
+
+    ambito_normalizado = normalizar_ambito_spin(ambito)
+    if not ambito_normalizado:
+        raise ValueError(f"Ámbito de Spin no válido: {ambito!r}")
+    return MENSAJES_CANAL_PARTIDO_LIBERACION_ADMINISTRATIVA[ambito_normalizado]
 
 
 def mensaje_canal_partido_liberacion_automatica(ambito):

--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -32,6 +32,7 @@ from SpinConstantes import (
     TIPO_SPIN_ENCONTRADO,
     CANAL_SPIN_COMUNIDADES_ID,
     CANAL_SPIN_GENERAL_ID,
+    mensaje_canal_partido_liberacion_administrativa,
     mensaje_canal_partido_liberacion_automatica,
     mensaje_canal_partido_liberacion_manual,
     mensaje_spin_libre,
@@ -157,7 +158,7 @@ async def tomar_reserva_para_liberar_spin(ambito, reserva_esperada=None):
         if reserva_esperada is not None and reserva is not reserva_esperada:
             return None
         marcar_liberando_spin(ambito)
-        if reserva.timeout_task:
+        if reserva.timeout_task and reserva.timeout_task is not asyncio.current_task():
             reserva.timeout_task.cancel()
         return reserva
 
@@ -833,11 +834,12 @@ async def liberar_reserva_spin_administrativa(ambito, usuario_admin):
     if not reserva:
         return False
 
+    await finalizar_liberacion_spin(ambito_normalizado)
     nombre_ambito = "Spin Comunidades" if ambito_normalizado == AMBITO_SPIN_COMUNIDADES else "Spin General"
 
     if reserva.canal_partido:
         try:
-            await reserva.canal_partido.send(mensaje_canal_partido_liberacion_manual(ambito_normalizado))
+            await reserva.canal_partido.send(mensaje_canal_partido_liberacion_administrativa(ambito_normalizado))
         except Exception as exc:
             print(f"No se pudo enviar el mensaje de liberación administrativa de {nombre_ambito}: {exc}")
 
@@ -859,7 +861,6 @@ async def liberar_reserva_spin_administrativa(ambito, usuario_admin):
         args=(nombre_usuario, datetime.utcnow(), TIPO_SPIN_ADMIN_RELEASE, ambito_normalizado, usuario_discord_id),
     )
     thread.start()
-    await finalizar_liberacion_spin(ambito_normalizado)
     return True
 
 
@@ -907,6 +908,7 @@ class SpinButtonsView(discord.ui.View):
         if not reserva:
             return
 
+        await finalizar_liberacion_spin(ambito)
         nombre_ambito = self.nombre_ambito()
         if reserva.canal_partido:
             try:
@@ -931,7 +933,6 @@ class SpinButtonsView(discord.ui.View):
 
         thread = Thread(target=GestorSQL.insertar_spin, args=('LOMBARDBOT', datetime.utcnow(), TIPO_SPIN_AUTO_RELEASE, ambito))
         thread.start()
-        await finalizar_liberacion_spin(ambito)
 
     def actualizar_botones(self, spin_habilitado):
         for child in self.children:
@@ -1056,6 +1057,7 @@ class SpinButtonsView(discord.ui.View):
             await interaction.followup.send("No hay ningún Spin reservado en esta cola.", ephemeral=True)
             return
 
+        await finalizar_liberacion_spin(ambito)
         if reserva.canal_partido:
             try:
                 await reserva.canal_partido.send(mensaje_canal_partido_liberacion_manual(ambito))
@@ -1065,7 +1067,7 @@ class SpinButtonsView(discord.ui.View):
         self.actualizar_botones(spin_habilitado=True)
         try:
             await editar_primer_mensaje_spin(
-                interaction.channel,
+                reserva.canal_spin,
                 content=mensaje_spin_libre(ambito),
                 view=self,
             )
@@ -1075,7 +1077,6 @@ class SpinButtonsView(discord.ui.View):
         await interaction.followup.send(f"Has liberado el {self.nombre_ambito()}.", ephemeral=True)
         thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), TIPO_SPIN_ENCONTRADO, ambito, user.id))
         thread.start()
-        await finalizar_liberacion_spin(ambito)
 
             
 #Singleton para las necesidades del discord

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -914,7 +914,7 @@ async def test_liberacion_administrativa_inserta_historial_con_ambito_y_admin(mo
 
     assert liberado is True
     assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_GENERAL) is None
-    assert canal_partido.mensajes == ["El Spin General ha sido liberado."]
+    assert canal_partido.mensajes == ["El Spin General ha sido liberado por administración."]
     assert canal_spin.mensaje.ediciones[0]["content"] == "El Spin General está **LIBRE**"
     assert len(hilos) == 1
     assert hilos[0].target is UtilesDiscord.GestorSQL.insertar_spin
@@ -1069,11 +1069,16 @@ def test_formatear_historial_spins_asume_general_para_registros_heredados():
 def test_mensajes_liberacion_canal_partido_respetan_ambito_general():
     from SpinConstantes import (
         AMBITO_SPIN_GENERAL,
+        mensaje_canal_partido_liberacion_administrativa,
         mensaje_canal_partido_liberacion_automatica,
         mensaje_canal_partido_liberacion_manual,
     )
 
     assert mensaje_canal_partido_liberacion_manual(AMBITO_SPIN_GENERAL) == "El Spin General ha sido liberado."
+    assert (
+        mensaje_canal_partido_liberacion_administrativa(AMBITO_SPIN_GENERAL)
+        == "El Spin General ha sido liberado por administración."
+    )
     automatico = mensaje_canal_partido_liberacion_automatica(AMBITO_SPIN_GENERAL)
     assert automatico == (
         "El Spin General ha sido liberado automáticamente. 😡 Afortunadamente "


### PR DESCRIPTION
### Motivation
- Garantizar que al liberar una reserva de Spin el estado interno se libere siempre antes de intentar acciones en Discord para no reactivar ni dejar bloqueada la cola si Discord falla. 
- Aplicar la regla a liberación manual (`Encontrado`), automática (timeout) y administrativa, y mantener los estados visuales de los botones correctos en todo momento.

### Description
- Mover la liberación interna para ejecutarla antes de las operaciones de Discord en las rutas administrativas, automáticas y del botón `Encontrado` usando `finalizar_liberacion_spin` antes de enviar/editar mensajes. 
- Añadir textos canónicos para liberación administrativa (`MENSAJES_CANAL_PARTIDO_LIBERACION_ADMINISTRATIVA`) y la función `mensaje_canal_partido_liberacion_administrativa`, y usarla al notificar el canal del partido en liberaciones por admin. 
- Evitar que la tarea de timeout se cancele a sí misma comprobando `reserva.timeout_task is not asyncio.current_task()` al cancelar el timeout. 
- Asegurar que la edición del primer mensaje del canal use `reserva.canal_spin` en vez de `interaction.channel` para mantener la vista y el canal correctos tras la liberación. 
- Actualizar tests esperados en `tests/test_spin_comunidades.py` para reflejar el nuevo mensaje administrativo.

### Testing
- Ejecuté `PYTHONPATH=. pytest -q tests/test_spin_comunidades.py`, resultado: passed (todos los tests de Spin/Comunidades relacionados pasaron). 
- Ejecuté la batería completa `PYTHONPATH=. pytest -q`, resultado: la suite completa mostró 5 fallos en pruebas de integración de comunidades que son preexistentes y no están relacionados con estos cambios, mientras que el resto de tests pasó (498 passed, 5 failed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a348664a3f4832abd4f6e7e584e8e17)