### PR TITLE
Asegura publicación administrativa de resultados de comunidades

### DIFF
--- a/tests/test_comunidades_actualizar_publicacion.py
+++ b/tests/test_comunidades_actualizar_publicacion.py
@@ -28,3 +28,26 @@ def test_comunidades_actualizar_mantiene_reintento_con_foro_comunidades():
 
     assert "await _reintentar_publicaciones_ronda_comunidades(" in cuerpo
     assert "id_foro=FORO_RESULTADOS_COMUNIDADES_ID" in cuerpo
+
+
+def test_comunidades_admin_partido_publica_en_foro_comunidades():
+    fuente = Path("LombardBot.py").read_text(encoding="utf-8")
+    inicio = fuente.index('@bot.command(name="comunidades_admin_partido")')
+    fin = fuente.index('\n\n@bot.command', inicio)
+    cuerpo = fuente[inicio:fin]
+
+    assert "await publicar_resultado_partido_comunidades" in cuerpo
+    assert "id_foro=FORO_RESULTADOS_COMUNIDADES_ID" in cuerpo
+    assert "FORO_RESULTADOS_GENERAL_ID" not in cuerpo
+
+
+def test_crear_imagen_resultado_comunidades_usa_plantilla_y_campos_extra():
+    fuente = Path("LombardBot.py").read_text(encoding="utf-8")
+    inicio = fuente.index("def _crear_imagen_resultado_comunidades")
+    fin = fuente.index("\n\ndef _estado_con_emojis_comunidades", inicio)
+    cuerpo = fuente[inicio:fin]
+
+    assert 'Imagenes.crear_imagen(\n        "resultadoComunidades"' in cuerpo
+    assert "comunidad1={\"0\": comunidad_local}" in cuerpo
+    assert "comunidad2={\"0\": comunidad_visitante}" in cuerpo
+    assert "comunidadVS={\"0\": comunidad_vs}" in cuerpo


### PR DESCRIPTION
### Motivation

- Evitar regresiones y asegurar que la administración manual de partidos de comunidades publica resultados en el foro específico de comunidades y que la imagen usa la plantilla y campos esperados.

### Description

- Añade dos pruebas en `tests/test_comunidades_actualizar_publicacion.py` que verifican que `!comunidades_admin_partido` invoca `publicar_resultado_partido_comunidades` con `id_foro=FORO_RESULTADOS_COMUNIDADES_ID` y no con el foro general.
- Añade una prueba que valida que `_crear_imagen_resultado_comunidades` usa la plantilla `resultadoComunidades` e incluye `comunidad1`, `comunidad2` y `comunidadVS` en los datos pasados a `Imagenes.crear_imagen`.
- No se modificó código de producción; solo se añadió cobertura de tests para bloquear la conducta esperada.

### Testing

- Ejecutado `PYTHONPATH=. pytest -q tests/test_comunidades_actualizar_publicacion.py tests/test_imagenes_comunidades.py` y las pruebas pasaron: `5 passed, 1 warning`.
- Las nuevas pruebas validan estáticamente fragmentos de `LombardBot.py` y confirmaron las llamadas y campos esperados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36ca6bbe20832aac37be1433164ad7)