### PR TITLE
Ajusta vista de Spin reservada por ámbito

### DIFF
--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -844,12 +844,10 @@ async def liberar_reserva_spin_administrativa(ambito, usuario_admin):
             print(f"No se pudo enviar el mensaje de liberación administrativa de {nombre_ambito}: {exc}")
 
     try:
-        vista = SpinButtonsView(ambito_normalizado)
-        vista.actualizar_botones(spin_habilitado=True)
         await editar_primer_mensaje_spin(
             reserva.canal_spin,
             content=mensaje_spin_libre(ambito_normalizado),
-            view=vista,
+            view=crear_vista_spin_para_estado(ambito_normalizado, reservada=False),
         )
     except Exception as exc:
         print(f"No se pudo editar el primer mensaje de {nombre_ambito} tras liberación administrativa: {exc}")
@@ -865,10 +863,11 @@ async def liberar_reserva_spin_administrativa(ambito, usuario_admin):
 
 
 class SpinButtonsView(discord.ui.View):
-    def __init__(self, ambito=AMBITO_SPIN_GENERAL):
+    def __init__(self, ambito=AMBITO_SPIN_GENERAL, *, spin_habilitado=True):
         super().__init__(timeout=None)
         self.ambito = normalizar_ambito_spin(ambito) or AMBITO_SPIN_GENERAL
         self._aplicar_ambito_a_botones()
+        self.actualizar_botones(spin_habilitado=spin_habilitado)
 
     def nombre_ambito(self):
         return "Spin Comunidades" if self.ambito == AMBITO_SPIN_COMUNIDADES else "Spin General"
@@ -889,7 +888,6 @@ class SpinButtonsView(discord.ui.View):
                     child.custom_id = self.custom_id_spin()
                 elif child.label == "Encontrado":
                     child.custom_id = self.custom_id_encontrado()
-                    child.disabled = True
 
     async def auto_release_spin(self, reserva_esperada, mensaje_botones=None):
         """Libera por timeout únicamente la reserva concreta que creó la tarea.
@@ -922,11 +920,10 @@ class SpinButtonsView(discord.ui.View):
             print(f"No se pudo enviar DM de timeout de {nombre_ambito}: {exc}")
 
         try:
-            self.actualizar_botones(spin_habilitado=True)
             await editar_primer_mensaje_spin(
                 reserva.canal_spin,
                 content=mensaje_spin_libre(ambito),
-                view=self,
+                view=crear_vista_spin_para_estado(ambito, reservada=False),
             )
         except Exception as exc:
             print(f"No se pudo editar el primer mensaje de {nombre_ambito} tras timeout: {exc}")
@@ -1007,12 +1004,11 @@ class SpinButtonsView(discord.ui.View):
             reserva.timeout_task = timeout_task
             guardar_reserva_spin(reserva)
 
-        self.actualizar_botones(spin_habilitado=False)
         try:
             await editar_primer_mensaje_spin(
                 interaction.channel,
                 content=descripcion_partido,
-                view=self,
+                view=crear_vista_spin_para_estado(ambito, reservada=True),
             )
         except Exception as exc:
             async with obtener_bloqueo_reserva_spin(ambito):
@@ -1020,7 +1016,6 @@ class SpinButtonsView(discord.ui.View):
                     limpiar_reserva_spin(ambito)
             if reserva.timeout_task:
                 reserva.timeout_task.cancel()
-            self.actualizar_botones(spin_habilitado=True)
             await interaction.followup.send(
                 "No se pudo localizar o editar el mensaje principal de Spin. "
                 "La reserva interna ha quedado liberada; recrea el mensaje con "
@@ -1064,12 +1059,11 @@ class SpinButtonsView(discord.ui.View):
             except Exception as exc:
                 print(f"No se pudo enviar el mensaje de liberación de {self.nombre_ambito()}: {exc}")
 
-        self.actualizar_botones(spin_habilitado=True)
         try:
             await editar_primer_mensaje_spin(
                 reserva.canal_spin,
                 content=mensaje_spin_libre(ambito),
-                view=self,
+                view=crear_vista_spin_para_estado(ambito, reservada=False),
             )
         except Exception as exc:
             print(f"No se pudo editar el primer mensaje de {self.nombre_ambito()} al liberar: {exc}")
@@ -1078,7 +1072,19 @@ class SpinButtonsView(discord.ui.View):
         thread = Thread(target=GestorSQL.insertar_spin, args=(user.name, datetime.utcnow(), TIPO_SPIN_ENCONTRADO, ambito, user.id))
         thread.start()
 
-            
+
+def crear_vista_spin_para_estado(ambito, *, reservada=False):
+    """Crea una vista de Spin con botones coherentes para un único ámbito.
+
+    Según ``logicaSpin.md``, una cola libre muestra `Spin` habilitado y
+    `Encontrado` deshabilitado; una cola reservada invierte esos estados. Se
+    devuelve una instancia nueva para editar solo el mensaje del canal del
+    ámbito afectado, sin reutilizar ni mutar la vista de la otra cola.
+    """
+
+    ambito_normalizado = normalizar_ambito_spin(ambito) or AMBITO_SPIN_GENERAL
+    return SpinButtonsView(ambito_normalizado, spin_habilitado=not reservada)
+
 #Singleton para las necesidades del discord
 class DiscordClientSingleton:
     bot_instance = None

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -1163,3 +1163,139 @@ def test_resolver_partido_spin_comunidades_deja_sin_fecha_detras_de_fechados():
     finally:
         session.close()
         engine.dispose()
+
+
+def _estado_botones_spin(vista):
+    return {boton.label: boton.disabled for boton in vista.children}
+
+
+def test_crear_vista_spin_para_estado_invierte_botones_solo_en_reservada():
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL, AMBITO_SPIN_COMUNIDADES
+
+    vista_general_libre = UtilesDiscord.crear_vista_spin_para_estado(AMBITO_SPIN_GENERAL, reservada=False)
+    vista_general_reservada = UtilesDiscord.crear_vista_spin_para_estado(AMBITO_SPIN_GENERAL, reservada=True)
+    vista_comunidades_libre = UtilesDiscord.crear_vista_spin_para_estado(AMBITO_SPIN_COMUNIDADES, reservada=False)
+
+    assert _estado_botones_spin(vista_general_libre) == {"Spin": False, "Encontrado": True}
+    assert _estado_botones_spin(vista_general_reservada) == {"Spin": True, "Encontrado": False}
+    assert _estado_botones_spin(vista_comunidades_libre) == {"Spin": False, "Encontrado": True}
+    assert {boton.label: boton.custom_id for boton in vista_general_reservada.children} == {
+        "Spin": "lombardbot:spin:general",
+        "Encontrado": "lombardbot:encontrado:general",
+    }
+    assert {boton.label: boton.custom_id for boton in vista_comunidades_libre.children} == {
+        "Spin": "lombardbot:spin:comunidades",
+        "Encontrado": "lombardbot:encontrado:comunidades",
+    }
+
+
+@pytest.mark.asyncio
+async def test_spin_callback_edita_primer_mensaje_reservado_y_no_muta_la_otra_vista(monkeypatch):
+    from types import SimpleNamespace
+    import UtilesDiscord
+    from SpinConstantes import AMBITO_SPIN_GENERAL, AMBITO_SPIN_COMUNIDADES
+
+    mensajes = []
+    edits = []
+    avisos_partido = []
+
+    class Response:
+        async def defer(self):
+            pass
+
+    class Followup:
+        async def send(self, mensaje, *, ephemeral=False):
+            mensajes.append((mensaje, ephemeral))
+
+    class Message:
+        async def edit(self, **kwargs):
+            edits.append(kwargs)
+
+    class Channel:
+        def history(self, *, oldest_first=False, limit=1):
+            async def iterator():
+                yield Message()
+            return iterator()
+
+    class CanalPartido:
+        async def send(self, mensaje):
+            avisos_partido.append(mensaje)
+
+    class Guild:
+        def get_channel(self, canal_id):
+            assert canal_id == 9001
+            return CanalPartido()
+
+    class Query:
+        def filter(self, *args, **kwargs):
+            return self
+
+        def first(self):
+            return SimpleNamespace(idUsuarios=55)
+
+    class Session:
+        def query(self, modelo):
+            return Query()
+
+        def close(self):
+            pass
+
+    class TimeoutTask:
+        def __init__(self):
+            self.cancelled = False
+
+        def cancel(self):
+            self.cancelled = True
+
+    def create_task_fake(coro):
+        coro.close()
+        return TimeoutTask()
+
+    partido = UtilesDiscord.SpinMatchResult(
+        ambito=AMBITO_SPIN_GENERAL,
+        canal_partido_id=9001,
+        jugador1_discord_id=111,
+        jugador2_discord_id=222,
+        fecha=None,
+        descripcion_corta="Spin General reservado: <@111> y <@222> pueden buscar partido.",
+    )
+
+    vista_comunidades = UtilesDiscord.SpinButtonsView(AMBITO_SPIN_COMUNIDADES)
+    estado_comunidades_inicial = _estado_botones_spin(vista_comunidades)
+
+    monkeypatch.setattr(UtilesDiscord.GestorSQL, "conexionEngine", lambda: object())
+    monkeypatch.setattr(UtilesDiscord.GestorSQL, "sessionmaker", lambda bind=None: Session)
+    monkeypatch.setattr(UtilesDiscord, "buscar_partido_spin", lambda session, usuario_db, ambito: partido)
+    monkeypatch.setattr(UtilesDiscord.asyncio, "create_task", create_task_fake)
+    monkeypatch.setattr(UtilesDiscord.Thread, "start", lambda self: None)
+
+    interaction = SimpleNamespace(
+        response=Response(),
+        followup=Followup(),
+        user=SimpleNamespace(id=111, name="Jugador"),
+        guild=Guild(),
+        channel=Channel(),
+    )
+
+    try:
+        await UtilesDiscord.SpinButtonsView(AMBITO_SPIN_GENERAL).spin_callback.callback(interaction)
+
+        assert UtilesDiscord.reserva_spin_activa(UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_GENERAL))
+        assert UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_COMUNIDADES) is None
+        assert len(edits) == 1
+        assert edits[0]["content"] == "Spin General reservado: <@111> y <@222> pueden buscar partido."
+        assert _estado_botones_spin(edits[0]["view"]) == {"Spin": True, "Encontrado": False}
+        assert {boton.label: boton.custom_id for boton in edits[0]["view"].children} == {
+            "Spin": "lombardbot:spin:general",
+            "Encontrado": "lombardbot:encontrado:general",
+        }
+        assert _estado_botones_spin(vista_comunidades) == estado_comunidades_inicial
+        assert avisos_partido == ["<@111> y <@222>, podéis spinear."]
+        assert mensajes == [("Ahora puedes buscar partido en Spin General.", True)]
+    finally:
+        reserva = UtilesDiscord.obtener_reserva_spin(AMBITO_SPIN_GENERAL)
+        if getattr(reserva, "timeout_task", None):
+            reserva.timeout_task.cancel()
+        UtilesDiscord.reservas_spin[AMBITO_SPIN_GENERAL] = None
+        UtilesDiscord.reservas_spin[AMBITO_SPIN_COMUNIDADES] = None


### PR DESCRIPTION
### Motivation
- Reflejar visualmente que una cola de Spin está ocupada sin mutar la vista persistente de otra cola, siguiendo `logicaSpin.md` (deshabilitar `Spin`, habilitar `Encontrado`, editar primer mensaje del canal y aplicar por ámbito).
- Evitar efectos colaterales al usar una única instancia de `View` para varios ámbitos, de modo que la edición del estado de una cola no altere la otra.

### Description
- `SpinButtonsView` ahora acepta un parámetro `spin_habilitado` en su constructor y conserva `custom_id` por ámbito para los botones. (se parametriza el estado inicial de los botones).  
- Se añade `crear_vista_spin_para_estado(ambito, *, reservada=False)` que devuelve una nueva instancia de `SpinButtonsView` con los botones ajustados para el estado libre/reservado, de modo que las ediciones del mensaje usan una vista nueva y no mutan la vista en memoria.  
- Reemplacé las ediciones del primer mensaje de canal en los flujos de reserva (`spin_callback`), liberación manual (`encontrado_callback`), liberación automática (`auto_release_spin`) y liberación administrativa (`liberar_reserva_spin_administrativa`) para usar el helper y restaurar/mostrar la vista adecuada por ámbito.  
- Añadí pruebas unitarias que verifican que la vista creada invierte los estados de botones para `reservada` y que reservar una cola edita solo la vista del ámbito afectado sin mutar la otra vista (`tests/test_spin_comunidades.py`).

### Testing
- Ejecutado `git diff --check` y no reportó problemas, success.  
- Ejecutado `PYTHONPATH=. pytest -q tests/test_spin_comunidades.py` y todos los tests pasaron (`37 passed`) con warnings deprecación existentes; los casos nuevos verifican estados visuales y aislamiento entre ámbitos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3487e6e81c832a82332e69deb10809)