### PR TITLE
Ajusta layout de plantillas de resultado

### DIFF
--- a/configuracion.json
+++ b/configuracion.json
@@ -772,8 +772,8 @@
       "lado": "derecho"
     },
     {
-      "posicion_x": 745,
-      "posicion_y": 69,
+      "posicion_x": 965,
+      "posicion_y": 180,
       "efecto": "contorno",
       "outlineColor": "#ffffff",
       "alineacion": "centrado",
@@ -781,7 +781,7 @@
       "funcionColor": "si",
       "color": "#b69200",
       "ancho_contorno": 3,
-      "size": 100,
+      "size": 70,
       "titulo": true
     },
     {
@@ -983,30 +983,6 @@
       "alineacion": "centrado",
       "fuente": "Poppins-Bold.ttf",
       "size": 25
-    },
-    {
-      "posicion_x": 100,
-      "posicion_y": 50,
-      "color": "#00FF00",
-      "ancho": 300,
-      "alto": 100,
-      "inclinacion": 20,
-      "banner": true,
-      "alineacion": "centrado",
-      "transparencia": 20,
-      "lado": "izquierdo"
-    },
-    {
-      "posicion_x": 600,
-      "posicion_y": 100,
-      "color": "#00FF33",
-      "ancho": 600,
-      "alto": 200,
-      "inclinacion": 80,
-      "banner": true,
-      "alineacion": "centrado",
-      "transparencia": 60,
-      "lado": "derecho"
     }
   ],
   "resultadoComunidades": [
@@ -1035,16 +1011,15 @@
     {
       "nombre_diccionario": "comunidadVS",
       "clave": "0",
-      "posicion_x": 745,
-      "posicion_y": 69,
+      "posicion_x": 965,
+      "posicion_y": 180,
       "efecto": "contorno",
-      "outlineColor": "#ffffff",
+      "outlineColor": "#FEFEFF",
       "alineacion": "centrado",
       "fuente": "zuumerough-bold.ttf",
-      "funcionColor": "si",
-      "color": "#b69200",
+      "color": "#FFFFFF",
       "ancho_contorno": 3,
-      "size": 100
+      "size": 70
     },
     {
       "posicion_x": 800,
@@ -1245,30 +1220,6 @@
       "alineacion": "centrado",
       "fuente": "Poppins-Bold.ttf",
       "size": 25
-    },
-    {
-      "posicion_x": 100,
-      "posicion_y": 50,
-      "color": "#00FF00",
-      "ancho": 300,
-      "alto": 100,
-      "inclinacion": 20,
-      "banner": true,
-      "alineacion": "centrado",
-      "transparencia": 20,
-      "lado": "izquierdo"
-    },
-    {
-      "posicion_x": 600,
-      "posicion_y": 100,
-      "color": "#00FF33",
-      "ancho": 600,
-      "alto": 200,
-      "inclinacion": 80,
-      "banner": true,
-      "alineacion": "centrado",
-      "transparencia": 60,
-      "lado": "derecho"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- El resultado generado con una versión antigua de `configuracion.json` colocaba el título demasiado arriba y había banners de prueba que creaban bloques superpuestos en la cabecera, provocando una salida visual pobre.
- Las plantillas `resultado` y `resultadoComunidades` deben compartir exactamente la misma posición del título (salvo la diferencia semántica `comunidadVS` vs `titulo:true`) para garantizar consistencia visual.

### Description
- Actualiza `configuracion.json` para mover el título de `resultado` y el campo `comunidadVS` de `resultadoComunidades` a `posicion_x: 965` y `posicion_y: 180` y reducir `size` a `70` para que no invadan la cabecera superior.
- Normaliza el aspecto de `comunidadVS` a `color: "#FFFFFF"` y `outlineColor: "#FEFEFF"` y elimina la propiedad `funcionColor` en ese campo para mantener la diferencia lógica con `titulo` en `resultado`.
- Elimina dos entradas de banners de prueba (bloques verdes) que quedaban al final de ambas plantillas y provocaban superposición visual.
- Archivo modificado: `configuracion.json`.

### Testing
- Se validó la sintaxis JSON con `python3 -m json.tool configuracion.json` y la comprobación devolvió OK.
- Se ejecutó `git diff --check` para verificar problemas de formato y no se encontraron errores en el diff.
- Se generó una imagen de validación con `Imagenes.crear_imagen('resultadoComunidades', ...)`, que produjo `temp/imagenes/resultadoComunidades_370582.png` para verificación visual (los escudos no aparecieron por rutas de iconos de ejemplo, pero la posición y retirada de banners quedaron verificadas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a382059d004832a9c65dc97beb5e032)