### PR TITLE
Normalizar ámbitos de Spin sin distinguir mayúsculas

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -40,6 +40,7 @@ from SpinConstantes import (
     formatear_historial_spins,
     normalizar_filtro_historial_spin,
     normalizar_ambito_spin,
+    mensaje_ambito_spin_no_valido,
 )
 import GestionExcel
 import aiohttp
@@ -1839,7 +1840,7 @@ async def agregar_vista(ctx, message_id: int, ambito: str = "General"):
     try:
         ambito_normalizado = normalizar_ambito_spin(ambito)
         if not ambito_normalizado:
-            await ctx.send("Ámbito de Spin no válido. Usa General o Comunidades.", delete_after=20)
+            await ctx.send(mensaje_ambito_spin_no_valido(ambito), delete_after=20)
             return
         # Obten el canal y luego el mensaje usando el ID proporcionado
         message = await ctx.channel.fetch_message(message_id)
@@ -1865,7 +1866,7 @@ async def AgregaMensajeSpin(ctx, ambito: str = None):
     ambito_normalizado = normalizar_ambito_spin(ambito)
     if not ambito_normalizado:
         await ctx.send(
-            f"Ámbito de Spin no válido: `{ambito}`.\n{ayuda_agregar_mensaje_spin()}",
+            f"{mensaje_ambito_spin_no_valido(ambito)}\n{ayuda_agregar_mensaje_spin()}",
             delete_after=20,
         )
         return
@@ -1895,10 +1896,6 @@ def usuario_puede_liberar_spin(interaction: discord.Interaction):
 
 @bot.tree.command(name="liberarspin", description="Libera administrativamente una cola de Spin.")
 @app_commands.describe(ambito="Ámbito de Spin: General o Comunidades")
-@app_commands.choices(ambito=[
-    app_commands.Choice(name="General", value="General"),
-    app_commands.Choice(name="Comunidades", value="Comunidades"),
-])
 async def liberar_spin(interaction: discord.Interaction, ambito: str):
     if not usuario_puede_liberar_spin(interaction):
         await interaction.response.send_message("No tienes permiso para usar este comando.", ephemeral=True)
@@ -1906,7 +1903,7 @@ async def liberar_spin(interaction: discord.Interaction, ambito: str):
 
     ambito_normalizado = normalizar_ambito_spin(ambito)
     if not ambito_normalizado:
-        await interaction.response.send_message("Ámbito de Spin no válido. Usa General o Comunidades.", ephemeral=True)
+        await interaction.response.send_message(mensaje_ambito_spin_no_valido(ambito), ephemeral=True)
         return
 
     liberado = await UtilesDiscord.liberar_reserva_spin_administrativa(ambito_normalizado, interaction.user)
@@ -2356,11 +2353,6 @@ async def PruebaBD(ctx):
     
 @bot.tree.command(name="ultimosspins")
 @app_commands.describe(ambito="Ámbito de Spin: General, Comunidades o Todos")
-@app_commands.choices(ambito=[
-    app_commands.Choice(name="General", value="General"),
-    app_commands.Choice(name="Comunidades", value="Comunidades"),
-    app_commands.Choice(name="Todos", value="Todos"),
-])
 @commands.has_any_role('Moderadores', 'Administrador', 'Comisario')
 async def obtener_spins_recientes(interaction: discord.Interaction, minutos: int, ambito: str = "Todos"):
     Session = sessionmaker(bind=GestorSQL.conexionEngine())
@@ -2374,7 +2366,7 @@ async def obtener_spins_recientes(interaction: discord.Interaction, minutos: int
     try:
         filtro_ambito = normalizar_filtro_historial_spin(ambito)
         if filtro_ambito is None and normalizar_ambito_spin(ambito, permitir_todos=True) != AMBITO_SPIN_TODOS:
-            respuesta = "```Ámbito no válido. Usa General, Comunidades o Todos.```"
+            respuesta = f"```{mensaje_ambito_spin_no_valido(ambito, permitir_todos=True)}```"
             ephemeral = True
         else:
             # Realizar la consulta filtrando por fecha y, si procede, por ámbito.

--- a/SpinConstantes.py
+++ b/SpinConstantes.py
@@ -145,13 +145,22 @@ def _normalizar_texto_ambito(texto):
 def normalizar_ambito_spin(texto, *, permitir_todos=False):
     """Convierte textos de usuario a ámbitos internos de Spin.
 
-    Acepta los textos visibles ``General``, ``Comunidades`` y, cuando
-    ``permitir_todos`` es verdadero, ``Todos``. También acepta directamente los
-    valores internos ``GENERAL`` y ``COMUNIDADES``.
+    Acepta variantes simples de mayúsculas/minúsculas de los textos visibles
+    ``General``, ``Comunidades`` y, cuando ``permitir_todos`` es verdadero,
+    ``Todos``. También acepta directamente los valores internos ``GENERAL`` y
+    ``COMUNIDADES``. Los valores desconocidos devuelven ``None`` para que cada
+    comando pueda rechazarlos con un mensaje claro.
     """
 
     opciones = _TEXTOS_AMBITO_SPIN_TODOS if permitir_todos else _TEXTOS_AMBITO_SPIN
     return opciones.get(_normalizar_texto_ambito(texto))
+
+
+def mensaje_ambito_spin_no_valido(texto, *, permitir_todos=False):
+    """Devuelve un error claro para ámbitos de Spin desconocidos."""
+
+    valores = "General, Comunidades o Todos" if permitir_todos else "General o Comunidades"
+    return f"Ámbito de Spin no válido: `{texto}`. Usa {valores}."
 
 
 def formatear_linea_historial_spin(fecha, usuario, tipo, ambito):

--- a/tests/test_spin_comunidades.py
+++ b/tests/test_spin_comunidades.py
@@ -290,6 +290,31 @@ def test_mensaje_spin_libre_centraliza_textos_por_ambito():
     assert mensaje_spin_libre("COMUNIDADES") == MENSAJES_SPIN_LIBRE[AMBITO_SPIN_COMUNIDADES]
 
 
+def test_normalizar_ambito_spin_acepta_variantes_de_mayusculas():
+    from SpinConstantes import (
+        AMBITO_SPIN_COMUNIDADES,
+        AMBITO_SPIN_GENERAL,
+        normalizar_ambito_spin,
+        normalizar_filtro_historial_spin,
+        mensaje_ambito_spin_no_valido,
+    )
+
+    assert normalizar_ambito_spin("general") == AMBITO_SPIN_GENERAL
+    assert normalizar_ambito_spin("GeNeRaL") == AMBITO_SPIN_GENERAL
+    assert normalizar_ambito_spin("comunidades") == AMBITO_SPIN_COMUNIDADES
+    assert normalizar_ambito_spin("CoMuNiDaDeS") == AMBITO_SPIN_COMUNIDADES
+    assert normalizar_filtro_historial_spin("todos") is None
+    assert normalizar_filtro_historial_spin("ToDoS") is None
+    assert normalizar_ambito_spin("Ticket") is None
+    assert (
+        mensaje_ambito_spin_no_valido("Ticket")
+        == "Ámbito de Spin no válido: `Ticket`. Usa General o Comunidades."
+    )
+    assert (
+        mensaje_ambito_spin_no_valido("Ticket", permitir_todos=True)
+        == "Ámbito de Spin no válido: `Ticket`. Usa General, Comunidades o Todos."
+    )
+
 def test_spin_buttons_view_parametriza_custom_ids_por_ambito():
     import UtilesDiscord
     from SpinConstantes import AMBITO_SPIN_GENERAL, AMBITO_SPIN_COMUNIDADES


### PR DESCRIPTION
### Motivation
- Hacer que los comandos relacionados con la mecánica Spin acepten variantes sencillas de mayúsculas/minúsculas para los ámbitos definidos en `logicaSpin.md` (`General`, `Comunidades` y `Todos` cuando proceda). 
- Rechazar valores desconocidos con un mensaje claro y reutilizable para evitar respuestas inconsistentes en varios comandos. 

### Description
- Añade `mensaje_ambito_spin_no_valido(texto, *, permitir_todos=False)` en `SpinConstantes.py` y amplía la documentación de `normalizar_ambito_spin` para explicar que acepta variantes de capitalización y devuelve `None` para valores desconocidos. 
- Reemplaza textos literales de error en `LombardBot.py` por llamadas a `mensaje_ambito_spin_no_valido(...)` en `AgregarVista`, `AgregaMensajeSpin`, `liberarspin` y `ultimosspins`. 
- Elimina las `app_commands.choices` en los comandos slash afectados para permitir recibir texto libre y que la normalización acepte variantes de escritura en vez de ser rechazadas por Discord antes de llegar al bot. 
- Añade un test (`test_normalizar_ambito_spin_acepta_variantes_de_mayusculas`) en `tests/test_spin_comunidades.py` que verifica las variantes `general`/`GeNeRaL`, `comunidades`/`CoMuNiDaDeS`, `todos`/`ToDoS` y la cadena de error esperada para valores desconocidos. 

### Testing
- Compilación estática: `python3 -m py_compile SpinConstantes.py LombardBot.py` — OK. 
- Asserts de unidad local (invocación en un script Python que comprueba `normalizar_ambito_spin`, `normalizar_filtro_historial_spin` y `mensaje_ambito_spin_no_valido`) — OK. 
- `pytest -q tests/test_spin_comunidades.py` — no ejecutado por falta de la dependencia `sqlalchemy` en el entorno (error al cargar `conftest.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3489735514832a89be1703df713eeb)