### PR TITLE
Retry only failed match publications in comunidades_actualizar and add targeted retry helper

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -5002,13 +5002,7 @@ async def comunidades_actualizar(ctx, torneo_id: int, todos: Optional[str] = Non
             return
         ronda = rondas_abiertas[0]
 
-        avisos_previos = await _reintentar_publicaciones_ronda_comunidades(
-            ctx, session, ronda.id, id_foro=FORO_RESULTADOS_COMUNIDADES_ID
-        )
-        detalles.extend(
-            f"publicación pendiente para reintento: {aviso}"
-            for aviso in avisos_previos
-        )
+        partidos_publicacion_fallida = set()
 
         partidos_pendientes = (
             session.query(GestorSQL.ComunidadesPartido)
@@ -5039,10 +5033,10 @@ async def comunidades_actualizar(ctx, torneo_id: int, todos: Optional[str] = Non
             mensaje = f"ℹ️ No hay partidos individuales pendientes en la ronda {ronda.numero}."
             if cierre.get("cerrada"):
                 mensaje += " La ronda quedó consolidada."
-            if avisos_previos or avisos_cierre:
-                mensaje += "\n⚠️ " + "; ".join(avisos_previos + avisos_cierre) + "."
+            if avisos_cierre:
+                mensaje += "\n⚠️ " + "; ".join(avisos_cierre) + "."
             else:
-                mensaje += " Se comprobaron también las publicaciones consolidadas."
+                mensaje += " No se reintentaron publicaciones de partidos ya cerrados."
             await ctx.send(mensaje)
             return
 
@@ -5141,6 +5135,7 @@ async def comunidades_actualizar(ctx, torneo_id: int, todos: Optional[str] = Non
                     id_foro=FORO_RESULTADOS_COMUNIDADES_ID,
                 )
                 if avisos_resultado:
+                    partidos_publicacion_fallida.add(int(resultado.partido.id))
                     detalles.extend(
                         f"publicación pendiente para reintento: {aviso}"
                         for aviso in avisos_resultado
@@ -5172,14 +5167,19 @@ async def comunidades_actualizar(ctx, torneo_id: int, todos: Optional[str] = Non
                     f"{partido_bloodbowl_id}: error interno; administración avisada."
                 )
 
-        avisos_publicacion = await _reintentar_publicaciones_ronda_comunidades(
-            ctx, session, ronda.id, matches, id_foro=FORO_RESULTADOS_COMUNIDADES_ID
-        )
-        if avisos_publicacion:
-            detalles.extend(
-                f"publicación pendiente para reintento: {aviso}"
-                for aviso in avisos_publicacion
+        if partidos_publicacion_fallida:
+            avisos_publicacion = await _reintentar_publicaciones_partidos_comunidades(
+                ctx,
+                session,
+                partidos_publicacion_fallida,
+                matches,
+                id_foro=FORO_RESULTADOS_COMUNIDADES_ID,
             )
+            if avisos_publicacion:
+                detalles.extend(
+                    f"publicación pendiente para reintento: {aviso}"
+                    for aviso in avisos_publicacion
+                )
 
         cierre = _consolidar_cierre_ronda_comunidades(
             session, torneo_id, int(ronda.numero)
@@ -6019,6 +6019,47 @@ async def publicar_resultado_partido_comunidades(
         )
     except Exception as exc:
         avisos.append(f"hub del enfrentamiento {enfrentamiento.id}: {exc}")
+    return avisos
+
+
+async def _reintentar_publicaciones_partidos_comunidades(
+    ctx,
+    session,
+    partido_ids,
+    matches=(),
+    *,
+    id_foro=FORO_RESULTADOS_COMUNIDADES_ID,
+):
+    por_uuid = {
+        str(match.get("uuid")): match
+        for match in matches
+        if isinstance(match, dict) and match.get("uuid")
+    }
+    ids = sorted({int(partido_id) for partido_id in partido_ids})
+    if not ids:
+        return []
+    avisos = []
+    partidos = (
+        session.query(GestorSQL.ComunidadesPartido)
+        .filter(
+            GestorSQL.ComunidadesPartido.id.in_(ids),
+            GestorSQL.ComunidadesPartido.estado.in_(
+                (PARTIDO_FINALIZADO, PARTIDO_ADMINISTRADO)
+            ),
+        )
+        .order_by(GestorSQL.ComunidadesPartido.id)
+        .all()
+    )
+    for partido in partidos:
+        avisos.extend(
+            await publicar_resultado_partido_comunidades(
+                ctx,
+                session,
+                partido.id,
+                match=por_uuid.get(str(partido.partido_bloodbowl_id)),
+                id_foro=id_foro,
+            )
+        )
     return avisos
 
 

--- a/tests/test_comunidades_actualizar_publicacion.py
+++ b/tests/test_comunidades_actualizar_publicacion.py
@@ -27,13 +27,16 @@ def test_comunidades_actualizar_publica_cada_resultado_api_antes_del_corte_una_p
     assert "id_foro=FORO_RESULTADOS_COMUNIDADES_ID" in bloque_publicacion
 
 
-def test_comunidades_actualizar_mantiene_reintento_con_foro_comunidades():
+def test_comunidades_actualizar_reintenta_solo_partidos_fallidos_con_foro_comunidades():
     fuente = Path("LombardBot.py").read_text(encoding="utf-8")
     inicio = fuente.index("@bot.command(name=\"comunidades_actualizar\")")
     fin = fuente.index("\n\nLOGGER_COMUNIDADES", inicio)
     cuerpo = fuente[inicio:fin]
 
-    assert "await _reintentar_publicaciones_ronda_comunidades(" in cuerpo
+    assert "partidos_publicacion_fallida = set()" in cuerpo
+    assert "partidos_publicacion_fallida.add(int(resultado.partido.id))" in cuerpo
+    assert "await _reintentar_publicaciones_partidos_comunidades(" in cuerpo
+    assert "await _reintentar_publicaciones_ronda_comunidades(" not in cuerpo
     assert "id_foro=FORO_RESULTADOS_COMUNIDADES_ID" in cuerpo
 
 


### PR DESCRIPTION
### Motivation
- Reduce unnecessary retries by only reattempting publication for matches whose publication actually failed. 
- Improve clarity of status messages when there are no pending individual matches. 
- Make retry logic more targeted and maintainable by separating per-match retries from the round-level retry function.

### Description
- Track failed publication match ids with a `partidos_publicacion_fallida = set()` and add failed ids via `partidos_publicacion_fallida.add(int(resultado.partido.id))` after `publicar_resultado_partido_comunidades` returns avisos. 
- Add a new helper `async def _reintentar_publicaciones_partidos_comunidades(...)` that retries publication only for the provided match ids and uses `partido.partido_bloodbowl_id` to find the original API `match`. 
- Replace the blanket call to `_reintentar_publicaciones_ronda_comunidades` after processing with a conditional call to `_reintentar_publicaciones_partidos_comunidades` when there are failed match publications. 
- Adjust messaging when there are no pending individual matches to avoid implying round-level retries when only per-match retries are relevant.

### Testing
- Ran the updated unit tests in `tests/test_comunidades_actualizar_publicacion.py` with `pytest` and they passed. 
- Verified the test that ensures publication happens before the cut (`test_comunidades_actualizar_publica_cada_resultado_api_antes_del_corte_una_pasada`) still passes. 
- Verified the new test expectations about the new retry flow (`test_comunidades_actualizar_reintenta_solo_partidos_fallidos_con_foro_comunidades`) pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d97a0548832aace68cd33f50341b)