### PR TITLE
Add `resultadoComunidades` layout to configuracion.json and test validation

### DIFF
--- a/configuracion.json
+++ b/configuracion.json
@@ -978,7 +978,238 @@
       "fuente": "Poppins-Bold.ttf",
       "size": 25
     }
+],
+  "resultadoComunidades": [
+    {
+    "posicion_x": 50,
+    "posicion_y": 275,
+    "color": "#1d4ccc",
+    "ancho": 800,
+    "alto": 150,
+    "banner": true,
+	"alineacion" : "centrado",
+	"transparencia" : 20,
+	"lado" : "izquierdo"
+	},
+	{
+    "posicion_x": 1100,
+    "posicion_y": 275,
+    "color": "#1dcc4b",
+    "ancho": 800,
+    "alto": 150,
+    "banner": true,
+	"alineacion" : "centrado",
+	"transparencia" : 20,
+	"lado" : "derecho"
+	},
+	{
+      "nombre_diccionario": "comunidadVS",
+      "clave": "0",
+      "posicion_x": 745,
+      "posicion_y": 69,
+      "efecto": "contorno",
+	  "outlineColor": "#FEFEFF",
+      "alineacion": "centrado",
+      "fuente": "zuumerough-bold.ttf",
+	  "color": "#FFFFFF",
+	  "ancho_contorno":3,
+      "size": 100
+	},
+	{
+      "posicion_x": 1200,
+      "posicion_y": 690,
+      "alineacion": "centrado",
+      "fuente": "zuumerough-bold.ttf",
+	  "funcionColor":"si",
+	  "color": "#FFFFFF",
+	  "ancho_contorno":3,
+      "size": 100,
+	  "mitexto": true,
+	  "texto":"patata voladora"
+	},
+	{
+    "posicion_x": 800,
+    "posicion_y": 275,
+    "color": "#000000",
+    "ancho": 200,
+    "alto": 150,
+    "piramide": true,
+	"alineacion" : "centrado",
+	"inclinacion" : "60"
+	},
+	{
+	"ganador":true,
+	"posicion_x": 0,
+    "posicion_y": 0,
+	"alineacion" : "centrado"
+	},
+    {
+      "nombre_diccionario": "entrenadores",
+      "clave": "0",
+      "posicion_x": 340,
+      "posicion_y": 370,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+      "fuente": "Poppins-Bold.ttf",
+      "size": 35
+    },
+	{
+      "nombre_diccionario": "nombre_equipos",
+      "clave": "0",
+      "posicion_x": 340,
+      "posicion_y": 295,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+      "fuente": "Poppins-Bold.ttf",
+      "size": 45
+    },
+	{
+	  "icono": "si",
+      "nombre_diccionario": "escudos",
+      "clave": "0",
+      "posicion_x": 700,
+      "posicion_y": 290,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+	  "ancho_icono": 160,
+	  "alto_icono": 200
+    },
+	{
+      "nombre_diccionario": "resultados",
+      "clave": "0",
+      "posicion_x": 880,
+      "posicion_y": 290,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+      "fuente": "Poppins-Bold.ttf",
+	  "color": "#FFF7FA",
+      "size": 110
+    },
+	{
+	  "icono": "si",
+      "nombre_diccionario": "razas",
+      "clave": "0",
+      "posicion_x": 270,
+      "posicion_y": 605,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+	  "ancho_icono": 520,
+	  "alto_icono": 385
+    },
+	{
+      "nombre_diccionario": "kos",
+      "clave": "0",
+      "posicion_x": 910,
+      "posicion_y": 565,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+      "fuente": "Poppins-Bold.ttf",
+      "size": 25
+    },
+	{
+      "nombre_diccionario": "heridos",
+      "clave": "0",
+      "posicion_x": 910,
+      "posicion_y": 710,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+      "fuente": "Poppins-Bold.ttf",
+      "size": 25
+    },
+	{
+      "nombre_diccionario": "muertos",
+      "clave": "0",
+      "posicion_x": 907,
+      "posicion_y": 850,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+      "fuente": "Poppins-Bold.ttf",
+      "size": 25
+    },
+	{
+      "nombre_diccionario": "entrenadores",
+      "clave": "1",
+      "posicion_x": 1580,
+      "posicion_y": 370,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+      "fuente": "Poppins-Bold.ttf",
+      "size": 35
+    },
+	{
+      "nombre_diccionario": "nombre_equipos",
+      "clave": "1",
+      "posicion_x": 1580,
+      "posicion_y": 295,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+      "fuente": "Poppins-Bold.ttf",
+      "size": 45
+    },
+	{
+	  "icono": "si",
+      "nombre_diccionario": "escudos",
+      "clave": "1",
+      "posicion_x": 1200,
+      "posicion_y": 290,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+	  "ancho_icono": 160,
+	  "alto_icono": 200
+    },
+	{
+      "nombre_diccionario": "resultados",
+      "clave": "1",
+      "posicion_x": 1050,
+      "posicion_y": 290,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+      "fuente": "Poppins-Bold.ttf",
+	  "color": "#FFF7FA",
+      "size": 110
+    },
+	{
+	  "icono": "si",
+      "nombre_diccionario": "razas",
+      "clave": "1",
+      "posicion_x": 1650,
+      "posicion_y": 605,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+	  "ancho_icono": 520,
+	  "alto_icono": 385
+    },
+	{
+      "nombre_diccionario": "kos",
+      "clave": "1",
+      "posicion_x": 1335,
+      "posicion_y": 560,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+      "fuente": "Poppins-Bold.ttf",
+      "size": 25
+    },
+	{
+      "nombre_diccionario": "heridos",
+      "clave": "1",
+      "posicion_x": 1335,
+      "posicion_y": 710,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+      "fuente": "Poppins-Bold.ttf",
+      "size": 25
+    },
+	{
+      "nombre_diccionario": "muertos",
+      "clave": "1",
+      "posicion_x": 1335,
+      "posicion_y": 850,
+      "efecto": "ninguno",
+      "alineacion": "centrado",
+      "fuente": "Poppins-Bold.ttf",
+      "size": 25
+    }
 ]
 }
 
-	
+

--- a/tests/test_configuracion_resultado_comunidades.py
+++ b/tests/test_configuracion_resultado_comunidades.py
@@ -1,0 +1,31 @@
+import json
+from copy import deepcopy
+from pathlib import Path
+
+
+def test_resultado_comunidades_es_resultado_con_titulo_de_comunidades_vs():
+    configuracion = json.loads(Path("configuracion.json").read_text(encoding="utf-8"))
+
+    resultado = deepcopy(configuracion["resultado"])
+    resultado_comunidades = deepcopy(configuracion["resultadoComunidades"])
+
+    titulo_resultado = next(elemento for elemento in resultado if elemento.get("titulo") is True)
+    titulo_comunidades = resultado_comunidades[resultado.index(titulo_resultado)]
+
+    esperado = deepcopy(titulo_resultado)
+    esperado.pop("titulo")
+    esperado.pop("funcionColor", None)
+    esperado["nombre_diccionario"] = "comunidadVS"
+    esperado["clave"] = "0"
+    esperado["color"] = "#FFFFFF"
+    esperado["outlineColor"] = "#FEFEFF"
+
+    resultado[resultado.index(titulo_resultado)] = esperado
+
+    assert resultado_comunidades == resultado
+    assert titulo_comunidades["posicion_x"] == titulo_resultado["posicion_x"]
+    assert titulo_comunidades["posicion_y"] == titulo_resultado["posicion_y"]
+    assert titulo_comunidades["fuente"] == titulo_resultado["fuente"]
+    assert titulo_comunidades["size"] == titulo_resultado["size"]
+    assert titulo_comunidades["efecto"] == titulo_resultado["efecto"]
+    assert titulo_comunidades["nombre_diccionario"] == "comunidadVS"


### PR DESCRIPTION
### Motivation
- Introduce a dedicated `resultadoComunidades` layout block to define per-comunidad result elements and banners alongside the existing `resultado` configuration.
- Ensure the new configuration mirrors the existing `resultado` semantics for the title element (`comunidadVS`) and is validated by an automated test.

### Description
- Added a new top-level `resultadoComunidades` array to `configuracion.json` that contains layout definitions for community results, banners, title, icons and text properties, and positional attributes. 
- Populated `resultadoComunidades` with entries corresponding to left/right banners, title (`comunidadVS`), pyramid/center elements, team info, shields, results, icons and numeric fields for both sides. 
- Added `tests/test_configuracion_resultado_comunidades.py` which loads `configuracion.json` and asserts that `resultadoComunidades` matches `resultado` after transforming the title element into the expected `comunidadVS` entry and verifying key positional and style fields.

### Testing
- Ran the new unit test with `pytest tests/test_configuracion_resultado_comunidades.py -q` and it completed successfully. 
- Ran the test suite with `pytest -q` and all tests passed including the added validation for `resultadoComunidades`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36bfa1eba8832aa7ff0eaa56c5bb5d)