### PR TITLE
Mover preferencias al mensaje de partido y añadir advertencia de Spin Comunidades

### DIFF
--- a/ComunidadesDiscord.py
+++ b/ComunidadesDiscord.py
@@ -6,6 +6,8 @@ import logging
 from decimal import Decimal, InvalidOperation
 from typing import Any, Optional, Tuple
 
+from SpinConstantes import CANAL_SPIN_COMUNIDADES_ID
+
 
 MAX_CANALES_POR_CATEGORIA_COMUNIDADES = 40
 LOGGER = logging.getLogger(__name__)
@@ -304,6 +306,26 @@ def _mensaje_partido_comunidades(enfrentamiento: Any, partido: Any) -> str:
     defensor_discord_id = int(partido.defensor_usuario.id_discord)
     equipo_local = etiqueta_equipo_comunidades(partido.equipo_local)
     equipo_visitante = etiqueta_equipo_comunidades(partido.equipo_visitante)
+    preferencias = []
+    for usuario in (partido.usuario_local, partido.usuario_visitante):
+        preferencia = getattr(
+            getattr(usuario, "preferencias_fecha", None), "preferencia", ""
+        )
+        if preferencia and str(preferencia).strip():
+            preferencias.append(
+                f"- {mencion_usuario_comunidades(usuario)} suele poder jugar "
+                f"{texto_discord_seguro_comunidades(str(preferencia).strip())}"
+            )
+    seccion_preferencias = ""
+    if preferencias:
+        seccion_preferencias = "\n\n### Preferencias horarias\n" + "\n".join(
+            preferencias
+        )
+    canal_spin = (
+        f"<#{int(CANAL_SPIN_COMUNIDADES_ID)}>"
+        if CANAL_SPIN_COMUNIDADES_ID is not None
+        else "el canal de Spin Comunidades"
+    )
     return (
         f"## Partido {int(partido.indice)} — Mesa {int(enfrentamiento.mesa_numero)}\n"
         f"**Equipos:** {equipo_local} vs {equipo_visitante}\n"
@@ -313,6 +335,9 @@ def _mensaje_partido_comunidades(enfrentamiento: Any, partido: Any) -> str:
         f"**Fecha límite:** {enfrentamiento.ronda.fecha_fin.strftime('%Y-%m-%d %H:%M')}\n"
         "Cuando acordéis el día y la hora del partido, registrad la quedada "
         "en este canal con `/fecha`."
+        f"{seccion_preferencias}\n\n"
+        f"⚠️ Antes de iniciar el partido tenéis que **USAR** {canal_spin} "
+        "y **LIBERARLO** al encontrar partido."
     )
 
 
@@ -631,7 +656,6 @@ def mensajes_canal_enfrentamiento_comunidades(
 
     equipos = (enfrentamiento.equipo_a, enfrentamiento.equipo_b)
     lineas_jugadores = []
-    preferencias = []
     for equipo in equipos:
         if lineas_jugadores:
             lineas_jugadores.append("")
@@ -647,22 +671,9 @@ def mensajes_canal_enfrentamiento_comunidades(
                 f"- {mencion_usuario_comunidades(usuario)} — "
                 f"**{nombre_bloodbowl}** — {raza}"
             )
-            preferencia = getattr(
-                getattr(usuario, "preferencias_fecha", None), "preferencia", ""
-            )
-            if preferencia and str(preferencia).strip():
-                preferencias.append(
-                    f"- {mencion_usuario_comunidades(usuario)} suele poder jugar "
-                    f"{texto_discord_seguro_comunidades(str(preferencia).strip())}"
-                )
 
     estado_a = estado_visible(fotos[int(enfrentamiento.equipo_a_id)])
     estado_b = estado_visible(fotos[int(enfrentamiento.equipo_b_id)])
-    seccion_preferencias = ""
-    if preferencias:
-        seccion_preferencias = "\n\n### Preferencias horarias\n" + "\n".join(
-            preferencias
-        )
 
     jugadores = "\n".join(lineas_jugadores)
     mensaje_general = (
@@ -670,8 +681,7 @@ def mensajes_canal_enfrentamiento_comunidades(
         f"{etiqueta_equipo_comunidades(enfrentamiento.equipo_a)} vs "
         f"{etiqueta_equipo_comunidades(enfrentamiento.equipo_b)}\n\n"
         "### Jugadores\n"
-        f"{jugadores}"
-        f"{seccion_preferencias}\n\n"
+        f"{jugadores}\n\n"
         "### Selección de atacante\n"
         "Cada equipo dispone de **24 horas** para seleccionar atacante con "
         "`/comunidades_seleccion_atacante`. La elección es secreta hasta que "

--- a/tests/test_comunidades_materializacion_partidos.py
+++ b/tests/test_comunidades_materializacion_partidos.py
@@ -24,6 +24,7 @@ from GestorSQL import (
     ComunidadesPartido,
     ComunidadesRonda,
     ComunidadesTorneo,
+    PreferenciasFecha,
     Usuario,
 )
 
@@ -69,6 +70,13 @@ def _crear_escenario(session):
         Usuario(idUsuarios=22, id_discord=202, nombre_discord="B Dos"),
     ]
     session.add_all(usuarios)
+    session.add_all(
+        [
+            PreferenciasFecha(idUsuarios=12, preferencia="laborables desde las 20:00"),
+            PreferenciasFecha(idUsuarios=22, preferencia="fines de semana"),
+            PreferenciasFecha(idUsuarios=11, preferencia="no debe aparecer en partido 1"),
+        ]
+    )
     ronda = ComunidadesRonda(
         torneo_id=torneo.id,
         numero=1,
@@ -241,6 +249,12 @@ def test_materializa_dos_canales_con_permisos_mensajes_y_estado():
         assert "**Equipos:** [A] Equipo A vs [B] Equipo B" in guild.creaciones[0]["canal"].mensajes[0]
         assert "**Fecha límite:** 2026-07-08 22:00" in guild.creaciones[0]["canal"].mensajes[0]
         assert "registrad la quedada en este canal con `/fecha`" in guild.creaciones[0]["canal"].mensajes[0]
+        assert "### Preferencias horarias" in guild.creaciones[0]["canal"].mensajes[0]
+        assert "<@102> suele poder jugar laborables desde las 20:00" in guild.creaciones[0]["canal"].mensajes[0]
+        assert "<@202> suele poder jugar fines de semana" in guild.creaciones[0]["canal"].mensajes[0]
+        assert "no debe aparecer en partido 1" not in guild.creaciones[0]["canal"].mensajes[0]
+        assert "Antes de iniciar el partido tenéis que **USAR** el canal de Spin Comunidades" in guild.creaciones[0]["canal"].mensajes[0]
+        assert guild.creaciones[0]["canal"].mensajes[0].rstrip().endswith("y **LIBERARLO** al encontrar partido.")
         enfrentamiento = session.get(ComunidadesEnfrentamiento, enfrentamiento_id)
         assert enfrentamiento.estado == "PARTIDOS_CREADOS"
         assert [partido.canal_discord_id for partido in enfrentamiento.partidos] == [901, 902]

--- a/tests/test_comunidades_mensajes.py
+++ b/tests/test_comunidades_mensajes.py
@@ -85,7 +85,7 @@ def test_etiqueta_equipo_antepone_la_comunidad_entre_corchetes():
     )
 
 
-def test_mensaje_general_muestra_datos_del_torneo_y_preferencias_despues_de_jugadores():
+def test_mensaje_general_muestra_datos_del_torneo_sin_preferencias_horarias():
     torneo = SimpleNamespace(
         plantilla_mensaje_ronda1="Aviso de primera ronda",
         plantilla_mensaje_rondas_siguientes="Aviso posterior",
@@ -100,9 +100,9 @@ def test_mensaje_general_muestra_datos_del_torneo_y_preferencias_despues_de_juga
     assert "- <@101> — **OrcoBB** — Orcos" in general
     assert "- <@102> — **RataBB** — Skaven" in general
     assert "Incorrecta" not in general
-    assert general.index("<@101> — **OrcoBB**") < general.index("### Preferencias horarias")
-    assert "<@101> suele poder jugar laborables desde las 20:00" in general
-    assert "<@201> suele poder jugar fines de semana" in general
+    assert "### Preferencias horarias" not in general
+    assert "<@101> suele poder jugar laborables desde las 20:00" not in general
+    assert "<@201> suele poder jugar fines de semana" not in general
     assert "<@202> suele poder jugar" not in general
     assert adicional == "Aviso de primera ronda"
 


### PR DESCRIPTION
### Motivation
- Adaptar los mensajes de los canales de partidos de comunidades para que las preferencias horarias se muestren en el mensaje de cada partido individual y no en el mensaje general del enfrentamiento, conforme a la especificación del torneo y la lógica de Spin.
- Recordar a los jugadores que deben usar la cola de Spin Comunidades antes de iniciar el partido para evitar emparejamientos simultáneos y mantener coherencia con los textos de otras competiciones.

### Description
- Se añadió la importación de `CANAL_SPIN_COMUNIDADES_ID` y en `_mensaje_partido_comunidades` se extraen y formatean las preferencias sólo de los dos jugadores implicados, mostrando la sección `### Preferencias horarias` únicamente cuando existen preferencias.
- Se añadió al final del mensaje de cada partido la advertencia de uso y liberación del canal de Spin (muestra `<#ID>` si `CANAL_SPIN_COMUNIDADES_ID` está configurado o un texto de fallback).
- Se eliminó la presentación de preferencias horarias del mensaje general del enfrentamiento en `mensajes_canal_enfrentamiento_comunidades` para evitar duplicidad y mostrar las preferencias únicamente en los mensajes de los partidos.
- Se actualizaron los tests correspondientes en `tests/test_comunidades_mensajes.py` y `tests/test_comunidades_materializacion_partidos.py` para validar el nuevo comportamiento.

### Testing
- Ejecutado `PYTHONPATH=. pytest tests/test_comunidades_mensajes.py tests/test_comunidades_materializacion_partidos.py` y todos los casos relevantes pasaron; resultado: `7 passed, 2 warnings`.
- Las pruebas de materialización de canales verifican que la sección de preferencias aparece en el mensaje del partido y que la advertencia de Spin figura al final del mensaje, y esas aserciones pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34ebb411c0832a85b406f5d17bed91)