### PR TITLE
Publicar resultados de comunidades en el foro de comunidades (FORO_RESULTADOS_COMUNIDADES_ID)

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -5003,7 +5003,7 @@ async def comunidades_actualizar(ctx, torneo_id: int, todos: Optional[str] = Non
         ronda = rondas_abiertas[0]
 
         avisos_previos = await _reintentar_publicaciones_ronda_comunidades(
-            ctx, session, ronda.id
+            ctx, session, ronda.id, id_foro=FORO_RESULTADOS_COMUNIDADES_ID
         )
         detalles.extend(
             f"publicación pendiente para reintento: {aviso}"
@@ -5161,7 +5161,7 @@ async def comunidades_actualizar(ctx, torneo_id: int, todos: Optional[str] = Non
                 )
 
         avisos_publicacion = await _reintentar_publicaciones_ronda_comunidades(
-            ctx, session, ronda.id, matches
+            ctx, session, ronda.id, matches, id_foro=FORO_RESULTADOS_COMUNIDADES_ID
         )
         if avisos_publicacion:
             detalles.extend(
@@ -5853,7 +5853,12 @@ async def comunidades_transferir_cazador(
 
 
 async def publicar_resultado_partido_comunidades(
-    ctx, session, partido_id: int, *, match=None
+    ctx,
+    session,
+    partido_id: int,
+    *,
+    match=None,
+    id_foro=FORO_RESULTADOS_COMUNIDADES_ID,
 ):
     """Publica un partido consolidado y, si es el segundo, todos sus efectos.
 
@@ -5880,9 +5885,9 @@ async def publicar_resultado_partido_comunidades(
 
     try:
         guild = getattr(ctx, "guild", None)
-        foro = discord.utils.get(getattr(guild, "channels", []), id=FORO_RESULTADOS_COMUNIDADES_ID)
+        foro = discord.utils.get(getattr(guild, "channels", []), id=id_foro)
         if foro is None and guild is not None:
-            foro = await _resolver_canal_notificacion_comunidades(ctx, FORO_RESULTADOS_COMUNIDADES_ID)
+            foro = await _resolver_canal_notificacion_comunidades(ctx, id_foro)
         if foro is None or not isinstance(foro, discord.ForumChannel):
             raise RuntimeError("foro de resultados no disponible")
         titulo = f"{partido.enfrentamiento.torneo.nombre} J{partido.enfrentamiento.ronda.numero}"
@@ -5954,7 +5959,14 @@ async def publicar_resultado_partido_comunidades(
     return avisos
 
 
-async def _reintentar_publicaciones_ronda_comunidades(ctx, session, ronda_id: int, matches=()):
+async def _reintentar_publicaciones_ronda_comunidades(
+    ctx,
+    session,
+    ronda_id: int,
+    matches=(),
+    *,
+    id_foro=FORO_RESULTADOS_COMUNIDADES_ID,
+):
     por_uuid = {
         str(match.get("uuid")): match
         for match in matches
@@ -5978,6 +5990,7 @@ async def _reintentar_publicaciones_ronda_comunidades(ctx, session, ronda_id: in
                 session,
                 partido.id,
                 match=por_uuid.get(str(partido.partido_bloodbowl_id)),
+                id_foro=id_foro,
             )
         )
     return avisos
@@ -6235,7 +6248,7 @@ async def comunidades_admin_partido(
             return
 
         avisos = await publicar_resultado_partido_comunidades(
-            ctx, session, resultado.partido.id
+            ctx, session, resultado.partido.id, id_foro=FORO_RESULTADOS_COMUNIDADES_ID
         )
         cierre = _consolidar_cierre_ronda_comunidades(
             session, torneo_id, ronda_numero


### PR DESCRIPTION
### Motivation
- Asegurar que las publicaciones de resultados originadas por los flujos de comunidades vayan siempre al foro de comunidades y no al foro general. 
- Evitar depender del valor por defecto y pasar explícitamente el `id_foro` cuando se reintenten o generen publicaciones desde API o administración. 

### Description
- Añadido el parámetro `id_foro=FORO_RESULTADOS_COMUNIDADES_ID` a `publicar_resultado_partido_comunidades` y se usa para resolver el foro destino en lugar del valor fijo anterior. 
- Modificado `_reintentar_publicaciones_ronda_comunidades` para aceptar `id_foro` y propagarlo a `publicar_resultado_partido_comunidades`. 
- Actualizado el comando `!comunidades_actualizar` para invocar `_reintentar_publicaciones_ronda_comunidades(..., id_foro=FORO_RESULTADOS_COMUNIDADES_ID)` tanto en el reintento previo como en el reintento tras procesar `matches`. 
- Actualizado el flujo administrativo `!comunidades_admin_partido` para pasar `id_foro=FORO_RESULTADOS_COMUNIDADES_ID` cuando publica el resultado administrado. 
- Cambios localizados en `LombardBot.py` y sin modificaciones en los flujos de liga regular/playoffs/suizo individual, que mantienen `FORO_RESULTADOS_GENERAL_ID`. 

### Testing
- Se compiló el código fuente con `python3 -m py_compile LombardBot.py UtilesDiscord.py ComunidadesCore.py` y la compilación fue satisfactoria. 
- Se intentó ejecutar `pytest -q tests/test_comunidades_registro_resultados.py tests/test_comunidades_flujo_integracion.py`, pero la ejecución quedó bloqueada por dependencias ausentes en el entorno (`ModuleNotFoundError: No module named 'sqlalchemy'`).
- No se introdujeron advertencias en `git diff --check` tras los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c23da508832ab4998f7c40e7b77e)