### PR TITLE
Publicar resultados de comunidades durante actualización API

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -5133,6 +5133,18 @@ async def comunidades_actualizar(ctx, torneo_id: int, todos: Optional[str] = Non
                 )
                 session.commit()
                 encontrados += 1
+                avisos_resultado = await publicar_resultado_partido_comunidades(
+                    ctx,
+                    session,
+                    int(resultado.partido.id),
+                    match=match,
+                    id_foro=FORO_RESULTADOS_COMUNIDADES_ID,
+                )
+                if avisos_resultado:
+                    detalles.extend(
+                        f"publicación pendiente para reintento: {aviso}"
+                        for aviso in avisos_resultado
+                    )
                 if resultado.enfrentamiento_resuelto:
                     detalles.append(
                         f"{partido_bloodbowl_id}: cerrado partido {partido.id} y "

--- a/tests/test_comunidades_actualizar_publicacion.py
+++ b/tests/test_comunidades_actualizar_publicacion.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_comunidades_actualizar_publica_cada_resultado_api_antes_del_corte_una_pasada():
+    """El modo `1` debe publicar el resultado detectado antes de cortar el bucle."""
+    fuente = Path("LombardBot.py").read_text(encoding="utf-8")
+    inicio = fuente.index("@bot.command(name=\"comunidades_actualizar\")")
+    fin = fuente.index("\n\nLOGGER_COMUNIDADES", inicio)
+    cuerpo = fuente[inicio:fin]
+
+    pos_commit = cuerpo.index("session.commit()")
+    pos_publicar = cuerpo.index("await publicar_resultado_partido_comunidades", pos_commit)
+    pos_break = cuerpo.index("if not procesar_todos:", pos_publicar)
+
+    assert pos_commit < pos_publicar < pos_break
+    bloque_publicacion = cuerpo[pos_publicar:pos_break]
+    assert "match=match" in bloque_publicacion
+    assert "id_foro=FORO_RESULTADOS_COMUNIDADES_ID" in bloque_publicacion
+
+
+def test_comunidades_actualizar_mantiene_reintento_con_foro_comunidades():
+    fuente = Path("LombardBot.py").read_text(encoding="utf-8")
+    inicio = fuente.index("@bot.command(name=\"comunidades_actualizar\")")
+    fin = fuente.index("\n\nLOGGER_COMUNIDADES", inicio)
+    cuerpo = fuente[inicio:fin]
+
+    assert "await _reintentar_publicaciones_ronda_comunidades(" in cuerpo
+    assert "id_foro=FORO_RESULTADOS_COMUNIDADES_ID" in cuerpo


### PR DESCRIPTION
### Motivation
- Cuando `!comunidades_actualizar` detecta un resultado nuevo desde la API debe publicarse inmediatamente en el foro de comunidades y generar la imagen en modo comunidades con los campos de comunidad, sin alterar la lógica transaccional de guardado y cierre.
- El modo de una pasada (`1`) debe comportarse igual: publicar el resultado detectado antes de cortar el bucle de procesamiento.

### Description
- Se añadió una llamada a `publicar_resultado_partido_comunidades(...)` justo después del `session.commit()` al procesar cada resultado en `comunidades_actualizar`, pasando el `match` de la API y `id_foro=FORO_RESULTADOS_COMUNIDADES_ID` para forzar publicación en el foro de comunidades.
- Los `avisos` devueltos por la publicación se acumulan en `detalles` para que el flujo de reintento idempotente posterior pueda manejarlos sin duplicar envíos.
- Se añadió la prueba `tests/test_comunidades_actualizar_publicacion.py` que verifica que la publicación se realiza después del `commit`, antes del corte por el modo `1`, y que el `match` y `id_foro` se incluyen en la llamada.
- No se cambió la lógica de `registrar_resultado_partido_comunidades`, el cierre de partido individual ni la resolución del enfrentamiento global; la funcionalidad de reintentos ya existente se mantiene.

### Testing
- Ejecutado `PYTHONPATH=. pytest -q tests/test_comunidades_actualizar_publicacion.py tests/test_imagenes_comunidades.py tests/test_comunidades_registro_resultados.py` y todos los tests automatizados finalizaron correctamente (`9 passed, 1 warning`).
- Se instalaron dependencias necesarias durante la ejecución de los tests para permitir la importación de los módulos de persistencia y generación de imágenes, y las pruebas de integración relacionadas con imágenes y registro de resultados pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c7c38558832a9e5eaf5e1c48eca5)