### PR TITLE
Fix comunidades forum result publication retries

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -5322,6 +5322,58 @@ def _finalizar_publicacion_comunidades(
         session.close()
 
 
+def _estado_publicacion_comunidades(clave: str):
+    """Devuelve el estado persistido de una publicación idempotente."""
+    Session = sessionmaker(bind=GestorSQL.conexionEngine())
+    session = Session()
+    try:
+        operacion = (
+            session.query(GestorSQL.ComunidadesOperacionIdempotente)
+            .filter(GestorSQL.ComunidadesOperacionIdempotente.clave == str(clave))
+            .one_or_none()
+        )
+        if operacion is None:
+            return None, None
+        return operacion.estado, operacion.recurso_externo_id
+    finally:
+        session.close()
+
+
+async def _resolver_hilo_resultados_publicacion_comunidades(
+    ctx, canal_foro, titulo: str, clave_hilo: str, reserva_hilo: bool
+):
+    """Localiza o crea el hilo de resultados sin bloquear reintentos válidos."""
+    hilo = await _buscar_hilo_resultados_comunidades(canal_foro, titulo)
+    if hilo is not None:
+        if reserva_hilo:
+            _finalizar_publicacion_comunidades(
+                clave_hilo, mensaje_id=getattr(hilo, "id", None)
+            )
+        return hilo
+
+    if reserva_hilo:
+        try:
+            creado = await canal_foro.create_thread(
+                name=titulo, content=f"Resultados de {titulo}"
+            )
+            hilo = creado.thread
+            _finalizar_publicacion_comunidades(
+                clave_hilo, mensaje_id=getattr(hilo, "id", None)
+            )
+            return hilo
+        except Exception:
+            _finalizar_publicacion_comunidades(clave_hilo, liberar=True)
+            raise
+
+    estado_hilo, hilo_id = _estado_publicacion_comunidades(clave_hilo)
+    if estado_hilo == "COMPLETADA" and hilo_id:
+        hilo = await _resolver_canal_notificacion_comunidades(ctx, int(hilo_id))
+        if hilo is not None:
+            return hilo
+        raise RuntimeError("hilo de resultados ya registrado, pero Discord no lo devuelve")
+    raise RuntimeError("otro proceso está creando el hilo de resultados")
+
+
 async def _enviar_unico_comunidades(
     canal, tipo: str, registro_id: int, contenido: str, **kwargs
 ) -> bool:
@@ -5929,7 +5981,7 @@ async def publicar_resultado_partido_comunidades(
     reserva idempotente persistida, de modo que los reintentos no repiten las
     publicaciones que ya llegaron a enviarse.
     """
-    partido = session.query(GestorSQL.ComunidadesPartido).get(int(partido_id))
+    partido = session.get(GestorSQL.ComunidadesPartido, int(partido_id))
     if partido is None or partido.estado not in {PARTIDO_FINALIZADO, PARTIDO_ADMINISTRADO}:
         return []
     avisos = []
@@ -5958,25 +6010,9 @@ async def publicar_resultado_partido_comunidades(
         clave_hilo, reserva_hilo, _ = _reservar_publicacion_comunidades(
             "hilo-foro", ronda_id
         )
-        hilo = await _buscar_hilo_resultados_comunidades(foro, titulo)
-        if hilo is None and reserva_hilo:
-            try:
-                creado = await foro.create_thread(
-                    name=titulo, content=f"Resultados de {titulo}"
-                )
-                hilo = creado.thread
-                _finalizar_publicacion_comunidades(
-                    clave_hilo, mensaje_id=getattr(hilo, "id", None)
-                )
-            except Exception:
-                _finalizar_publicacion_comunidades(clave_hilo, liberar=True)
-                raise
-        elif hilo is None:
-            raise RuntimeError("otro proceso está creando el hilo de resultados")
-        elif reserva_hilo:
-            _finalizar_publicacion_comunidades(
-                clave_hilo, mensaje_id=getattr(hilo, "id", None)
-            )
+        hilo = await _resolver_hilo_resultados_publicacion_comunidades(
+            ctx, foro, titulo, clave_hilo, reserva_hilo
+        )
         if getattr(hilo, "archived", False):
             await hilo.edit(archived=False)
         ruta = _crear_imagen_resultado_comunidades(session, partido, match)

--- a/tests/test_comunidades_actualizar_publicacion.py
+++ b/tests/test_comunidades_actualizar_publicacion.py
@@ -105,6 +105,29 @@ def test_publicacion_comunidades_genera_resultado_con_plantilla_comunidades():
     assert "es_comunidades" in cuerpo_imagen
 
 
+def test_publicacion_comunidades_usa_session_get_y_reutiliza_hilo_completado():
+    fuente = Path("LombardBot.py").read_text(encoding="utf-8")
+    inicio = fuente.index("async def publicar_resultado_partido_comunidades")
+    fin = fuente.index(
+        "\n\nasync def _reintentar_publicaciones_ronda_comunidades", inicio
+    )
+    cuerpo = fuente[inicio:fin]
+
+    assert "session.get(GestorSQL.ComunidadesPartido, int(partido_id))" in cuerpo
+    assert ".query(GestorSQL.ComunidadesPartido).get" not in cuerpo
+    assert "await _resolver_hilo_resultados_publicacion_comunidades(" in cuerpo
+
+    inicio_helper = fuente.index(
+        "async def _resolver_hilo_resultados_publicacion_comunidades"
+    )
+    fin_helper = fuente.index("\n\nasync def _enviar_unico_comunidades", inicio_helper)
+    helper = fuente[inicio_helper:fin_helper]
+
+    assert 'estado_hilo == "COMPLETADA" and hilo_id' in helper
+    assert "await _resolver_canal_notificacion_comunidades(ctx, int(hilo_id))" in helper
+    assert "otro proceso está creando el hilo de resultados" in helper
+
+
 def test_datos_plantilla_comunidades_incluyen_comunidades_y_vs_exacto(
     comunidades_session,
     escenario_comunidades_factory,


### PR DESCRIPTION
### Motivation
- Evitar el `LegacyAPIWarning` de SQLAlchemy al cargar partidos y reducir errores en la publicación de imágenes en el foro al resolver correctamente hilos ya creados o registrados por operaciones idempotentes.
- Prevenir bloqueos falsos con el mensaje "otro proceso está creando el hilo de resultados" cuando la reserva idempotente ya está completada pero el hilo no aparece en la caché de Discord.

### Description
- Reemplazada la llamada obsoleta `session.query(...).get(...)` por `session.get(...)` en la publicación de resultados de comunidades para usar la API recomendada de SQLAlchemy 2.x (archivo `LombardBot.py`).
- Añadida la función `_estado_publicacion_comunidades` que consulta el estado persistido de una publicación idempotente (archivo `LombardBot.py`).
- Añadida la función `_resolver_hilo_resultados_publicacion_comunidades` que localiza o crea el hilo de resultados y reutiliza el `recurso_externo_id` de una operación ya `COMPLETADA` cuando corresponde (archivo `LombardBot.py`).
- Sustituido el bloque inline de resolución/creación de hilo en `publicar_resultado_partido_comunidades` por una llamada al nuevo resolvedor, y conservada la eliminación segura de la imagen tras el envío (archivo `LombardBot.py`).
- Añadida una prueba de regresión que verifica el uso de `session.get` y la presencia del helper de reutilización de hilos (`tests/test_comunidades_actualizar_publicacion.py`).

### Testing
- Ejecutado `PYTHONPATH=. pytest -q tests/test_comunidades_actualizar_publicacion.py` y todos los tests relevantes pasaron (10 passed, 1 warning sobre `declarative_base()` existente). 
- Ejecutado `python -m py_compile LombardBot.py tests/test_comunidades_actualizar_publicacion.py` sin errores de compilación. 
- Ejecutado `git diff --check` para comprobar problemas en el diff y no se detectaron errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37114276b8832ab632634f21823b73)