### PR TITLE
Publish archived community results without DB changes and improve idempotent thread resolution

### DIFF
--- a/LombardBot.py
+++ b/LombardBot.py
@@ -5231,6 +5231,172 @@ async def comunidades_actualizar(ctx, torneo_id: int, todos: Optional[str] = Non
         session.close()
 
 
+async def _resolver_hilo_resultados_comunidades_sin_bd(ctx, canal_foro, titulo: str):
+    """Localiza o crea el hilo de resultados sin tocar la BD."""
+    hilo = await _buscar_hilo_resultados_comunidades(canal_foro, titulo)
+    if hilo is None:
+        creado = await canal_foro.create_thread(
+            name=titulo, content=f"Resultados de {titulo}"
+        )
+        hilo = creado.thread
+    if getattr(hilo, "archived", False):
+        await hilo.edit(archived=False)
+    return hilo
+
+
+async def publicar_imagen_resultado_partido_comunidades_sin_bd(
+    ctx,
+    session,
+    partido,
+    *,
+    match=None,
+    id_foro=FORO_RESULTADOS_COMUNIDADES_ID,
+):
+    """Publica solo la imagen de un partido existente sin registrar idempotencia."""
+    guild = getattr(ctx, "guild", None)
+    foro = discord.utils.get(getattr(guild, "channels", []), id=id_foro)
+    if foro is None and guild is not None:
+        foro = await _resolver_canal_notificacion_comunidades(ctx, id_foro)
+    if foro is None or not isinstance(foro, discord.ForumChannel):
+        raise RuntimeError("foro de resultados no disponible")
+    titulo = f"{partido.enfrentamiento.torneo.nombre} J{partido.enfrentamiento.ronda.numero}"
+    hilo = await _resolver_hilo_resultados_comunidades_sin_bd(ctx, foro, titulo)
+    ruta = _crear_imagen_resultado_comunidades(session, partido, match)
+    if not ruta:
+        raise RuntimeError("no se pudo generar la imagen")
+    try:
+        with open(ruta, "rb") as imagen:
+            await hilo.send("", file=File(imagen))
+    finally:
+        Imagenes.eliminar_imagen(ruta)
+
+
+@bot.command(name="comunidades_publica_antiguos")
+async def comunidades_publica_antiguos(ctx, torneo_id: int):
+    """Publica imágenes de resultados ya guardados sin actualizar la BD."""
+    if not es_comisario(ctx):
+        await ctx.send("No tienes permiso. Este comando es exclusivo para Comisario.")
+        return
+
+    SessionComunidades = sessionmaker(bind=GestorSQL.conexionEngine())
+    session = SessionComunidades()
+    encontrados_api = 0
+    publicados = 0
+    ignorados_sin_bd = 0
+    no_publicables = 0
+    errores = 0
+    detalles = []
+    try:
+        torneo = session.get(GestorSQL.ComunidadesTorneo, int(torneo_id))
+        if torneo is None:
+            await ctx.send(f"❌ No existe un torneo de comunidades con ID `{torneo_id}`.")
+            return
+        if not torneo.id_competicion_bbowl:
+            await ctx.send(
+                f"❌ El torneo `{torneo_id}` no tiene configurado `idCompBbowl`."
+            )
+            return
+
+        matches = APIBbowl.obtener_partidos(
+            bbowl_API_token, torneo.id_competicion_bbowl
+        )
+        if matches is None:
+            await ctx.send("❌ La API de Blood Bowl no devolvió una respuesta válida.")
+            return
+        if not matches:
+            await ctx.send("ℹ️ La API no devolvió partidos para la competición configurada.")
+            return
+
+        for match in matches:
+            try:
+                partido_bloodbowl_id, _, _ = _extraer_resultado_api_comunidades(match)
+                encontrados_api += 1
+            except ValueError as exc:
+                errores += 1
+                detalles.append(f"API: {exc}")
+                continue
+
+            partido = (
+                session.query(GestorSQL.ComunidadesPartido)
+                .filter(
+                    GestorSQL.ComunidadesPartido.torneo_id == int(torneo_id),
+                    GestorSQL.ComunidadesPartido.partido_bloodbowl_id
+                    == partido_bloodbowl_id,
+                )
+                .one_or_none()
+            )
+            if partido is None:
+                ignorados_sin_bd += 1
+                continue
+            if partido.estado not in {PARTIDO_FINALIZADO, PARTIDO_ADMINISTRADO}:
+                no_publicables += 1
+                detalles.append(
+                    f"{partido_bloodbowl_id}: partido {partido.id} existe pero está `{partido.estado}`."
+                )
+                continue
+
+            try:
+                await publicar_imagen_resultado_partido_comunidades_sin_bd(
+                    ctx,
+                    session,
+                    partido,
+                    match=match,
+                    id_foro=FORO_RESULTADOS_COMUNIDADES_ID,
+                )
+                publicados += 1
+            except Exception as exc:
+                errores += 1
+                LOGGER_COMUNIDADES.exception(
+                    "Fallo al publicar resultado antiguo de comunidades",
+                    extra={
+                        "torneo_id": torneo_id,
+                        "ronda_numero": getattr(
+                            getattr(partido.enfrentamiento, "ronda", None),
+                            "numero",
+                            None,
+                        ),
+                        "enfrentamiento_id": int(partido.enfrentamiento_id),
+                        "partido_id": int(partido.id),
+                    },
+                )
+                detalles.append(f"{partido_bloodbowl_id}: partido {partido.id}: {exc}")
+
+        session.rollback()
+        resumen = (
+            f"🖼️ **Publicación de resultados antiguos — torneo {torneo_id}**\n"
+            f"- Partidos leídos de API: **{encontrados_api}**\n"
+            f"- Imágenes publicadas: **{publicados}**\n"
+            f"- Ignorados sin partido en BD: **{ignorados_sin_bd}**\n"
+            f"- Existentes no publicables: **{no_publicables}**\n"
+            f"- Errores: **{errores}**\n"
+            "- BD: **sin cambios intencionados**"
+        )
+        if detalles:
+            resumen += "\n\n**Detalle:**\n" + "\n".join(
+                f"- {_texto_discord_seguro(detalle)}" for detalle in detalles[:15]
+            )
+            if len(detalles) > 15:
+                resumen += f"\n- … y {len(detalles) - 15} incidencias más."
+        await UtilesDiscord.enviar_mensaje_largo(ctx, resumen)
+    except Exception:
+        session.rollback()
+        LOGGER_COMUNIDADES.exception(
+            "Fallo en publicación de resultados antiguos de comunidades",
+            extra={
+                "torneo_id": torneo_id,
+                "ronda_numero": None,
+                "enfrentamiento_id": None,
+                "partido_id": None,
+            },
+        )
+        await ctx.send(
+            "❌ No se pudo completar la publicación de resultados antiguos. "
+            "No se han guardado cambios en la BD desde este comando."
+        )
+    finally:
+        session.close()
+
+
 LOGGER_COMUNIDADES = logging.getLogger("lombardbot.comunidades")
 
 
@@ -5320,6 +5486,58 @@ def _finalizar_publicacion_comunidades(
         raise
     finally:
         session.close()
+
+
+def _estado_publicacion_comunidades(clave: str):
+    """Devuelve el estado persistido de una publicación idempotente."""
+    Session = sessionmaker(bind=GestorSQL.conexionEngine())
+    session = Session()
+    try:
+        operacion = (
+            session.query(GestorSQL.ComunidadesOperacionIdempotente)
+            .filter(GestorSQL.ComunidadesOperacionIdempotente.clave == str(clave))
+            .one_or_none()
+        )
+        if operacion is None:
+            return None, None
+        return operacion.estado, operacion.recurso_externo_id
+    finally:
+        session.close()
+
+
+async def _resolver_hilo_resultados_publicacion_comunidades(
+    ctx, canal_foro, titulo: str, clave_hilo: str, reserva_hilo: bool
+):
+    """Localiza o crea el hilo de resultados sin bloquear reintentos válidos."""
+    hilo = await _buscar_hilo_resultados_comunidades(canal_foro, titulo)
+    if hilo is not None:
+        if reserva_hilo:
+            _finalizar_publicacion_comunidades(
+                clave_hilo, mensaje_id=getattr(hilo, "id", None)
+            )
+        return hilo
+
+    if reserva_hilo:
+        try:
+            creado = await canal_foro.create_thread(
+                name=titulo, content=f"Resultados de {titulo}"
+            )
+            hilo = creado.thread
+            _finalizar_publicacion_comunidades(
+                clave_hilo, mensaje_id=getattr(hilo, "id", None)
+            )
+            return hilo
+        except Exception:
+            _finalizar_publicacion_comunidades(clave_hilo, liberar=True)
+            raise
+
+    estado_hilo, hilo_id = _estado_publicacion_comunidades(clave_hilo)
+    if estado_hilo == "COMPLETADA" and hilo_id:
+        hilo = await _resolver_canal_notificacion_comunidades(ctx, int(hilo_id))
+        if hilo is not None:
+            return hilo
+        raise RuntimeError("hilo de resultados ya registrado, pero Discord no lo devuelve")
+    raise RuntimeError("otro proceso está creando el hilo de resultados")
 
 
 async def _enviar_unico_comunidades(
@@ -5929,7 +6147,7 @@ async def publicar_resultado_partido_comunidades(
     reserva idempotente persistida, de modo que los reintentos no repiten las
     publicaciones que ya llegaron a enviarse.
     """
-    partido = session.query(GestorSQL.ComunidadesPartido).get(int(partido_id))
+    partido = session.get(GestorSQL.ComunidadesPartido, int(partido_id))
     if partido is None or partido.estado not in {PARTIDO_FINALIZADO, PARTIDO_ADMINISTRADO}:
         return []
     avisos = []
@@ -5958,25 +6176,9 @@ async def publicar_resultado_partido_comunidades(
         clave_hilo, reserva_hilo, _ = _reservar_publicacion_comunidades(
             "hilo-foro", ronda_id
         )
-        hilo = await _buscar_hilo_resultados_comunidades(foro, titulo)
-        if hilo is None and reserva_hilo:
-            try:
-                creado = await foro.create_thread(
-                    name=titulo, content=f"Resultados de {titulo}"
-                )
-                hilo = creado.thread
-                _finalizar_publicacion_comunidades(
-                    clave_hilo, mensaje_id=getattr(hilo, "id", None)
-                )
-            except Exception:
-                _finalizar_publicacion_comunidades(clave_hilo, liberar=True)
-                raise
-        elif hilo is None:
-            raise RuntimeError("otro proceso está creando el hilo de resultados")
-        elif reserva_hilo:
-            _finalizar_publicacion_comunidades(
-                clave_hilo, mensaje_id=getattr(hilo, "id", None)
-            )
+        hilo = await _resolver_hilo_resultados_publicacion_comunidades(
+            ctx, foro, titulo, clave_hilo, reserva_hilo
+        )
         if getattr(hilo, "archived", False):
             await hilo.edit(archived=False)
         ruta = _crear_imagen_resultado_comunidades(session, partido, match)

--- a/tests/test_comunidades_actualizar_publicacion.py
+++ b/tests/test_comunidades_actualizar_publicacion.py
@@ -105,6 +105,29 @@ def test_publicacion_comunidades_genera_resultado_con_plantilla_comunidades():
     assert "es_comunidades" in cuerpo_imagen
 
 
+def test_publicacion_comunidades_usa_session_get_y_reutiliza_hilo_completado():
+    fuente = Path("LombardBot.py").read_text(encoding="utf-8")
+    inicio = fuente.index("async def publicar_resultado_partido_comunidades")
+    fin = fuente.index(
+        "\n\nasync def _reintentar_publicaciones_ronda_comunidades", inicio
+    )
+    cuerpo = fuente[inicio:fin]
+
+    assert "session.get(GestorSQL.ComunidadesPartido, int(partido_id))" in cuerpo
+    assert ".query(GestorSQL.ComunidadesPartido).get" not in cuerpo
+    assert "await _resolver_hilo_resultados_publicacion_comunidades(" in cuerpo
+
+    inicio_helper = fuente.index(
+        "async def _resolver_hilo_resultados_publicacion_comunidades"
+    )
+    fin_helper = fuente.index("\n\nasync def _enviar_unico_comunidades", inicio_helper)
+    helper = fuente[inicio_helper:fin_helper]
+
+    assert 'estado_hilo == "COMPLETADA" and hilo_id' in helper
+    assert "await _resolver_canal_notificacion_comunidades(ctx, int(hilo_id))" in helper
+    assert "otro proceso está creando el hilo de resultados" in helper
+
+
 def test_datos_plantilla_comunidades_incluyen_comunidades_y_vs_exacto(
     comunidades_session,
     escenario_comunidades_factory,
@@ -135,6 +158,38 @@ def test_datos_plantilla_comunidades_incluyen_comunidades_y_vs_exacto(
     }
     assert " Vs " in datos["comunidadVS"]["0"]
     assert " vs " not in datos["comunidadVS"]["0"]
+
+
+def test_comunidades_publica_antiguos_lee_api_y_publica_sin_actualizar_bd():
+    fuente = Path("LombardBot.py").read_text(encoding="utf-8")
+    inicio = fuente.index('@bot.command(name="comunidades_publica_antiguos")')
+    fin = fuente.index("\n\nLOGGER_COMUNIDADES", inicio)
+    cuerpo = fuente[inicio:fin]
+
+    assert "APIBbowl.obtener_partidos" in cuerpo
+    assert "_extraer_resultado_api_comunidades(match)" in cuerpo
+    assert "ComunidadesPartido.partido_bloodbowl_id" in cuerpo
+    assert "registrar_resultado_partido_comunidades" not in cuerpo
+    assert "session.commit()" not in cuerpo
+    assert "session.rollback()" in cuerpo
+    assert "await publicar_imagen_resultado_partido_comunidades_sin_bd(" in cuerpo
+    assert "id_foro=FORO_RESULTADOS_COMUNIDADES_ID" in cuerpo
+
+
+def test_publicar_antiguos_helper_no_usa_idempotencia_persistida():
+    fuente = Path("LombardBot.py").read_text(encoding="utf-8")
+    inicio = fuente.index(
+        "async def publicar_imagen_resultado_partido_comunidades_sin_bd"
+    )
+    fin = fuente.index('@bot.command(name="comunidades_publica_antiguos")', inicio)
+    cuerpo = fuente[inicio:fin]
+
+    assert "_crear_imagen_resultado_comunidades(session, partido, match)" in cuerpo
+    assert "hilo.send" in cuerpo
+    assert "_enviar_unico_comunidades" not in cuerpo
+    assert "_reservar_publicacion_comunidades" not in cuerpo
+    assert "_finalizar_publicacion_comunidades" not in cuerpo
+    assert "session.commit()" not in cuerpo
 
 
 def test_suizo_normal_sigue_usando_foro_general_y_plantilla_resultado_actual():


### PR DESCRIPTION
### Motivation
- Allow publishing previously recorded community match images read from the external API without mutating the local database or reusing idempotent publish reservations.
- Fix a deprecated pattern and use `session.get(...)` when loading a partido to be compatible with modern SQLAlchemy usage.
- Make thread creation/resolution for forum publications robust to concurrent publishers by persisting and checking publication state.

### Description
- Added `publicar_imagen_resultado_partido_comunidades_sin_bd` and helper `_resolver_hilo_resultados_comunidades_sin_bd` to publish only the image for an existing `ComunidadesPartido` without touching idempotency records or committing the session.
- Added a bot command `comunidades_publica_antiguos` that reads matches from `APIBbowl.obtener_partidos`, matches them to existing DB partidos, and publishes images for eligible finished matches while explicitly avoiding any `session.commit()` calls.
- Implemented `_estado_publicacion_comunidades` and `_resolver_hilo_resultados_publicacion_comunidades` to read persisted idempotent operation state and safely resolve or create forum threads while handling concurrent creators and completed thread reuse.
- Replaced deprecated `.query(...).get(...)` with `session.get(...)` in `publicar_resultado_partido_comunidades` and routed thread creation through the new resolver helper to finalize idempotent reservations correctly.

### Testing
- Ran the test module `tests/test_comunidades_actualizar_publicacion.py` which includes newly added tests `test_publicacion_comunidades_usa_session_get_y_reutiliza_hilo_completado`, `test_comunidades_publica_antiguos_lee_api_y_publica_sin_actualizar_bd`, and `test_publicar_antiguos_helper_no_usa_idempotencia_persistida` and they passed under `pytest`.
- Existing assertions in the same test file that validate the image template and forum IDs were also executed and passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37114276b8832ab632634f21823b73)