### PR TITLE
Mapear comunidades por lado en imagen de resultado (resultadoComunidades)

### DIFF
--- a/Imagenes.py
+++ b/Imagenes.py
@@ -236,6 +236,40 @@ def seleccionarTitulo(apellidos):
 
 
 
+def _comunidad_lado_partido_comunidades(partido_comunidades, usuario_id: int, equipo_id: int) -> str:
+    """Resuelve la comunidad del lado de plantilla desde el partido individual."""
+    enfrentamiento = getattr(partido_comunidades, "enfrentamiento", None)
+    equipos_enfrentamiento = (
+        getattr(enfrentamiento, "equipo_a", None),
+        getattr(enfrentamiento, "equipo_b", None),
+    )
+    for equipo in equipos_enfrentamiento:
+        if equipo is None or int(getattr(equipo, "id", 0) or 0) != int(equipo_id):
+            continue
+        miembros = getattr(equipo, "miembros", ()) or ()
+        if any(
+            int(getattr(miembro, "usuario_id", 0) or 0) == int(usuario_id)
+            for miembro in miembros
+        ):
+            return str(equipo.comunidad.nombre)
+        raise ValueError(
+            "El usuario del lado del partido no pertenece al equipo del enfrentamiento."
+        )
+    equipo_lado = None
+    if int(getattr(partido_comunidades, "equipo_local_id", 0) or 0) == int(equipo_id):
+        equipo_lado = getattr(partido_comunidades, "equipo_local", None)
+    elif int(getattr(partido_comunidades, "equipo_visitante_id", 0) or 0) == int(equipo_id):
+        equipo_lado = getattr(partido_comunidades, "equipo_visitante", None)
+    if equipo_lado is not None:
+        miembros = getattr(equipo_lado, "miembros", ()) or ()
+        if not miembros or any(
+            int(getattr(miembro, "usuario_id", 0) or 0) == int(usuario_id)
+            for miembro in miembros
+        ):
+            return str(equipo_lado.comunidad.nombre)
+    raise ValueError("No se pudo resolver la comunidad del lado del partido.")
+
+
 def _datos_comunidades_resultado(session, id_partido_bloodbowl):
     """Devuelve los campos extra esperados por resultadoComunidades.png."""
     partido_comunidades = (
@@ -246,8 +280,16 @@ def _datos_comunidades_resultado(session, id_partido_bloodbowl):
     if not partido_comunidades:
         return {"comunidad1": {}, "comunidad2": {}, "comunidadVS": {}}
 
-    comunidad_local = getattr(getattr(partido_comunidades.equipo_local, "comunidad", None), "nombre", "")
-    comunidad_visitante = getattr(getattr(partido_comunidades.equipo_visitante, "comunidad", None), "nombre", "")
+    comunidad_local = _comunidad_lado_partido_comunidades(
+        partido_comunidades,
+        partido_comunidades.usuario_local_id,
+        partido_comunidades.equipo_local_id,
+    )
+    comunidad_visitante = _comunidad_lado_partido_comunidades(
+        partido_comunidades,
+        partido_comunidades.usuario_visitante_id,
+        partido_comunidades.equipo_visitante_id,
+    )
     return {
         "comunidad1": {"0": comunidad_local},
         "comunidad2": {"0": comunidad_visitante},

--- a/LombardBot.py
+++ b/LombardBot.py
@@ -5408,6 +5408,50 @@ def _datos_api_imagen_comunidades(partido, match):
     return teams[indice_local], teams[indice_visitante]
 
 
+def _comunidad_lado_partido_comunidades(partido, usuario_id: int, equipo_id: int) -> str:
+    """Obtiene la comunidad del lado indicado usando el cruce individual real."""
+    enfrentamiento = getattr(partido, "enfrentamiento", None)
+    equipos_enfrentamiento = (
+        getattr(enfrentamiento, "equipo_a", None),
+        getattr(enfrentamiento, "equipo_b", None),
+    )
+    for equipo in equipos_enfrentamiento:
+        if equipo is None or int(getattr(equipo, "id", 0) or 0) != int(equipo_id):
+            continue
+        miembros = getattr(equipo, "miembros", ()) or ()
+        if any(
+            int(getattr(miembro, "usuario_id", 0) or 0) == int(usuario_id)
+            for miembro in miembros
+        ):
+            return str(equipo.comunidad.nombre)
+        raise ValueError(
+            "El usuario del lado del partido no pertenece al equipo del enfrentamiento."
+        )
+    equipo_lado = None
+    if int(getattr(partido, "equipo_local_id", 0) or 0) == int(equipo_id):
+        equipo_lado = getattr(partido, "equipo_local", None)
+    elif int(getattr(partido, "equipo_visitante_id", 0) or 0) == int(equipo_id):
+        equipo_lado = getattr(partido, "equipo_visitante", None)
+    if equipo_lado is not None:
+        miembros = getattr(equipo_lado, "miembros", ()) or ()
+        if not miembros or any(
+            int(getattr(miembro, "usuario_id", 0) or 0) == int(usuario_id)
+            for miembro in miembros
+        ):
+            return str(equipo_lado.comunidad.nombre)
+    raise ValueError("No se pudo resolver la comunidad del lado del partido.")
+
+
+def _comunidades_lados_partido_comunidades(partido) -> tuple[str, str, str]:
+    comunidad1 = _comunidad_lado_partido_comunidades(
+        partido, partido.usuario_local_id, partido.equipo_local_id
+    )
+    comunidad2 = _comunidad_lado_partido_comunidades(
+        partido, partido.usuario_visitante_id, partido.equipo_visitante_id
+    )
+    return comunidad1, comunidad2, f"{comunidad1} Vs {comunidad2}"
+
+
 def _crear_imagen_resultado_comunidades(session, partido, match=None):
     raza_local = _raza_usuario_partido_comunidades(
         session, partido, partido.usuario_local_id
@@ -5434,8 +5478,9 @@ def _crear_imagen_resultado_comunidades(session, partido, match=None):
     else:
         ganador = {"ruta": "./plantillas/Empate.png", "x": 729, "y": 241}
 
-    comunidad_local = str(partido.equipo_local.comunidad.nombre)
-    comunidad_visitante = str(partido.equipo_visitante.comunidad.nombre)
+    comunidad_local, comunidad_visitante, comunidad_vs = (
+        _comunidades_lados_partido_comunidades(partido)
+    )
 
     return Imagenes.crear_imagen(
         "resultadoComunidades",
@@ -5468,7 +5513,7 @@ def _crear_imagen_resultado_comunidades(session, partido, match=None):
         lado={"izquierdo": "#5f8dd3", "derecho": "#c95f5f"},
         comunidad1={"0": comunidad_local},
         comunidad2={"0": comunidad_visitante},
-        comunidadVS={"0": f"{comunidad_local} Vs {comunidad_visitante}"},
+        comunidadVS={"0": comunidad_vs},
     )
 
 

--- a/tests/test_imagenes_comunidades.py
+++ b/tests/test_imagenes_comunidades.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from Imagenes import _datos_comunidades_resultado
+
+
+def test_datos_comunidades_resultado_respeta_lado_local_visitante(
+    comunidades_session,
+    escenario_comunidades_factory,
+    ronda_comunidades_factory,
+    materializar_enfrentamiento,
+):
+    torneo, comunidades, _equipos = escenario_comunidades_factory(equipos=4, comunidades=4, rondas=1)
+    ronda_comunidades_factory(torneo, 1, semilla=1)
+    enfrentamiento = torneo.rondas[0].enfrentamientos[0]
+    partidos = materializar_enfrentamiento(enfrentamiento, ronda_numero=1)
+    partido = partidos[1]
+    partido.partido_bloodbowl_id = "bbowl-partido-2"
+    comunidades_session.commit()
+
+    datos = _datos_comunidades_resultado(comunidades_session, "bbowl-partido-2")
+
+    assert datos == {
+        "comunidad1": {"0": partido.equipo_local.comunidad.nombre},
+        "comunidad2": {"0": partido.equipo_visitante.comunidad.nombre},
+        "comunidadVS": {
+            "0": f"{partido.equipo_local.comunidad.nombre} Vs {partido.equipo_visitante.comunidad.nombre}"
+        },
+    }
+    assert partido.equipo_local_id == enfrentamiento.equipo_b_id
+    assert partido.equipo_visitante_id == enfrentamiento.equipo_a_id


### PR DESCRIPTION
### Motivation
- Garantizar que la plantilla `resultadoComunidades.png` reciba las comunidades correctas por lado (local/visitante) usando el modelo de comunidades del torneo y respetando el mismo orden que nombres, razas y TD ya usados en la plantilla. 
- Evitar inconsistencias cuando el segundo partido individual invierte el mapeo entre `equipo A / equipo B` y `local / visitante`.

### Description
- Añadidos los helpers `_comunidad_lado_partido_comunidades` y `_comunidades_lados_partido_comunidades` que resuelven la comunidad de cada lado validando `partido`, su `enfrentamiento`, `equipo_a`/`equipo_b` y los `miembros` del equipo. (`LombardBot.py`, `Imagenes.py`).
- Reemplazado el acceso directo a `equipo_local.comunidad.nombre` / `equipo_visitante.comunidad.nombre` por la nueva resolución para poblar `comunidad1`, `comunidad2` y `comunidadVS` antes de llamar a `Imagenes.crear_imagen("resultadoComunidades", ...)`. (`LombardBot.py`, `Imagenes.py`).
- La concatenación `comunidadVS` se construye exactamente como `"{comunidad1} Vs {comunidad2}"` y se pasa al renderizador asegurando el mismo orden local/visitante que el resto de campos de la plantilla. (`Imagenes.py`, `LombardBot.py`).
- Añadida una prueba de regresión `tests/test_imagenes_comunidades.py` que materializa un enfrentamiento y verifica que los campos `comunidad1`, `comunidad2` y `comunidadVS` respetan el lado local/visitante incluso cuando los IDs de equipo están invertidos para el segundo partido.

### Testing
- Se compiló el código fuente con `python - <<'PY' ... compile(...) ... PY` para verificar que los módulos son sintácticamente correctos y la verificación pasó correctamente. 
- Se ejecutó `git diff --check` para revisar problemas de formato y no se detectaron errores. 
- Se intentó ejecutar `pytest -q tests/test_imagenes_comunidades.py` pero falló en este entorno por falta de la dependencia `sqlalchemy` (`ModuleNotFoundError: No module named 'sqlalchemy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c526bfe4832a91e1fdc41c35f7d9)