### PR TITLE
Respetar ámbito propio en colas Spin

### DIFF
--- a/SpinConstantes.py
+++ b/SpinConstantes.py
@@ -26,6 +26,7 @@ TIPO_SPIN = "Spin"
 TIPO_SPIN_ENCONTRADO = "Encontrado"
 TIPO_SPIN_AUTO_RELEASE = "AutoRelease"
 TIPO_SPIN_ADMIN_RELEASE = "LiberacionAdmin"
+MENSAJE_SIN_PARTIDO_COLA_SPIN = "No tienes ningún partido pendiente en esta cola de Spin."
 
 MENSAJES_SPIN_LIBRE = {
     AMBITO_SPIN_GENERAL: "El Spin General está **LIBRE**",

--- a/UtilesDiscord.py
+++ b/UtilesDiscord.py
@@ -30,6 +30,7 @@ from SpinConstantes import (
     TIPO_SPIN_AUTO_RELEASE,
     TIPO_SPIN_ADMIN_RELEASE,
     TIPO_SPIN_ENCONTRADO,
+    MENSAJE_SIN_PARTIDO_COLA_SPIN,
     CANAL_SPIN_COMUNIDADES_ID,
     CANAL_SPIN_GENERAL_ID,
     mensaje_canal_partido_liberacion_administrativa,
@@ -966,7 +967,7 @@ class SpinButtonsView(discord.ui.View):
             else:
                 try:
                     partido_spin = buscar_partido_spin(session, usuario_db, ambito)
-                    mensaje_error = None if partido_spin else "No tienes ningún partido pendiente en esta cola de Spin."
+                    mensaje_error = None if partido_spin else MENSAJE_SIN_PARTIDO_COLA_SPIN
                 except ValueError:
                     partido_spin = None
                     mensaje_error = "El ámbito de Spin no es válido. Avise a un administrador."

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -216,7 +216,7 @@ def test_resolver_partido_spin_delega_solo_en_general(monkeypatch):
 
     def resolver_general(session, usuario_db):
         llamadas.append("general")
-        return "partido-general"
+        return None
 
     def resolver_comunidades(session, usuario_db):
         llamadas.append("comunidades")
@@ -225,7 +225,7 @@ def test_resolver_partido_spin_delega_solo_en_general(monkeypatch):
     monkeypatch.setattr(UtilesDiscord, "resolver_partido_spin_general", resolver_general)
     monkeypatch.setattr(UtilesDiscord, "resolver_partido_spin_comunidades", resolver_comunidades)
 
-    assert UtilesDiscord.resolver_partido_spin(object(), object(), AMBITO_SPIN_GENERAL) == "partido-general"
+    assert UtilesDiscord.resolver_partido_spin(object(), object(), AMBITO_SPIN_GENERAL) is None
     assert llamadas == ["general"]
 
 
@@ -240,12 +240,12 @@ def test_resolver_partido_spin_delega_solo_en_comunidades(monkeypatch):
 
     def resolver_comunidades(session, usuario_db):
         llamadas.append("comunidades")
-        return "partido-comunidades"
+        return None
 
     monkeypatch.setattr(UtilesDiscord, "resolver_partido_spin_general", resolver_general)
     monkeypatch.setattr(UtilesDiscord, "resolver_partido_spin_comunidades", resolver_comunidades)
 
-    assert UtilesDiscord.resolver_partido_spin(object(), object(), "Comunidades") == "partido-comunidades"
+    assert UtilesDiscord.resolver_partido_spin(object(), object(), "Comunidades") is None
     assert llamadas == ["comunidades"]
 
 


### PR DESCRIPTION
### Motivation

- Hacer que la UI y la lógica respeten la regla de `logicaSpin.md` que exige que cada cola busque solo en su propio ámbito y no haga fallback al otro.

### Description

- Añadido el mensaje canónico `MENSAJE_SIN_PARTIDO_COLA_SPIN` en `SpinConstantes.py` con el texto exacto exigido por la especificación. 
- Reemplazado el literal en el callback `spin_callback` de `UtilesDiscord.py` para usar `MENSAJE_SIN_PARTIDO_COLA_SPIN` cuando `buscar_partido_spin` no encuentra partido en el ámbito solicitado. 
- Ajustados tests en `tests/test_spin_comunidades.py` para verificar que `resolver_partido_spin` devuelve `None` cuando el proveedor del ámbito invocado no encuentra partido (y por tanto no debe caer en el otro ámbito).

### Testing

- Ejecutado `PYTHONPATH=. pytest tests/test_spin_comunidades.py -q` tras instalar dependencias necesarias; todos los tests de ese fichero pasaron: `37 passed, 15 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a348946da84832a95ba82bcd38933aa)