### PR TITLE
Actualiza foros de resultados para suizo de comunidades

### DIFF
--- a/DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES.md
+++ b/DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES.md
@@ -977,10 +977,19 @@ del equipo y entre corchetes: `[COMUNIDAD] NOMBREEQUIPO`.
 
 ### 16.1. Foro de resultados
 
-Se conserva el foro hardcodeado usado por el suizo actual. Al importar o administrar cada partido individual:
+Al importar o administrar cada partido individual, la publicación de resultados debe usar foros diferenciados por tipo de competición:
 
+- el suizo normal, la liga regular y el playoff siguen publicando resultados en el foro `1223765590146158653`;
+- cualquier torneo suizo de comunidades publica resultados en el foro `1517927833966739567`;
+- ambos IDs deben existir como constantes en el código, con nombres explícitos que identifiquen el foro de resultados general y el foro de resultados del suizo de comunidades;
 - se genera y publica la imagen de resultado;
 - se informa en el canal individual correspondiente.
+
+Los resultados del suizo de comunidades deben usar la plantilla de imagen `resultadoComunidades.png`. Esta plantilla recibe los mismos datos que la plantilla del suizo normal y, además, los siguientes campos:
+
+- `comunidad1`: comunidad del jugador/equipo del lado 1;
+- `comunidad2`: comunidad del jugador/equipo del lado 2;
+- `comunidadVS`: concatenación exacta `"{comunidad1} Vs {comunidad2}"`, por ejemplo `"PdM Vs Butter"`.
 
 No se eliminan publicaciones del foro al cerrar o regenerar rondas.
 
@@ -1157,7 +1166,7 @@ Todas las reglas funcionales de este documento se consideran confirmadas, en par
 ### Detalles que la tarea de implementación deberá concretar sin cambiar reglas
 
 - nombres físicos definitivos de las demás tablas y constraints;
-- IDs hardcodeados existentes del foro y canal administrativo;
+- constantes explícitas para el foro de resultados general (`1223765590146158653`), el foro de resultados del suizo de comunidades (`1517927833966739567`) y el canal administrativo;
 - texto inicial de las plantillas configurables, sus marcadores admitidos y el diseño visual de embeds;
 - estrategia técnica para garantizar el rollback coordinado de base de datos y canales Discord exigido por las operaciones atómicas;
 - comportamiento exacto ya existente de PJ/PG/PE/PP y Buchholz para bye, que debe reutilizarse sin desviaciones;


### PR DESCRIPTION
### Motivation
- La documentación anterior preservaba un "foro hardcodeado" único para resultados, lo que no contempla distinguir suizo general y suizo de comunidades. 
- Es necesario dejar claro qué foros usar según el tipo de competición y exigir constantes explícitas en el código para evitar ambigüedades. 
- Los resultados del suizo de comunidades requieren una plantilla de imagen con campos adicionales para mostrar la comunidad de cada bando y su concatenación.

### Description
- Se modifica `DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES.md` sección `16.1. Foro de resultados` para indicar que el suizo normal/liga/playoff publica en el foro `1223765590146158653` y que cualquier suizo de comunidades publica en el foro `1517927833966739567`.
- Se exige que ambos IDs existan como constantes explícitas en el código, con nombres que identifiquen el foro de resultados general y el foro del suizo de comunidades.
- Se añade que los resultados del suizo de comunidades deben usar la plantilla de imagen `resultadoComunidades.png` y que ésta recibe, además de los campos de la plantilla normal, los campos `comunidad1`, `comunidad2` y `comunidadVS` con la concatenación exacta `"{comunidad1} Vs {comunidad2}"`.
- Se actualiza la sección `20. Decisiones cerradas y asuntos de implementación` para reemplazar la referencia a "IDs hardcodeados existentes del foro" por la exigencia de constantes explícitas para ambos foros y el canal administrativo.

### Testing
- Se buscó y verificó la presencia de los nuevos tokens en el documento con `rg -n "16\.1|1223765590146158653|1517927833966739567|resultadoComunidades" DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES.md`, y la búsqueda devolvió las líneas esperadas.
- Se inspeccionó el diff del archivo con `git diff -- DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES.md` para confirmar las inserciones y sustituciones realizadas.
- Se verificó el contenido y la numeración de líneas modificadas con `nl -ba DOCUMENTACION_TORNEO_SUIZO_COMUNIDADES.md | sed -n '978,996p;1166,1170p'` para asegurar que las secciones actualizadas contienen los cambios documentados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c0c23ebc832ab74fd165e7ab6833)